### PR TITLE
Remove redundant shebang from source files

### DIFF
--- a/.actions/setup_tools.py
+++ b/.actions/setup_tools.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright The PyTorch Lightning team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/lightning/__about__.py
+++ b/src/lightning/__about__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright The PyTorch Lightning team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/pytorch_lightning/__about__.py
+++ b/src/pytorch_lightning/__about__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright The PyTorch Lightning team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/pytorch_lightning/utilities/deepspeed.py
+++ b/src/pytorch_lightning/utilities/deepspeed.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2020 The PyTorch Lightning team and Microsoft Corporation. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/pytorch_lightning/utilities/deepspeed_model_summary.py
+++ b/src/pytorch_lightning/utilities/deepspeed_model_summary.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2020 The PyTorch Lightning team and Microsoft Corporation. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## What does this PR do?

The shebang 
```
#!/usr/bin/env python
```
can be found on top of some source files, like about.py or deepspeed_summary.py. These files are not meant to be executed  directly so a shebang makes no sense there.


## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃


cc @borda @justusschock @awaelchli @rohitgr7