### PR TITLE
Disallow batch sampler with multiple IPU devices

### DIFF
--- a/docs/source-pytorch/accelerators/ipu_basic.rst
+++ b/docs/source-pytorch/accelerators/ipu_basic.rst
@@ -38,6 +38,9 @@ Run on multiple IPUs
 --------------------
 To use multiple IPUs set the devices to a number that is a power of 2 (i.e: 2, 4, 8, 16, ...)
 
+.. note::
+  It is not possible to use :class:`torch.utils.data.BatchSampler` in your dataloaders if you are using multiple IPUs.
+
 .. code-block:: python
 
     trainer = pl.Trainer(accelerator="ipu", devices=8)

--- a/docs/source-pytorch/accelerators/ipu_basic.rst
+++ b/docs/source-pytorch/accelerators/ipu_basic.rst
@@ -38,7 +38,6 @@ Run on multiple IPUs
 --------------------
 To use multiple IPUs set the devices to a number that is a power of 2 (i.e: 2, 4, 8, 16, ...)
 
-
 .. code-block:: python
 
     trainer = pl.Trainer(accelerator="ipu", devices=8)

--- a/docs/source-pytorch/accelerators/ipu_basic.rst
+++ b/docs/source-pytorch/accelerators/ipu_basic.rst
@@ -38,8 +38,6 @@ Run on multiple IPUs
 --------------------
 To use multiple IPUs set the devices to a number that is a power of 2 (i.e: 2, 4, 8, 16, ...)
 
-.. note::
-  It is not possible to use :class:`torch.utils.data.BatchSampler` in your dataloaders if you are using multiple IPUs.
 
 .. code-block:: python
 
@@ -65,7 +63,8 @@ Currently there are some known limitations that are being addressed in the near 
 
 Please see the `MNIST example <https://github.com/Lightning-AI/lightning/blob/master/examples/pl_ipu/mnist_sample.py>`__ which displays most of the limitations and how to overcome them till they are resolved.
 
-* ``self.log`` is not supported in the ``training_step``, ``validation_step``, ``test_step`` or ``predict_step``. This is due to the step function being traced and sent to the IPU devices. We're actively working on fixing this
-* Multiple optimizers are not supported. ``training_step`` only supports returning one loss from the ``training_step`` function as a result
-* Since the step functions are traced, branching logic or any form of primitive values are traced into constants. Be mindful as this could lead to errors in your custom code
-* Clipping gradients is not supported
+* ``self.log`` is not supported in the ``training_step``, ``validation_step``, ``test_step`` or ``predict_step``. This is due to the step function being traced and sent to the IPU devices. We're actively working on fixing this.
+* Multiple optimizers are not supported. ``training_step`` only supports returning one loss from the ``training_step`` function as a result.
+* Since the step functions are traced, branching logic or any form of primitive values are traced into constants. Be mindful as this could lead to errors in your custom code.
+* Clipping gradients is not supported.
+* It is not possible to use :class:`torch.utils.data.BatchSampler` in your dataloaders if you are using multiple IPUs.

--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -164,7 +164,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Updated Habana Accelerator's `auto_device_count`, `is_available` & `get_device_name` methods based on the latest torch habana package ([#13423](https://github.com/PyTorchLightning/pytorch-lightning/pull/13423))
 
 
--
+- Disallowed using `BatchSampler` when running on multiple IPUs ([#13854](https://github.com/PyTorchLightning/pytorch-lightning/pull/13854))
 
 
 ### Deprecated

--- a/src/pytorch_lightning/strategies/ipu.py
+++ b/src/pytorch_lightning/strategies/ipu.py
@@ -162,6 +162,7 @@ class IPUStrategy(ParallelStrategy):
             if self.lightning_module.trainer.enable_validation:
                 model = poptorch.inferenceModel(model=model, options=inference_opts)
                 self.poptorch_models[RunningStage.VALIDATING] = model
+                self.poptorch_models[RunningStage.SANITY_CHECKING] = model
         elif trainer_fn == TrainerFn.VALIDATING:
             model = poptorch.inferenceModel(model=model, options=self.inference_opts)
             self.poptorch_models[RunningStage.VALIDATING] = model

--- a/src/pytorch_lightning/strategies/ipu.py
+++ b/src/pytorch_lightning/strategies/ipu.py
@@ -228,7 +228,9 @@ class IPUStrategy(ParallelStrategy):
             # the user is returning the `poptorch.DataLoader` directly, don't change anything.
             return dataloader
 
-        dl_args, dl_kwargs = _get_dataloader_init_args_and_kwargs(dataloader, sampler)
+        dl_args, dl_kwargs = _get_dataloader_init_args_and_kwargs(
+            dataloader, sampler, mode, self.replication_factor > 1
+        )
         opts = self.training_opts if mode == RunningStage.TRAINING else self.inference_opts
         dataloader = poptorch.DataLoader(opts, *dl_args, **dl_kwargs)
         return dataloader

--- a/src/pytorch_lightning/strategies/ipu.py
+++ b/src/pytorch_lightning/strategies/ipu.py
@@ -162,7 +162,8 @@ class IPUStrategy(ParallelStrategy):
             if self.lightning_module.trainer.enable_validation:
                 model = poptorch.inferenceModel(model=model, options=inference_opts)
                 self.poptorch_models[RunningStage.VALIDATING] = model
-                self.poptorch_models[RunningStage.SANITY_CHECKING] = model
+                if self.lightning_module.trainer.num_sanity_val_steps > 0:
+                    self.poptorch_models[RunningStage.SANITY_CHECKING] = model
         elif trainer_fn == TrainerFn.VALIDATING:
             model = poptorch.inferenceModel(model=model, options=self.inference_opts)
             self.poptorch_models[RunningStage.VALIDATING] = model

--- a/tests/tests_pytorch/accelerators/test_ipu.py
+++ b/tests/tests_pytorch/accelerators/test_ipu.py
@@ -619,7 +619,11 @@ def test_poptorch_models_at_different_stages(tmpdir):
     trainer.optimizers = model.configure_optimizers()[0]
     trainer.state.fn = TrainerFn.FITTING
     trainer.strategy.setup(trainer)
-    assert list(trainer.strategy.poptorch_models) == [RunningStage.TRAINING, RunningStage.VALIDATING]
+    assert list(trainer.strategy.poptorch_models) == [
+        RunningStage.TRAINING,
+        RunningStage.VALIDATING,
+        RunningStage.SANITY_CHECKING,
+    ]
 
     for fn, stage in (
         (TrainerFn.VALIDATING, RunningStage.VALIDATING),

--- a/tests/tests_pytorch/utilities/test_data.py
+++ b/tests/tests_pytorch/utilities/test_data.py
@@ -332,19 +332,19 @@ def test_replace_dataloader_init_method(cls, args, kwargs, arg_names, dataset, c
             assert getattr(dataloader, key) == value
 
 
-def test_dataloader_disallow_batch_sampler_no_raise():
+def test_dataloader_disallow_batch_sampler():
     dataset = RandomDataset(5, 100)
     dataloader = DataLoader(dataset, batch_size=10)
+
     # This should not raise
     _dataloader_init_kwargs_resolve_sampler(dataloader, dataloader.sampler, disallow_batch_sampler=True)
 
-
-def test_dataloader_disallow_batch_sampler_raise():
     dataset = RandomDataset(5, 100)
     sampler = SequentialSampler(dataset)
     batch_sampler = BatchSampler(sampler, batch_size=10, drop_last=False)
     dataloader = DataLoader(dataset, batch_sampler=batch_sampler)
 
+    # this should raise - using batch sampler, that was not automatically instantiated by DataLoader
     with pytest.raises(MisconfigurationException, match="when running on multiple IPU devices"):
         _dataloader_init_kwargs_resolve_sampler(dataloader, dataloader.sampler, disallow_batch_sampler=True)
 


### PR DESCRIPTION
## What does this PR do?

When running on multiple IPUs, `poptorch.DataLoader` increases batch size, which is not compatible with `batch_sampler` argument at all. This was discovered during debugging of #13640 

### Does your PR introduce any breaking changes? If yes, please list them.

It is impossible to have a `BatchSampler` in while running on multiple IPUs. This never worked, however the user did not get an error message about it, but some different one, later on. Now the attempt to have explicit `BatchSampler` fails.

Note that users can still pass `batch_size` argument, which creates a default `BatchSampler` under the hood and this still works

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs) (on Slack it was)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @justusschock @awaelchli @ninginthecloud @rohitgr7 @otaj @borda @akihironitta