### PR TITLE
Revert "Fix mypy typing errors in pytorch_lightning/strategies/single_tpu.py"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ module = [
     "pytorch_lightning.strategies.parallel",
     "pytorch_lightning.strategies.sharded",
     "pytorch_lightning.strategies.sharded_spawn",
+    "pytorch_lightning.strategies.single_tpu",
     "pytorch_lightning.strategies.tpu_spawn",
     "pytorch_lightning.strategies.strategy",
     "pytorch_lightning.profilers.advanced",


### PR DESCRIPTION
Reverts Lightning-AI/lightning#13534

In the previous PR I explained that the condition ```is_overridden("on_post_move_to_device", self.lightning_module)``` can not be True. This is incorrect. I missed the heritage of ```LightningModule``` with ```ModelHooks```.
Indeed, ```ModelHooks``` implements ```on_post_move_to_device```.
I am very sorry for this.

I think I did not see it in the unit tests because this function has been deprecated in v1.5 and will be removed in v1.7, therefore it is not tested. According to this test: https://github.com/Lightning-AI/lightning/blob/61c28cb428a13c2aea6d7f3f55e0f00431a4ea4e/tests/tests_pytorch/deprecated_api/test_remove_1-7.py#L64