### PR TITLE
[App] Add cloud platform exception

### DIFF
--- a/src/lightning_app/core/work.py
+++ b/src/lightning_app/core/work.py
@@ -518,7 +518,11 @@ class LightningWork(abc.ABC):
 
     @abc.abstractmethod
     def run(self, *args, **kwargs):
-        """Override to add your own logic."""
+        """Override to add your own logic.
+
+        Raises:
+            LightningPlatformException: If resource exceeds platform quotas or other contraints.
+        """
         pass
 
     def on_exception(self, exception: BaseException):

--- a/src/lightning_app/core/work.py
+++ b/src/lightning_app/core/work.py
@@ -521,7 +521,7 @@ class LightningWork(abc.ABC):
         """Override to add your own logic.
 
         Raises:
-            LightningPlatformException: If resource exceeds platform quotas or other contraints.
+            LightningPlatformException: If resource exceeds platform quotas or other constraints.
         """
         pass
 

--- a/src/lightning_app/utilities/exceptions.py
+++ b/src/lightning_app/utilities/exceptions.py
@@ -41,6 +41,10 @@ class LightningWorkException(Exception):
     """Exception used to inform users of misuse with LightningWork."""
 
 
+class LightningPlatformException(Exception):
+    """Exception used to inform users of issues related to platform the LightningApp is running on."""
+
+
 class LightningAppStateException(Exception):
     """Exception to inform users of app state errors."""
 

--- a/src/lightning_app/utilities/exceptions.py
+++ b/src/lightning_app/utilities/exceptions.py
@@ -45,8 +45,7 @@ class LightningPlatformException(Exception):  # pragma: no cover
     """Exception used to inform users of issues related to platform the LightningApp is running on.
 
     It gets raised by the Lightning Launcher on the platform side when the app is running in the cloud, and is useful
-    when framework or user code needs to catch exceptions specific to the platform, e.g., when resources exceed
-    quotas.
+    when framework or user code needs to catch exceptions specific to the platform, e.g., when resources exceed quotas.
     """
 
 

--- a/src/lightning_app/utilities/exceptions.py
+++ b/src/lightning_app/utilities/exceptions.py
@@ -43,6 +43,7 @@ class LightningWorkException(Exception):
 
 class LightningPlatformException(Exception):  # pragma: no cover
     """Exception used to inform users of issues related to platform the LightningApp is running on.
+
     It's raised for framework by a platform LightningApp is running on.
     """
 

--- a/src/lightning_app/utilities/exceptions.py
+++ b/src/lightning_app/utilities/exceptions.py
@@ -44,7 +44,9 @@ class LightningWorkException(Exception):
 class LightningPlatformException(Exception):  # pragma: no cover
     """Exception used to inform users of issues related to platform the LightningApp is running on.
 
-    It's raised for framework by a platform LightningApp is running on.
+    It gets raised by the Lightning Launcher on the platform side when the app is running in the cloud, and is useful
+    when framework or user code needs to catch exceptions specific to the platform, e.g., when resources exceed
+    quotas.
     """
 
 

--- a/src/lightning_app/utilities/exceptions.py
+++ b/src/lightning_app/utilities/exceptions.py
@@ -41,8 +41,10 @@ class LightningWorkException(Exception):
     """Exception used to inform users of misuse with LightningWork."""
 
 
-class LightningPlatformException(Exception):
-    """Exception used to inform users of issues related to platform the LightningApp is running on."""
+class LightningPlatformException(Exception):  # pragma: no cover
+    """Exception used to inform users of issues related to platform the LightningApp is running on.
+    It's raised for framework by a platform LightningApp is running on.
+    """
 
 
 class LightningAppStateException(Exception):


### PR DESCRIPTION
## What does this PR do?

We add a new `LightningPlatformException` as to indicate possible error events happening on the platform the Lightning App is on.
We currently consider (but future use is not limited to) the following cases:
- User tries to create new default Work and exceeds the allowed quota (10).
- User does not have enough credits and tries to create non-default Work.

This Exception is used on the launcher side, so here's just a definition of that exception.

This way if that's the user's intent, they can react accordingly to the situation.

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @borda