### PR TITLE
Add batch size script argument for standalone tests

### DIFF
--- a/tests/tests_pytorch/run_standalone_tests.sh
+++ b/tests/tests_pytorch/run_standalone_tests.sh
@@ -18,9 +18,11 @@ set -e
 test_batch_size=6
 while getopts "b:" opt; do
     case $opt in
-        b) test_batch_size=$OPTARG;;
-        *) echo "Usage: $(basename $0) [-b batch_size]"
-        exit 1;;
+        b)
+            test_batch_size=$OPTARG;;
+        *)
+            echo "Usage: $(basename $0) [-b batch_size]"
+            exit 1;;
     esac
 done
 

--- a/tests/tests_pytorch/run_standalone_tests.sh
+++ b/tests/tests_pytorch/run_standalone_tests.sh
@@ -15,7 +15,9 @@
 set -e
 # THIS FILE ASSUMES IT IS RUN INSIDE THE tests/tests_pytorch DIRECTORY
 
+# Batch size for testing: Determines how many standalone test invocations run in parallel
 test_batch_size=6
+
 while getopts "b:" opt; do
     case $opt in
         b)

--- a/tests/tests_pytorch/run_standalone_tests.sh
+++ b/tests/tests_pytorch/run_standalone_tests.sh
@@ -15,6 +15,15 @@
 set -e
 # THIS FILE ASSUMES IT IS RUN INSIDE THE tests/tests_pytorch DIRECTORY
 
+test_batch_size=6
+while getopts "b:" opt; do
+    case $opt in
+        b) test_batch_size=$OPTARG;;
+        *) echo "Usage: $(basename $0) [-b batch_size]"
+        exit 1;;
+    esac
+done
+
 # this environment variable allows special tests to run
 export PL_RUN_STANDALONE_TESTS=1
 # python arguments
@@ -40,7 +49,6 @@ parametrizations_arr=($parametrizations)
 # tests to skip - space separated
 blocklist='profilers/test_profiler.py::test_pytorch_profiler_nested_emit_nvtx utilities/test_warnings.py'
 report=''
-test_batch_size=6
 
 rm -f standalone_test_output.txt  # in case it exists, remove it
 function show_batched_output {

--- a/tests/tests_pytorch/run_standalone_tests.sh
+++ b/tests/tests_pytorch/run_standalone_tests.sh
@@ -25,6 +25,7 @@ while getopts "b:" opt; do
             exit 1;;
     esac
 done
+shift $((OPTIND-1))
 
 # this environment variable allows special tests to run
 export PL_RUN_STANDALONE_TESTS=1


### PR DESCRIPTION
## What does this PR do?

Needed for #11098

The batch size for the standalone tests so far was hardcoded. This PR exposes it as a script argument while keeping the hardcoded value as the default.

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃



cc @carmocca @akihironitta @borda