### PR TITLE
fix recursive call to deletion in sys.modules from pl_legacy_patch

### DIFF
--- a/pytorch_lightning/utilities/migration.py
+++ b/pytorch_lightning/utilities/migration.py
@@ -52,4 +52,3 @@ class pl_legacy_patch:
 
         if "pytorch_lightning.utilities.argparse_utils" in sys.modules:
             del sys.modules["pytorch_lightning.utilities.argparse_utils"]
-

--- a/pytorch_lightning/utilities/migration.py
+++ b/pytorch_lightning/utilities/migration.py
@@ -14,13 +14,9 @@
 from __future__ import annotations
 
 import sys
-import threading
 from types import ModuleType, TracebackType
 
 import pytorch_lightning.utilities.argparse
-
-# Create a global lock to ensure no race condition with deleting sys modules
-_lock = threading.Lock()
 
 
 class pl_legacy_patch:
@@ -39,7 +35,7 @@ class pl_legacy_patch:
     """
 
     def __enter__(self) -> None:
-        _lock.acquire()
+
         # `pl.utilities.argparse_utils` was renamed to `pl.utilities.argparse`
         legacy_argparse_module = ModuleType("pytorch_lightning.utilities.argparse_utils")
         sys.modules["pytorch_lightning.utilities.argparse_utils"] = legacy_argparse_module
@@ -53,5 +49,7 @@ class pl_legacy_patch:
     ) -> None:
         if hasattr(pytorch_lightning.utilities.argparse, "_gpus_arg_default"):
             delattr(pytorch_lightning.utilities.argparse, "_gpus_arg_default")
-        del sys.modules["pytorch_lightning.utilities.argparse_utils"]
-        _lock.release()
+
+        if "pytorch_lightning.utilities.argparse_utils" in sys.modules:
+            del sys.modules["pytorch_lightning.utilities.argparse_utils"]
+


### PR DESCRIPTION
This PR fixes errors occurring from recursive calls to the checkpoint loading patch described in #12922. As mentioned in the issue, I had trouble checking the tests locally, but this should be a safe modification.

Fixes  #12922.

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
