### PR TITLE
Fix saving hyperparameters in a composition where parent is not a LM or LDM

### DIFF
--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -70,7 +70,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed epoch-end logging results not being reset after the end of the epoch ([#14061](https://github.com/Lightning-AI/lightning/pull/14061))
 
 
-- Fix saving hyperparameters in a composition where the parent class is not a `LightningModule` or `LightningDataModule` ([#14151](https://github.com/Lightning-AI/lightning/pull/14151))
+- Fixed saving hyperparameters in a composition where the parent class is not a `LightningModule` or `LightningDataModule` ([#14151](https://github.com/Lightning-AI/lightning/pull/14151))
 
 
 

--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -70,6 +70,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed epoch-end logging results not being reset after the end of the epoch ([#14061](https://github.com/Lightning-AI/lightning/pull/14061))
 
 
+- Fix saving hyperparameters in a composition where the parent class is not a `LightningModule` or `LightningDataModule` ([#14151](https://github.com/Lightning-AI/lightning/pull/14151))
+
+
+
 ## [1.7.1] - 2022-08-09
 
 ### Fixed

--- a/src/pytorch_lightning/utilities/parsing.py
+++ b/src/pytorch_lightning/utilities/parsing.py
@@ -162,7 +162,10 @@ def get_init_args(frame: types.FrameType) -> Dict[str, Any]:
 
 
 def collect_init_args(
-    frame: types.FrameType, path_args: List[Dict[str, Any]], inside: bool = False
+    frame: types.FrameType,
+    path_args: List[Dict[str, Any]],
+    inside: bool = False,
+    classes: Tuple[Type, ...] = (object,),
 ) -> List[Dict[str, Any]]:
     """Recursively collects the arguments passed to the child constructors in the inheritance tree.
 
@@ -170,6 +173,7 @@ def collect_init_args(
         frame: the current stack frame
         path_args: a list of dictionaries containing the constructor args in all parent classes
         inside: track if we are inside inheritance path, avoid terminating too soon
+        classes: the classes in which to inspect the frames
 
     Return:
           A list of dictionaries where each dictionary contains the arguments passed to the
@@ -181,13 +185,13 @@ def collect_init_args(
     if not isinstance(frame.f_back, types.FrameType):
         return path_args
 
-    if "__class__" in local_vars:
+    if "__class__" in local_vars and issubclass(local_vars["__class__"], classes):
         local_args = get_init_args(frame)
         # recursive update
         path_args.append(local_args)
-        return collect_init_args(frame.f_back, path_args, inside=True)
+        return collect_init_args(frame.f_back, path_args, inside=True, classes=classes)
     if not inside:
-        return collect_init_args(frame.f_back, path_args, inside)
+        return collect_init_args(frame.f_back, path_args, inside, classes=classes)
     return path_args
 
 
@@ -225,7 +229,7 @@ def save_hyperparameters(
         init_args = {f.name: getattr(obj, f.name) for f in fields(obj)}
     else:
         init_args = {}
-        for local_args in collect_init_args(frame, []):
+        for local_args in collect_init_args(frame, [], classes=(pl.LightningModule, pl.LightningDataModule)):
             init_args.update(local_args)
 
     if ignore is None:

--- a/src/pytorch_lightning/utilities/parsing.py
+++ b/src/pytorch_lightning/utilities/parsing.py
@@ -165,7 +165,7 @@ def collect_init_args(
     frame: types.FrameType,
     path_args: List[Dict[str, Any]],
     inside: bool = False,
-    classes: Tuple[Type, ...] = (object,),
+    classes: Tuple[Type, ...] = (),
 ) -> List[Dict[str, Any]]:
     """Recursively collects the arguments passed to the child constructors in the inheritance tree.
 
@@ -185,7 +185,7 @@ def collect_init_args(
     if not isinstance(frame.f_back, types.FrameType):
         return path_args
 
-    if "__class__" in local_vars and issubclass(local_vars["__class__"], classes):
+    if "__class__" in local_vars and (not classes or issubclass(local_vars["__class__"], classes)):
         local_args = get_init_args(frame)
         # recursive update
         path_args.append(local_args)

--- a/src/pytorch_lightning/utilities/parsing.py
+++ b/src/pytorch_lightning/utilities/parsing.py
@@ -229,7 +229,10 @@ def save_hyperparameters(
         init_args = {f.name: getattr(obj, f.name) for f in fields(obj)}
     else:
         init_args = {}
-        for local_args in collect_init_args(frame, [], classes=(pl.LightningModule, pl.LightningDataModule)):
+
+        from pytorch_lightning.core.mixins import HyperparametersMixin
+
+        for local_args in collect_init_args(frame, [], classes=(HyperparametersMixin,)):
             init_args.update(local_args)
 
     if ignore is None:

--- a/tests/tests_pytorch/models/test_hparams.py
+++ b/tests/tests_pytorch/models/test_hparams.py
@@ -29,6 +29,7 @@ from torch.utils.data import DataLoader
 from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.core.datamodule import LightningDataModule
+from pytorch_lightning.core.mixins import HyperparametersMixin
 from pytorch_lightning.core.saving import load_hparams_from_yaml, save_hparams_to_yaml
 from pytorch_lightning.demos.boring_classes import BoringDataModule, BoringModel, RandomDataset
 from pytorch_lightning.utilities import _OMEGACONF_AVAILABLE, AttributeDict, is_picklable
@@ -399,7 +400,7 @@ def _raw_checkpoint_path(trainer) -> str:
     return raw_checkpoint_path
 
 
-@pytest.mark.parametrize("base_class", (LightningModule, LightningDataModule))
+@pytest.mark.parametrize("base_class", (HyperparametersMixin, LightningModule, LightningDataModule))
 def test_save_hyperparameters_under_composition(base_class):
     """Test that in a composition where the parent is not a Lightning-like module, the parent's arguments don't get
     collected."""

--- a/tests/tests_pytorch/models/test_hparams.py
+++ b/tests/tests_pytorch/models/test_hparams.py
@@ -411,7 +411,6 @@ def test_save_hyperparameters_under_composition(base_class):
 
     class NotPLSubclass:  # intentionally not subclassing LightningModule/LightningDataModule
         def __init__(self, same_arg="parent_default", other_arg="other"):
-            super().__init__()
             self.child = ChildInComposition(same_arg="cocofruit")
 
     parent = NotPLSubclass()

--- a/tests/tests_pytorch/models/test_hparams.py
+++ b/tests/tests_pytorch/models/test_hparams.py
@@ -399,6 +399,25 @@ def _raw_checkpoint_path(trainer) -> str:
     return raw_checkpoint_path
 
 
+@pytest.mark.parametrize("base_class", (LightningModule, LightningDataModule))
+def test_save_hyperparameters_under_composition(base_class):
+    """Test that in a composition where the parent is not a Lightning-like module, the parent's arguments don't get
+    collected."""
+
+    class ChildInComposition(base_class):
+        def __init__(self, same_arg):
+            super().__init__()
+            self.save_hyperparameters()
+
+    class NotPLSubclass:  # intentionally not subclassing LightningModule/LightningDataModule
+        def __init__(self, same_arg="parent_default", other_arg="other"):
+            super().__init__()
+            self.child = ChildInComposition(same_arg="cocofruit")
+
+    parent = NotPLSubclass()
+    assert parent.child.hparams == dict(same_arg="cocofruit")
+
+
 class LocalVariableModelSuperLast(BoringModel):
     """This model has the super().__init__() call at the end."""
 


### PR DESCRIPTION
## What does this PR do?

Fixes #13181
Closes: #13202

Look at this code:

```py
    class Child(LightningModule):
        def __init__(self, same_arg):
            super().__init__()
            self.save_hyperparameters()

    class Parent: 
        def __init__(self, same_arg="parent_default", other_arg="other"):
            self.child = Child(same_arg="cocofruit")

    parent = Parent()
    print(parent.child.hparams)
```

Note: There is a LightningModule composed inside of a non-LightningModule class. 

**Q: At the call `self.save_hyperparameters()`, which parameters do we excpect to get saved?**
A: Only the ones from the child LightningModule. But on master, it collects also the ones from the parent class. 

**Q: But Adrian, collecting more parameters is always better. The more the better!**
A: No. 1) You could coincidentally have two arguments with the same name in two different classes. So there is a collision and in master, one overwrites the other. Bad! 2) We save hyperparameters not just for the sake of saving them. We want to save exactly the ones needed to reconstruct the object when loading `ChildInComposition.load_from_checkpoint`. No more, no less.



## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃


cc @borda @justusschock @awaelchli @ninginthecloud @rohitgr7 @otaj @akihironitta