### PR TITLE
Fix: Start Lightning App on Cloud if Repo Begins With Name "Lightning"

### DIFF
--- a/src/lightning_app/utilities/packaging/lightning_utils.py
+++ b/src/lightning_app/utilities/packaging/lightning_utils.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, Optional
 
 from packaging.version import Version
 
-from lightning_app import _logger, _PROJECT_ROOT, _root_logger
+from lightning_app import _logger, _PROJECT_ROOT, _PACKAGE_ROOT, _root_logger
 from lightning_app.__version__ import version
 from lightning_app.core.constants import PACKAGE_LIGHTNING
 from lightning_app.utilities.git import check_github_repository, get_dir_name
@@ -90,7 +90,7 @@ def get_dist_path_if_editable_install(project_name) -> str:
 
 def _prepare_lightning_wheels_and_requirements(root: Path) -> Optional[Callable]:
 
-    if "site-packages" in _PROJECT_ROOT:
+    if "site-packages" in _PACKAGE_ROOT:
         return
 
     # Packaging the Lightning codebase happens only inside the `lightning` repo.

--- a/src/lightning_app/utilities/packaging/lightning_utils.py
+++ b/src/lightning_app/utilities/packaging/lightning_utils.py
@@ -89,8 +89,8 @@ def get_dist_path_if_editable_install(project_name) -> str:
 
 
 def _prepare_lightning_wheels_and_requirements(root: Path) -> Optional[Callable]:
-    """This function determines if lightning is installed in editable mode (for developers)
-    and packages the current lightning source along with the app.
+    """This function determines if lightning is installed in editable mode (for developers) and packages the
+    current lightning source along with the app.
 
     For normal users who install via PyPi or Conda, then this function does not do anything.
     """

--- a/src/lightning_app/utilities/packaging/lightning_utils.py
+++ b/src/lightning_app/utilities/packaging/lightning_utils.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, Optional
 
 from packaging.version import Version
 
-from lightning_app import _logger, _PROJECT_ROOT, _PACKAGE_ROOT, _root_logger
+from lightning_app import _logger, _PROJECT_ROOT, _root_logger
 from lightning_app.__version__ import version
 from lightning_app.core.constants import PACKAGE_LIGHTNING
 from lightning_app.utilities.git import check_github_repository, get_dir_name
@@ -89,8 +89,13 @@ def get_dist_path_if_editable_install(project_name) -> str:
 
 
 def _prepare_lightning_wheels_and_requirements(root: Path) -> Optional[Callable]:
+    """This function determines if lightning is installed in editable mode (for developers)
+    and packages the current lightning source along with the app.
 
-    if "site-packages" in _PACKAGE_ROOT:
+    For normal users who install via PyPi or Conda, then this function does not do anything.
+    """
+
+    if not get_dist_path_if_editable_install("lightning"):
         return
 
     # Packaging the Lightning codebase happens only inside the `lightning` repo.

--- a/tests/tests_app/utilities/packaging/test_lightning_utils.py
+++ b/tests/tests_app/utilities/packaging/test_lightning_utils.py
@@ -1,4 +1,6 @@
 import os
+from unittest import mock
+from unittest.mock import ANY, Mock
 
 import pytest
 
@@ -14,11 +16,26 @@ from lightning_app.utilities.packaging.lightning_utils import (
 def test_prepare_lightning_wheels_and_requirement(tmpdir):
     """This test ensures the lightning source gets packaged inside the lightning repo."""
 
-    cleanup_handle = _prepare_lightning_wheels_and_requirements(tmpdir)
+    cDEFAULTleanup_handle = _prepare_lightning_wheels_and_requirements(tmpdir)
     tar_name = f"lightning-{version}.tar.gz"
     assert sorted(os.listdir(tmpdir)) == [tar_name]
     cleanup_handle()
     assert os.listdir(tmpdir) == []
+
+
+def _mocked_get_dist_path_if_editable_install(*args, **kwargs):
+    return None
+
+
+@mock.patch(
+    "lightning_app.utilities.packaging.lightning_utils.get_dist_path_if_editable_install",
+    new=_mocked_get_dist_path_if_editable_install,
+)
+def test_prepare_lightning_wheels_and_requirement_for_packages_installed_in_editable_mode(tmpdir):
+    """This test ensures the source does not get packaged inside the lightning repo if not installed in editable mode.
+    """
+    cleanup_handle = _prepare_lightning_wheels_and_requirements(tmpdir)
+    assert cleanup_handle is None
 
 
 @pytest.mark.skip(reason="TODO: Find a way to check for the latest version")

--- a/tests/tests_app/utilities/packaging/test_lightning_utils.py
+++ b/tests/tests_app/utilities/packaging/test_lightning_utils.py
@@ -32,8 +32,8 @@ def _mocked_get_dist_path_if_editable_install(*args, **kwargs):
     new=_mocked_get_dist_path_if_editable_install,
 )
 def test_prepare_lightning_wheels_and_requirement_for_packages_installed_in_editable_mode(tmpdir):
-    """This test ensures the source does not get packaged inside the lightning repo if not installed in editable mode.
-    """
+    """This test ensures the source does not get packaged inside the lightning repo if not installed in editable
+    mode."""
     cleanup_handle = _prepare_lightning_wheels_and_requirements(tmpdir)
     assert cleanup_handle is None
 

--- a/tests/tests_app/utilities/packaging/test_lightning_utils.py
+++ b/tests/tests_app/utilities/packaging/test_lightning_utils.py
@@ -16,7 +16,7 @@ from lightning_app.utilities.packaging.lightning_utils import (
 def test_prepare_lightning_wheels_and_requirement(tmpdir):
     """This test ensures the lightning source gets packaged inside the lightning repo."""
 
-    cDEFAULTleanup_handle = _prepare_lightning_wheels_and_requirements(tmpdir)
+    cleanup_handle = _prepare_lightning_wheels_and_requirements(tmpdir)
     tar_name = f"lightning-{version}.tar.gz"
     assert sorted(os.listdir(tmpdir)) == [tar_name]
     cleanup_handle()

--- a/tests/tests_app/utilities/packaging/test_lightning_utils.py
+++ b/tests/tests_app/utilities/packaging/test_lightning_utils.py
@@ -1,6 +1,5 @@
 import os
 from unittest import mock
-from unittest.mock import ANY, Mock
 
 import pytest
 


### PR DESCRIPTION
## What does this PR do?

Ensure that if a repository starts with the name "lightning" that it can actually be packaged and run on the cloud. This was occurring due to not checking if the package is installed in editable mode or not. if it is not installed in editable mode, do not package the source :) 

Fixes #13942
Fixes #13913

Note for Reviewers: ~I am having trouble figuring out how to test this. One option would be to completely mock out the `_PACKAGE_ROOT` variable, but this does not seem like a particularly useful test to actually ensure functionality? Looking for input here.~

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- ~[ ] Did you make sure to **update the documentation** with your changes? (if necessary)~
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- ~[ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)~

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

cc @borda