### PR TITLE
Set default strategy to ddp_fork in interactive environments

### DIFF
--- a/src/pytorch_lightning/trainer/connectors/accelerator_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/accelerator_connector.py
@@ -87,8 +87,9 @@ from pytorch_lightning.utilities.imports import (
     _HOROVOD_AVAILABLE,
     _HPU_AVAILABLE,
     _IPU_AVAILABLE,
+    _IS_INTERACTIVE,
     _TORCH_GREATER_EQUAL_1_11,
-    _TPU_AVAILABLE, _IS_INTERACTIVE,
+    _TPU_AVAILABLE,
 )
 
 log = logging.getLogger(__name__)

--- a/src/pytorch_lightning/trainer/connectors/accelerator_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/accelerator_connector.py
@@ -88,7 +88,7 @@ from pytorch_lightning.utilities.imports import (
     _HPU_AVAILABLE,
     _IPU_AVAILABLE,
     _TORCH_GREATER_EQUAL_1_11,
-    _TPU_AVAILABLE,
+    _TPU_AVAILABLE, _IS_INTERACTIVE,
 )
 
 log = logging.getLogger(__name__)
@@ -588,7 +588,9 @@ class AcceleratorConnector:
             # TODO: lazy initialized device, then here could be self._strategy_flag = "single_device"
             return SingleDeviceStrategy(device=device)  # type: ignore
         if len(self._parallel_devices) > 1:
-            return DDPSpawnStrategy.strategy_name
+            if _IS_INTERACTIVE:
+                return "ddp_fork"
+            return "ddp_spawn"
 
         return DDPStrategy.strategy_name
 

--- a/tests/tests_pytorch/accelerators/test_accelerator_connector.py
+++ b/tests/tests_pytorch/accelerators/test_accelerator_connector.py
@@ -425,6 +425,16 @@ def test_strategy_choice_ddp_spawn_cpu():
 
 
 @RunIf(skip_windows=True)
+@mock.patch("pytorch_lightning.trainer.connectors.accelerator_connector._IS_INTERACTIVE", True)
+def test_strategy_choice_ddp_fork_in_interactive():
+    trainer = Trainer(strategy=None, devices=2)
+    assert isinstance(trainer.accelerator, CPUAccelerator)
+    assert isinstance(trainer.strategy, DDPSpawnStrategy)
+    assert isinstance(trainer.strategy.cluster_environment, LightningEnvironment)
+    assert trainer.strategy.launcher._start_method == "fork"
+
+
+@RunIf(skip_windows=True)
 def test_strategy_choice_ddp_fork_cpu():
     trainer = Trainer(strategy="ddp_fork", accelerator="cpu", devices=2)
     assert isinstance(trainer.accelerator, CPUAccelerator)

--- a/tests/tests_pytorch/accelerators/test_accelerator_connector.py
+++ b/tests/tests_pytorch/accelerators/test_accelerator_connector.py
@@ -427,7 +427,9 @@ def test_strategy_choice_ddp_spawn_cpu():
 @RunIf(skip_windows=True)
 @mock.patch("pytorch_lightning.trainer.connectors.accelerator_connector._IS_INTERACTIVE", True)
 def test_strategy_choice_ddp_fork_in_interactive():
-    trainer = Trainer(strategy=None, devices=2)
+    """Test that when accelerator and strategy are unspecified, the connector chooses DDP Fork in interactive
+    environments by default."""
+    trainer = Trainer(devices=2)
     assert isinstance(trainer.accelerator, CPUAccelerator)
     assert isinstance(trainer.strategy, DDPSpawnStrategy)
     assert isinstance(trainer.strategy.cluster_environment, LightningEnvironment)


### PR DESCRIPTION
## What does this PR do?

Follow up to #13744 and #13405.

This PR makes it so that in Jupyter notebooks, you only need two specify 

```py
Trainer(devices=2)
```

instead of

```py
Trainer(strategy="ddp_notebook", devices=2)
```

similar to the TPU strategy being auto-selected when accelerator="tpu". 


### Does your PR introduce any breaking changes? If yes, please list them.

No.


## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃
cc @borda @justusschock @kaushikb11 @awaelchli @akihironitta @rohitgr7