### PR TITLE
Fix flaky test caused by weak reference

### DIFF
--- a/tests/tests_pytorch/trainer/connectors/test_data_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_data_connector.py
@@ -445,7 +445,8 @@ def test_dataloader_source_direct_access():
 def test_dataloader_source_request_from_module():
     """Test requesting a dataloader from a module works."""
     module = BoringModel()
-    module.trainer = Trainer()
+    trainer = Trainer()
+    module.trainer = trainer
     module.foo = Mock(return_value=module.train_dataloader())
 
     source = _DataLoaderSource(module, "foo")


### PR DESCRIPTION
## What does this PR do?

Fixes:
```py
_________________ test_dataloader_source_request_from_module __________________

    def test_dataloader_source_request_from_module():
        """Test requesting a dataloader from a module works."""
        module = BoringModel()
        module.trainer = Trainer()
        module.foo = Mock(return_value=module.train_dataloader())
    
        source = _DataLoaderSource(module, "foo")
        assert source.is_module()
        module.foo.assert_not_called()
>       assert isinstance(source.dataloader(), DataLoader)

D:\a\lightning\lightning\tests\tests_pytorch\trainer\connectors\test_data_connector.py:454: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = _DataLoaderSource(instance=BoringModel(
  (layer): Linear(in_features=32, out_features=2, bias=True)
), name='foo')

    def dataloader(self) -> Union[TRAIN_DATALOADERS, EVAL_DATALOADERS]:
        """Returns the dataloader from the source.
    
        If the source is a module, the method with the corresponding :attr:`name` gets called.
        """
        from pytorch_lightning import LightningDataModule, LightningModule  # prevent cyclic import
    
        if not self.name:
            return self.instance
    
        if isinstance(self.instance, LightningModule):
>           return self.instance.trainer._call_lightning_module_hook(self.name, pl_module=self.instance)
E           ReferenceError: weakly-referenced object no longer exists
```
Example: https://github.com/Lightning-AI/lightning/runs/7773962786?check_suite_focus=true#step:20:3270

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [n/a] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [n/a] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

cc @borda @akihironitta