### PR TITLE
Fix typos in Checkpointing doc

### DIFF
--- a/docs/source-pytorch/common/checkpointing_intermediate.rst
+++ b/docs/source-pytorch/common/checkpointing_intermediate.rst
@@ -12,7 +12,7 @@ Checkpointing (intermediate)
 *****************************
 Modify checkpointing behavior
 *****************************
-For fine-grain control over checkpointing behavior, use the :class:`~pytorch_lightning.callbacks.ModelCheckpoint` object
+For fine-grained control over checkpointing behavior, use the :class:`~pytorch_lightning.callbacks.ModelCheckpoint` object
 
 .. code-block:: python
 
@@ -46,9 +46,9 @@ When
 ====
 
 - When using iterative training which doesn't have an epoch, you can checkpoint at every ``N`` training steps by specifying ``every_n_train_steps=N``.
-- You can also control the interval of epochs between checkpoints using ``every_n_epochs`` between checkpoints, to avoid slowdowns.
-- You can checkpoint at a regular time interval using ``train_time_interval`` argument independent of the steps or epochs.
-- In case you are monitoring a training metrics, we'd suggest using ``save_on_train_epoch_end=True`` to ensure the required metric is being accumulated correctly for creating a checkpoint.
+- You can also control the interval of epochs between checkpoints using ``every_n_epochs``, to avoid slowdowns.
+- You can checkpoint at a regular time interval using the ``train_time_interval`` argument independent of the steps or epochs.
+- In case you are monitoring a training metric, we'd suggest using ``save_on_train_epoch_end=True`` to ensure the required metric is being accumulated correctly for creating a checkpoint.
 
 
 Which

--- a/docs/source-pytorch/common/checkpointing_intermediate.rst
+++ b/docs/source-pytorch/common/checkpointing_intermediate.rst
@@ -45,7 +45,7 @@ To save checkpoints based on a (*when/which/what/where*) condition (for example 
 When
 ====
 
-- When using iterative training which doesn't have an epoch, you can checkpoint at every ``N`` training steps by specifying ``every_n_training_steps=N``.
+- When using iterative training which doesn't have an epoch, you can checkpoint at every ``N`` training steps by specifying ``every_n_train_steps=N``.
 - You can also control the interval of epochs between checkpoints using ``every_n_epochs`` between checkpoints, to avoid slowdowns.
 - You can checkpoint at a regular time interval using ``train_time_interval`` argument independent of the steps or epochs.
 - In case you are monitoring a training metrics, we'd suggest using ``save_on_train_epoch_end=True`` to ensure the required metric is being accumulated correctly for creating a checkpoint.


### PR DESCRIPTION
## What does this PR do?

Current `ModelCheckpoint` callback gets `every_n_train_steps` instead of `every_n_training_steps`.
So I fixed the typo in the `checkpointing` doc.

Fixes #\<issue_number>

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
