### PR TITLE
[CLI] change cluster creation cost savings mode default

### DIFF
--- a/src/lightning_app/CHANGELOG.md
+++ b/src/lightning_app/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
--
+- Default values and parameter names for Lightning AI BYOC cluster management ([#14132](https://github.com/Lightning-AI/lightning/pull/14132))
 
 
 ### Changed

--- a/src/lightning_app/cli/lightning_cli_create.py
+++ b/src/lightning_app/cli/lightning_cli_create.py
@@ -33,8 +33,8 @@ def create():
     help="Instance types that you want to support, for computer jobs within the cluster.",
 )
 @click.option(
-    "--disable-cost-savings",
-    "disable_cost_savings",
+    "--enable-performance",
+    "enable_performance",
     type=bool,
     required=False,
     default=False,
@@ -65,7 +65,7 @@ def create_cluster(
     provider: str,
     instance_types: str,
     edit_before_creation: bool,
-    disable_cost_savings: bool,
+    enable_performance: bool,
     wait: bool,
     **kwargs,
 ):
@@ -81,6 +81,6 @@ def create_cluster(
         external_id=external_id,
         instance_types=instance_types.split(",") if instance_types is not None else None,
         edit_before_creation=edit_before_creation,
-        cost_savings=not disable_cost_savings,
+        cost_savings=not enable_performance,
         wait=wait,
     )

--- a/src/lightning_app/cli/lightning_cli_create.py
+++ b/src/lightning_app/cli/lightning_cli_create.py
@@ -33,14 +33,14 @@ def create():
     help="Instance types that you want to support, for computer jobs within the cluster.",
 )
 @click.option(
-    "--cost-savings",
-    "cost_savings",
+    "--disable-cost-savings",
+    "disable_cost_savings",
     type=bool,
     required=False,
     default=False,
     is_flag=True,
-    help=""""Use this flag to ensure that the cluster is created with a profile that is optimized for cost savings.
-        This makes runs cheaper but start-up times may increase.""",
+    help=""""Use this flag to ensure that the cluster is created with a profile that is optimized for performance.
+        This makes runs more expensive but start-up times decrease.""",
 )
 @click.option(
     "--edit-before-creation",
@@ -65,12 +65,12 @@ def create_cluster(
     provider: str,
     instance_types: str,
     edit_before_creation: bool,
-    cost_savings: bool,
+    disable_cost_savings: bool,
     wait: bool,
     **kwargs,
 ):
     """Create a Lightning AI BYOC compute cluster with your cloud provider credentials."""
-    if provider != "aws":
+    if provider.lower() != "aws":
         click.echo("Only AWS is supported for now. But support for more providers is coming soon.")
         return
     cluster_manager = AWSClusterManager()
@@ -81,6 +81,6 @@ def create_cluster(
         external_id=external_id,
         instance_types=instance_types.split(",") if instance_types is not None else None,
         edit_before_creation=edit_before_creation,
-        cost_savings=cost_savings,
+        cost_savings=not disable_cost_savings,
         wait=wait,
     )

--- a/tests/tests_app/cli/test_cli.py
+++ b/tests/tests_app/cli/test_cli.py
@@ -76,7 +76,7 @@ def test_main_lightning_cli_help():
         (["--instance-types", "t3.xlarge"], ["t3.xlarge"], True),
         (["--instance-types", "t3.xlarge,t3.2xlarge"], ["t3.xlarge", "t3.2xlarge"], True),
         ([], None, True),
-        (["--disable-cost-savings"], None, False),
+        (["--enable_performance"], None, False),
     ],
 )
 def test_create_cluster(

--- a/tests/tests_app/cli/test_cli.py
+++ b/tests/tests_app/cli/test_cli.py
@@ -76,7 +76,7 @@ def test_main_lightning_cli_help():
         (["--instance-types", "t3.xlarge"], ["t3.xlarge"], True),
         (["--instance-types", "t3.xlarge,t3.2xlarge"], ["t3.xlarge", "t3.2xlarge"], True),
         ([], None, True),
-        (["--enable_performance"], None, False),
+        (["--enable-performance"], None, False),
     ],
 )
 def test_create_cluster(

--- a/tests/tests_app/cli/test_cli.py
+++ b/tests/tests_app/cli/test_cli.py
@@ -71,14 +71,17 @@ def test_main_lightning_cli_help():
 @mock.patch("lightning_cloud.login.Auth.authenticate", MagicMock())
 @mock.patch("lightning_app.cli.cmd_clusters.AWSClusterManager.create")
 @pytest.mark.parametrize(
-    "instance_types,expected_instance_types",
+    "extra_arguments,expected_instance_types,expected_cost_savings_mode",
     [
-        (["--instance-types", "t3.xlarge"], ["t3.xlarge"]),
-        (["--instance-types", "t3.xlarge,t3.2xlarge"], ["t3.xlarge", "t3.2xlarge"]),
-        ([], None),
+        (["--instance-types", "t3.xlarge"], ["t3.xlarge"], True),
+        (["--instance-types", "t3.xlarge,t3.2xlarge"], ["t3.xlarge", "t3.2xlarge"], True),
+        ([], None, True),
+        (["--disable-cost-savings"], None, False),
     ],
 )
-def test_create_cluster(create_command: mock.MagicMock, instance_types, expected_instance_types):
+def test_create_cluster(
+    create_command: mock.MagicMock, extra_arguments, expected_instance_types, expected_cost_savings_mode
+):
     runner = CliRunner()
     runner.invoke(
         create_cluster,
@@ -91,7 +94,7 @@ def test_create_cluster(create_command: mock.MagicMock, instance_types, expected
             "--role-arn",
             "arn:aws:iam::1234567890:role/lai-byoc",
         ]
-        + instance_types,
+        + extra_arguments,
     )
 
     create_command.assert_called_once_with(
@@ -101,7 +104,7 @@ def test_create_cluster(create_command: mock.MagicMock, instance_types, expected
         external_id="dummy",
         instance_types=expected_instance_types,
         edit_before_creation=False,
-        cost_savings=False,
+        cost_savings=expected_cost_savings_mode,
         wait=False,
     )
 


### PR DESCRIPTION

## What does this PR do?

This PR changes the default for cluster creation:
instead of having customers opt-into cost savings mode, we'll ask them to opt-out of cost savings mode.

Based on internal discussions - see LAI2-10134

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @borda