### PR TITLE
Docs/memory

### DIFF
--- a/docs/source-app/core_api/lightning_work/compute_content.rst
+++ b/docs/source-app/core_api/lightning_work/compute_content.rst
@@ -31,8 +31,8 @@ Here is the full list of supported machine names:
 
    * - Name
      - # of CPUs
-     - GPUs
-     - Memory
+     - GPUs (GPU Memory)
+     - RAM
    * - default
      - 2
      - 0

--- a/docs/source-app/core_api/lightning_work/index.rst
+++ b/docs/source-app/core_api/lightning_work/index.rst
@@ -2,7 +2,8 @@
 Lightning Work
 ##############
 
-**Audience:** Users who want to know how Lightning Work works under the hood 🤯.
+| **Audience:** Users who want to know how Lightning Work works under the hood 🤯.
+| **Limitation:** At this time there is a 20GB disk size limit for Lightning Works.
 
 ----
 


### PR DESCRIPTION
## What does this PR do?

This PR updates the doc to note the 20GB disk size limit and specifies in the Cloud Compute table that Memory = RAM and memory in GPU column = GPU memory.
