### PR TITLE
Improvements to standalone scripts

### DIFF
--- a/.azure/gpu-tests.yml
+++ b/.azure/gpu-tests.yml
@@ -116,6 +116,15 @@ jobs:
       timeoutInMinutes: "35"
       condition: eq(variables['continue'], '1')
 
+    - bash: bash run_standalone_tasks.sh
+      workingDirectory: tests/tests_pytorch
+      env:
+        PL_USE_MOCKED_MNIST: "1"
+        PL_RUN_CUDA_TESTS: "1"
+      displayName: 'Testing: PyTorch standalone tasks'
+      timeoutInMinutes: "10"
+      condition: eq(variables['continue'], '1')
+
     - bash: |
         python -m coverage report
         python -m coverage xml

--- a/dockers/tpu-tests/tpu_test_cases.jsonnet
+++ b/dockers/tpu-tests/tpu_test_cases.jsonnet
@@ -31,6 +31,7 @@ local tputests = base.BaseTest {
       git checkout {SHA}
       export PACKAGE_NAME=pytorch
       export FREEZE_REQUIREMENTS=1
+      export PL_STANDALONE_TESTS_BATCH_SIZE=1
       pip install -e .[test]
       echo $KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS
       export XRT_TPU_CONFIG="tpu_worker;0;${KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS:7}"
@@ -38,7 +39,7 @@ local tputests = base.BaseTest {
       cd tests/tests_pytorch
       coverage run --source=pytorch_lightning -m pytest -vv --durations=0 ./
       echo "\n||| Running standalone tests |||\n"
-      bash run_standalone_tests.sh -b 1
+      bash run_standalone_tests.sh
       test_exit_code=$?
       echo "\n||| END PYTEST LOGS |||\n"
       coverage xml

--- a/tests/tests_pytorch/run_standalone_tasks.sh
+++ b/tests/tests_pytorch/run_standalone_tasks.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Copyright The PyTorch Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+# THIS FILE ASSUMES IT IS RUN INSIDE THE tests/tests_pytorch DIRECTORY
+
+report=''
+
+if nvcc --version; then
+    nvprof --profile-from-start off -o trace_name.prof -- python -m coverage run --source pytorch_lightning --append -m pytest --no-header profilers/test_profiler.py::test_pytorch_profiler_nested_emit_nvtx
+fi
+
+# needs to run outside of `pytest`
+python utilities/test_warnings.py
+if [ $? -eq 0 ]; then
+    report+="Ran\tutilities/test_warnings.py\n"
+fi
+
+# test deadlock is properly handled with TorchElastic.
+LOGS=$(PL_RUN_STANDALONE_TESTS=1 PL_RECONCILE_PROCESS=1 python -m torch.distributed.run --nproc_per_node=2 --max_restarts 0 -m coverage run --source pytorch_lightning -a plugins/environments/torch_elastic_deadlock.py | grep "SUCCEEDED")
+if [ -z "$LOGS" ]; then
+    exit 1
+fi
+report+="Ran\tplugins/environments/torch_elastic_deadlock.py\n"
+
+# test that a user can manually launch individual processes
+export PYTHONPATH="${PYTHONPATH}:$(pwd)"
+args="--trainer.accelerator gpu --trainer.devices 2 --trainer.strategy ddp --trainer.max_epochs=1 --trainer.limit_train_batches=1 --trainer.limit_val_batches=1 --trainer.limit_test_batches=1"
+MASTER_ADDR="localhost" MASTER_PORT=1234 LOCAL_RANK=1 python ../../examples/convert_from_pt_to_pl/image_classifier_5_lightning_datamodule.py ${args} &
+MASTER_ADDR="localhost" MASTER_PORT=1234 LOCAL_RANK=0 python ../../examples/convert_from_pt_to_pl/image_classifier_5_lightning_datamodule.py ${args}
+report+="Ran\tmanual ddp launch test\n"
+
+# echo test report
+printf '=%.s' {1..80}
+printf "\n$report"
+printf '=%.s' {1..80}
+printf '\n'

--- a/tests/tests_pytorch/run_standalone_tasks.sh
+++ b/tests/tests_pytorch/run_standalone_tasks.sh
@@ -15,34 +15,25 @@
 set -e
 # THIS FILE ASSUMES IT IS RUN INSIDE THE tests/tests_pytorch DIRECTORY
 
-report=''
-
 if nvcc --version; then
+    echo "Running profilers/test_profiler.py::test_pytorch_profiler_nested_emit_nvtx"
     nvprof --profile-from-start off -o trace_name.prof -- python -m coverage run --source pytorch_lightning --append -m pytest --no-header profilers/test_profiler.py::test_pytorch_profiler_nested_emit_nvtx
 fi
 
 # needs to run outside of `pytest`
+echo "Running utilities/test_warnings.py"
 python utilities/test_warnings.py
-if [ $? -eq 0 ]; then
-    report+="Ran\tutilities/test_warnings.py\n"
-fi
 
 # test deadlock is properly handled with TorchElastic.
+echo "Running plugins/environments/torch_elastic_deadlock.py"
 LOGS=$(PL_RUN_STANDALONE_TESTS=1 PL_RECONCILE_PROCESS=1 python -m torch.distributed.run --nproc_per_node=2 --max_restarts 0 -m coverage run --source pytorch_lightning -a plugins/environments/torch_elastic_deadlock.py | grep "SUCCEEDED")
 if [ -z "$LOGS" ]; then
     exit 1
 fi
-report+="Ran\tplugins/environments/torch_elastic_deadlock.py\n"
 
 # test that a user can manually launch individual processes
+echo "Running manual ddp launch test"
 export PYTHONPATH="${PYTHONPATH}:$(pwd)"
 args="--trainer.accelerator gpu --trainer.devices 2 --trainer.strategy ddp --trainer.max_epochs=1 --trainer.limit_train_batches=1 --trainer.limit_val_batches=1 --trainer.limit_test_batches=1"
 MASTER_ADDR="localhost" MASTER_PORT=1234 LOCAL_RANK=1 python ../../examples/convert_from_pt_to_pl/image_classifier_5_lightning_datamodule.py ${args} &
 MASTER_ADDR="localhost" MASTER_PORT=1234 LOCAL_RANK=0 python ../../examples/convert_from_pt_to_pl/image_classifier_5_lightning_datamodule.py ${args}
-report+="Ran\tmanual ddp launch test\n"
-
-# echo test report
-printf '=%.s' {1..80}
-printf "\n$report"
-printf '=%.s' {1..80}
-printf '\n'

--- a/tests/tests_pytorch/run_standalone_tests.sh
+++ b/tests/tests_pytorch/run_standalone_tests.sh
@@ -16,18 +16,8 @@ set -e
 # THIS FILE ASSUMES IT IS RUN INSIDE THE tests/tests_pytorch DIRECTORY
 
 # Batch size for testing: Determines how many standalone test invocations run in parallel
-test_batch_size=6
-
-while getopts "b:" opt; do
-    case $opt in
-        b)
-            test_batch_size=$OPTARG;;
-        *)
-            echo "Usage: $(basename $0) [-b batch_size]"
-            exit 1;;
-    esac
-done
-shift $((OPTIND-1))
+# It can be set through the env variable PL_STANDALONE_TESTS_BATCH_SIZE and defaults to 6 if not set
+test_batch_size="${PL_STANDALONE_TESTS_BATCH_SIZE:-6}"
 
 # this environment variable allows special tests to run
 export PL_RUN_STANDALONE_TESTS=1

--- a/tests/tests_pytorch/run_standalone_tests.sh
+++ b/tests/tests_pytorch/run_standalone_tests.sh
@@ -80,7 +80,6 @@ done
 # wait for leftover tests
 for pid in ${pids[*]}; do wait $pid; done
 show_batched_output
-echo "Batched mode finished. End of standalone tests."
 
 # echo test report
 printf '=%.s' {1..80}

--- a/tests/tests_pytorch/run_standalone_tests.sh
+++ b/tests/tests_pytorch/run_standalone_tests.sh
@@ -80,31 +80,7 @@ done
 # wait for leftover tests
 for pid in ${pids[*]}; do wait $pid; done
 show_batched_output
-echo "Batched mode finished. Continuing with the rest of standalone tests."
-
-if nvcc --version; then
-    nvprof --profile-from-start off -o trace_name.prof -- python ${defaults} profilers/test_profiler.py::test_pytorch_profiler_nested_emit_nvtx
-fi
-
-# needs to run outside of `pytest`
-python utilities/test_warnings.py
-if [ $? -eq 0 ]; then
-    report+="Ran\tutilities/test_warnings.py\n"
-fi
-
-# test deadlock is properly handled with TorchElastic.
-LOGS=$(PL_RUN_STANDALONE_TESTS=1 PL_RECONCILE_PROCESS=1 python -m torch.distributed.run --nproc_per_node=2 --max_restarts 0 -m coverage run --source pytorch_lightning -a plugins/environments/torch_elastic_deadlock.py | grep "SUCCEEDED")
-if [ -z "$LOGS" ]; then
-    exit 1
-fi
-report+="Ran\tplugins/environments/torch_elastic_deadlock.py\n"
-
-# test that a user can manually launch individual processes
-export PYTHONPATH="${PYTHONPATH}:$(pwd)"
-args="--trainer.accelerator gpu --trainer.devices 2 --trainer.strategy ddp --trainer.max_epochs=1 --trainer.limit_train_batches=1 --trainer.limit_val_batches=1 --trainer.limit_test_batches=1"
-MASTER_ADDR="localhost" MASTER_PORT=1234 LOCAL_RANK=1 python ../../examples/convert_from_pt_to_pl/image_classifier_5_lightning_datamodule.py ${args} &
-MASTER_ADDR="localhost" MASTER_PORT=1234 LOCAL_RANK=0 python ../../examples/convert_from_pt_to_pl/image_classifier_5_lightning_datamodule.py ${args}
-report+="Ran\tmanual ddp launch test\n"
+echo "Batched mode finished. End of standalone tests."
 
 # echo test report
 printf '=%.s' {1..80}


### PR DESCRIPTION
## What does this PR do?

Small improvements as a follow up to #11098

In #13841 I introduced the batch size argument for the standalone script, which worked fine for the CI but unfortunately it also broke the following use case, which is handy for locally debugging:

```
bash run_standalone_tests.sh -k <the_name_of_the_test_case_to_run>
```

I'm reverting this back to an environment variable because the argument parsing in bash would otherwise get a bit too nasty. 


## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃



cc @carmocca @akihironitta @borda @justusschock @awaelchli @rohitgr7