### PR TITLE
(app) Add s3 drive type (1/2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### ** NEWS: PyTorch Lightning has been renamed Lightning! In addition to building models, you can now build research workflows and production pipelines**
+### \*\* NEWS: PyTorch Lightning has been renamed Lightning! In addition to building models, you can now build research workflows and production pipelines\*\*
 
 <div align="center">
 <img src="https://pl-flash-data.s3.amazonaws.com/assets_lightning/docs/images/logos/lightning-ai.png" width="400px">

--- a/src/lightning_app/core/work.py
+++ b/src/lightning_app/core/work.py
@@ -52,7 +52,6 @@ class LightningWork(abc.ABC):
         cloud_build_config: Optional[BuildConfig] = None,
         cloud_compute: Optional[CloudCompute] = None,
         run_once: Optional[bool] = None,  # TODO: Remove run_once
-        drives: Optional[List[Drive]] = None,
     ):
         """LightningWork, or Work in short, is a building block for long-running jobs.
 
@@ -141,7 +140,6 @@ class LightningWork(abc.ABC):
         self._cloud_compute = cloud_compute or CloudCompute()
         self._backend: Optional[Backend] = None
         self._on_init_end()
-        self._drives = drives
 
     @property
     def url(self) -> str:
@@ -225,10 +223,6 @@ class LightningWork(abc.ABC):
 
     @property
     def cloud_compute(self) -> CloudCompute:
-        return self._cloud_compute
-
-    @property
-    def drives(self) -> List[Drive]:
         return self._cloud_compute
 
     @cloud_compute.setter

--- a/src/lightning_app/core/work.py
+++ b/src/lightning_app/core/work.py
@@ -52,6 +52,7 @@ class LightningWork(abc.ABC):
         cloud_build_config: Optional[BuildConfig] = None,
         cloud_compute: Optional[CloudCompute] = None,
         run_once: Optional[bool] = None,  # TODO: Remove run_once
+        drives: Optional[List[Drive]] = None,
     ):
         """LightningWork, or Work in short, is a building block for long-running jobs.
 
@@ -140,6 +141,7 @@ class LightningWork(abc.ABC):
         self._cloud_compute = cloud_compute or CloudCompute()
         self._backend: Optional[Backend] = None
         self._on_init_end()
+        self._drives = drives
 
     @property
     def url(self) -> str:
@@ -223,6 +225,10 @@ class LightningWork(abc.ABC):
 
     @property
     def cloud_compute(self) -> CloudCompute:
+        return self._cloud_compute
+
+    @property
+    def drives(self) -> List[Drive]:
         return self._cloud_compute
 
     @cloud_compute.setter

--- a/src/lightning_app/storage/drive.py
+++ b/src/lightning_app/storage/drive.py
@@ -51,8 +51,10 @@ class Drive:
             raise Exception(f"The id should be unique to identify your drive. Found `{self.id}`.")
 
         if optimization and optimization not in self.__PROTOCOLS_OPTIMIZATIONS__[self.protocol]:
-            raise Exception(f"This Drive protocol is not compatible with the {optimization} optimization. Available "
-                            f"optimizations for this protocol are: {self.__PROTOCOLS_OPTIMIZATIONS__[self.protocol]}")
+            raise Exception(
+                f"This Drive protocol is not compatible with the {optimization} optimization. Available "
+                f"optimizations for this protocol are: {self.__PROTOCOLS_OPTIMIZATIONS__[self.protocol]}"
+            )
 
         self.root_folder = pathlib.Path(root_folder).resolve() if root_folder else os.getcwd()
         if not os.path.isdir(self.root_folder):

--- a/src/lightning_app/storage/drive.py
+++ b/src/lightning_app/storage/drive.py
@@ -13,7 +13,8 @@ from lightning_app.utilities.component import _is_flow_context
 class Drive:
 
     __IDENTIFIER__ = "__drive__"
-    __PROTOCOLS__ = ["lit://"]
+    __PROTOCOLS__ = ["lit://", "s3://"]
+    __PROTOCOLS_OPTIMIZATIONS__ = {"lit://": [], "s3://": ["indexed-s3"]}
 
     def __init__(
         self,
@@ -21,6 +22,7 @@ class Drive:
         allow_duplicates: bool = False,
         component_name: Optional[str] = None,
         root_folder: Optional[str] = None,
+        optimization: Optional[str] = None,
     ):
         """The Drive object provides a shared space to write and read files from.
 
@@ -33,6 +35,8 @@ class Drive:
             component_name: The component name which owns this drive.
                 When not provided, it is automatically inferred by Lightning.
             root_folder: This is the folder from where the Drive perceives the data (e.g this acts as a mount dir).
+            optimization: Whether to optimize the drive with a given option. This also defines if the drive will be
+                mounted to the component and accessible via normal file system operations.
         """
         self.id = None
         for protocol in self.__PROTOCOLS__:
@@ -45,6 +49,10 @@ class Drive:
 
         if "/" in self.id:
             raise Exception(f"The id should be unique to identify your drive. Found `{self.id}`.")
+
+        if optimization and optimization not in self.__PROTOCOLS_OPTIMIZATIONS__[self.protocol]:
+            raise Exception(f"This Drive protocol is not compatible with the {optimization} optimization. Available "
+                            f"optimizations for this protocol are: {self.__PROTOCOLS_OPTIMIZATIONS__[self.protocol]}")
 
         self.root_folder = pathlib.Path(root_folder).resolve() if root_folder else os.getcwd()
         if not os.path.isdir(self.root_folder):

--- a/src/lightning_app/storage/drive.py
+++ b/src/lightning_app/storage/drive.py
@@ -49,7 +49,7 @@ class Drive:
         if not self.id:
             raise Exception(f"The Drive id needs to start with one of the following protocols: {self.__PROTOCOLS__}")
 
-        if self.protocol != "lit://" and "/" in self.id:
+        if self.protocol != "s3://" and "/" in self.id:
             raise Exception(f"The id should be unique to identify your drive. Found `{self.id}`.")
 
         self.root_folder = pathlib.Path(root_folder).resolve() if root_folder else os.getcwd()

--- a/src/lightning_app/storage/drive.py
+++ b/src/lightning_app/storage/drive.py
@@ -35,10 +35,17 @@ class Drive:
             root_folder: This is the folder from where the Drive perceives the data (e.g this acts as a mount dir).
         """
         self.id = None
+        self.protocol = None
         for protocol in self.__PROTOCOLS__:
             if id.startswith(protocol):
                 self.protocol = protocol
                 self.id = id.replace(protocol, "")
+                break
+        else:  # N.B. for-else loop
+            raise ValueError(
+                f"Unknown protocol for the drive 'id' argument '{id}`. The 'id' string "
+                f"must start with one of the following prefixes {self.__PROTOCOLS__}"
+            )
 
         if self.protocol == "s3://" and not self.id.endswith("/"):
             raise ValueError(

--- a/src/lightning_app/storage/drive.py
+++ b/src/lightning_app/storage/drive.py
@@ -40,6 +40,12 @@ class Drive:
                 self.protocol = protocol
                 self.id = id.replace(protocol, "")
 
+        if self.protocol == "s3://" and not self.id.endswith("/"):
+            raise ValueError(
+                "S3 drives must end in a trailing slash (`/`) to indicate a folder is being mounted. "
+                f"Recieved: '{id}'. Mounting a single file is not currently supported."
+            )
+
         if not self.id:
             raise Exception(f"The Drive id needs to start with one of the following protocols: {self.__PROTOCOLS__}")
 

--- a/src/lightning_app/storage/drive.py
+++ b/src/lightning_app/storage/drive.py
@@ -49,7 +49,7 @@ class Drive:
         if not self.id:
             raise Exception(f"The Drive id needs to start with one of the following protocols: {self.__PROTOCOLS__}")
 
-        if "/" in self.id:
+        if self.protocol != "lit://" and "/" in self.id:
             raise Exception(f"The id should be unique to identify your drive. Found `{self.id}`.")
 
         self.root_folder = pathlib.Path(root_folder).resolve() if root_folder else os.getcwd()

--- a/tests/tests_app/storage/test_drive.py
+++ b/tests/tests_app/storage/test_drive.py
@@ -109,8 +109,8 @@ def test_lit_drive_transferring_files():
 
 
 def test_lit_drive():
-    with pytest.raises(Exception, match="The Drive id needs to start with one of the following protocols"):
-        Drive("this_drive_id")
+    with pytest.raises(Exception, match="Unknown protocol for the drive 'id' argument"):
+        Drive("invalid_drive_id")
 
     with pytest.raises(
         Exception, match="The id should be unique to identify your drive. Found `this_drive_id/something_else`."

--- a/tests/tests_app/storage/test_drive.py
+++ b/tests/tests_app/storage/test_drive.py
@@ -214,7 +214,7 @@ def test_lit_drive():
 
 
 def test_s3_drives():
-    drive = Drive("s3://foo", allow_duplicates=True)
+    drive = Drive("s3://foo/", allow_duplicates=True)
     drive.component_name = "root.work"
 
     with pytest.raises(
@@ -245,7 +245,12 @@ def test_s3_drives():
         drive.get("a.txt")
 
 
-@pytest.mark.parametrize("drive_id", ["lit://drive", "s3://drive"])
+def test_create_s3_drive_without_trailing_slash_fails():
+    with pytest.raises(ValueError, match="S3 drives must end in a trailing slash"):
+        Drive("s3://foo")
+
+
+@pytest.mark.parametrize("drive_id", ["lit://drive", "s3://drive/"])
 def test_maybe_create_drive(drive_id):
     drive = Drive(drive_id, allow_duplicates=False)
     drive.component_name = "root.work1"
@@ -255,7 +260,7 @@ def test_maybe_create_drive(drive_id):
     assert new_drive.component_name == drive.component_name
 
 
-@pytest.mark.parametrize("drive_id", ["lit://drive", "s3://drive"])
+@pytest.mark.parametrize("drive_id", ["lit://drive", "s3://drive/"])
 def test_drive_deepcopy(drive_id):
     drive = Drive(drive_id, allow_duplicates=True)
     drive.component_name = "root.work1"

--- a/tests/tests_app/storage/test_drive.py
+++ b/tests/tests_app/storage/test_drive.py
@@ -11,7 +11,7 @@ from lightning_app.storage.drive import _maybe_create_drive, Drive
 from lightning_app.utilities.component import _set_flow_context
 
 
-class SyncWorkA(LightningWork):
+class SyncWorkLITDriveA(LightningWork):
     def __init__(self, tmpdir):
         super().__init__()
         self.tmpdir = tmpdir
@@ -25,19 +25,19 @@ class SyncWorkA(LightningWork):
         os.remove(f"{self.tmpdir}/a.txt")
 
 
-class SyncWorkB(LightningWork):
+class SyncWorkLITDriveB(LightningWork):
     def run(self, drive: Drive):
         assert not os.path.exists("a.txt")
         drive.get("a.txt")
         assert os.path.exists("a.txt")
 
 
-class SyncFlow(LightningFlow):
+class SyncFlowLITDrives(LightningFlow):
     def __init__(self, tmpdir):
         super().__init__()
         self.log_dir = Drive("lit://log_dir")
-        self.work_a = SyncWorkA(str(tmpdir))
-        self.work_b = SyncWorkB()
+        self.work_a = SyncWorkLITDriveA(str(tmpdir))
+        self.work_b = SyncWorkLITDriveB()
 
     def run(self):
         self.work_a.run(self.log_dir)
@@ -45,15 +45,15 @@ class SyncFlow(LightningFlow):
         self._exit()
 
 
-def test_synchronization_drive(tmpdir):
+def test_synchronization_lit_drive(tmpdir):
     if os.path.exists("a.txt"):
         os.remove("a.txt")
-    app = LightningApp(SyncFlow(tmpdir))
+    app = LightningApp(SyncFlowLITDrives(tmpdir))
     MultiProcessRuntime(app, start_server=False).dispatch()
     os.remove("a.txt")
 
 
-class Work(LightningWork):
+class LITDriveWork(LightningWork):
     def __init__(self):
         super().__init__(parallel=True)
         self.drive = None
@@ -75,7 +75,7 @@ class Work(LightningWork):
         self.counter += 1
 
 
-class Work2(LightningWork):
+class LITDriveWork2(LightningWork):
     def __init__(self):
         super().__init__(parallel=True)
 
@@ -86,11 +86,11 @@ class Work2(LightningWork):
         assert drive.list(".", component_name=self.name) == []
 
 
-class Flow(LightningFlow):
+class LITDriveFlow(LightningFlow):
     def __init__(self):
         super().__init__()
-        self.work = Work()
-        self.work2 = Work2()
+        self.work = LITDriveWork()
+        self.work2 = LITDriveWork2()
 
     def run(self):
         self.work.run("0")
@@ -102,13 +102,13 @@ class Flow(LightningFlow):
             self._exit()
 
 
-def test_drive_transferring_files():
-    app = LightningApp(Flow())
+def test_lit_drive_transferring_files():
+    app = LightningApp(LITDriveFlow())
     MultiProcessRuntime(app, start_server=False).dispatch()
     os.remove("a.txt")
 
 
-def test_drive():
+def test_lit_drive():
     with pytest.raises(Exception, match="The Drive id needs to start with one of the following protocols"):
         Drive("this_drive_id")
 
@@ -213,9 +213,41 @@ def test_drive():
     os.remove("a.txt")
 
 
-def test_maybe_create_drive():
+def test_s3_drives():
+    drive = Drive("s3://foo", allow_duplicates=True)
+    drive.component_name = "root.work"
 
-    drive = Drive("lit://drive_3", allow_duplicates=False)
+    with pytest.raises(
+        Exception, match="S3 based drives cannot currently add files via this API. Did you mean to use `lit://` drives?"
+    ):
+        drive.put("a.txt")
+    with pytest.raises(
+        Exception,
+        match="S3 based drives cannot currently list files via this API. Did you mean to use `lit://` drives?",
+    ):
+        drive.list("a.txt")
+    with pytest.raises(
+        Exception, match="S3 based drives cannot currently get files via this API. Did you mean to use `lit://` drives?"
+    ):
+        drive.get("a.txt")
+    with pytest.raises(
+        Exception,
+        match="S3 based drives cannot currently delete files via this API. Did you mean to use `lit://` drives?",
+    ):
+        drive.delete("a.txt")
+
+    _set_flow_context()
+    with pytest.raises(Exception, match="The flow isn't allowed to put files into a Drive."):
+        drive.put("a.txt")
+    with pytest.raises(Exception, match="The flow isn't allowed to list files from a Drive."):
+        drive.list("a.txt")
+    with pytest.raises(Exception, match="The flow isn't allowed to get files from a Drive."):
+        drive.get("a.txt")
+
+
+@pytest.mark.parametrize("drive_id", ["lit://drive", "s3://drive"])
+def test_maybe_create_drive(drive_id):
+    drive = Drive(drive_id, allow_duplicates=False)
     drive.component_name = "root.work1"
     new_drive = _maybe_create_drive(drive.component_name, drive.to_dict())
     assert new_drive.protocol == drive.protocol
@@ -223,9 +255,9 @@ def test_maybe_create_drive():
     assert new_drive.component_name == drive.component_name
 
 
-def test_drive_deepcopy():
-
-    drive = Drive("lit://drive", allow_duplicates=True)
+@pytest.mark.parametrize("drive_id", ["lit://drive", "s3://drive"])
+def test_drive_deepcopy(drive_id):
+    drive = Drive(drive_id, allow_duplicates=True)
     drive.component_name = "root.work1"
     new_drive = deepcopy(drive)
     assert new_drive.id == drive.id


### PR DESCRIPTION
## What does this PR do?

~This PR adds a list of Drives to the app Work specification, this will enable apps to mount a given drive in the work and be able to access it through the file system (Using for example file system data loaders). This is an alternative way to work with drives than the existing access pattern and will later be expanded with additional options for optimizations.~

---

@rlizzo edits: This PR has been updated after feedback to basically only include the configuration for setting an s3 based Drive Type. A follow up PR will be made which allows us to inspect `Drive` objects attacked to each work attribute and then configure them based on the protocol (s3, etc). At the advice of @tchaton we have have removed the ability to use s3 based drives from the `Drive` `get/list/put/delete` method. If we want to enable this in the future, we will have a discussion on the API with @awaelchli and other interested parties. 

---

All the changes presented in this PR related to running in a cloud environment, when running locally, specifying work drives will not have any effect (However, you can mimic the cloud environment by placing of symlinking files to the same root folder).

Additionally, this PR updates the Drive spec:

1. Adding a new protocol `s3://` allowing the creation of drives directly from S3 buckets.
2. ~Adding a new, optional `optimization` field allowing users to specify optimizations for Drives when running on the cloud environment.~

### Does your PR introduce any breaking changes? If yes, please list them.

This PR should be fully backwards compatible with existing code and the Work.drives field is optional. 

cc @borda