### PR TITLE
CI: Don't use `sphinx<2` in the readthedocs builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -50,7 +50,7 @@ build:
 # Optionally set the version of Python and requirements required to build your docs
 python:
   install:
-    - requirements: requirements/pytorch/docs.txt
-    #- requirements: requirements.txt
     - method: pip
       path: .
+      extra_requirements:
+        - docs


### PR DESCRIPTION
## What does this PR do?
Uses a newer version of Sphinx in the readthedocs builds.

During the investigation in #13547, I've realised that they uses `sphinx<2` (e.g. in [this build](https://readthedocs.org/projects/pytorch-lightning/builds/17356368/)) even if we specify `sphinx>=4.0,<5.0` in our requirements file:
https://github.com/Lightning-AI/lightning/blob/61c28cb428a13c2aea6d7f3f55e0f00431a4ea4e/.readthedocs.yml#L53
https://github.com/Lightning-AI/lightning/blob/61c28cb428a13c2aea6d7f3f55e0f00431a4ea4e/requirements/pytorch/docs.txt#L1

The reason why they pinned the version is to avoid the build failures in a lot of projects due to the incompatibility of docutils as described in the blog post below.
refs:
- https://blog.readthedocs.com/build-errors-docutils-0-18/
- https://github.com/readthedocs/readthedocs.org/issues/8679
- https://docs.readthedocs.io/en/stable/config-file/v2.html#sphinx

> If you are using a metadata file to describe code dependencies like setup.py, pyproject.toml, or similar, you can use the extra_requirements option (see [Packages](https://docs.readthedocs.io/en/stable/config-file/v2.html#packages)). This also allows you to override [the default pinning done by Read the Docs if your project was created before October 2020](https://docs.readthedocs.io/en/stable/build-default-versions.html#external-dependencies).

### Does your PR introduce any breaking changes? If yes, please list them.
It could introduce a failure in building our docs by the readthedocs although we build docs with the newer version of sphinx in our CI due to any difference in env between our CI and readthedocs' CD pipeline.

so, we should monitor the first build log after this PR gets merged here: https://readthedocs.org/projects/pytorch-lightning/builds/

## Before submitting

- [n/a] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [n/a] Did you write any **new necessary tests**? (not for typos and docs)
- [n/a] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [n/a] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
