### PR TITLE
BYOC: fix default types for cluster instance types

### DIFF
--- a/src/lightning_app/cli/lightning_cli_create.py
+++ b/src/lightning_app/cli/lightning_cli_create.py
@@ -79,7 +79,7 @@ def create_cluster(
         region=region,
         role_arn=role_arn,
         external_id=external_id,
-        instance_types=instance_types.split(",") if instance_types is not None else None,
+        instance_types=instance_types.split(",") if instance_types is not None else [],
         edit_before_creation=edit_before_creation,
         cost_savings=not enable_performance,
         wait=wait,

--- a/tests/tests_app/cli/test_cli.py
+++ b/tests/tests_app/cli/test_cli.py
@@ -75,8 +75,8 @@ def test_main_lightning_cli_help():
     [
         (["--instance-types", "t3.xlarge"], ["t3.xlarge"], True),
         (["--instance-types", "t3.xlarge,t3.2xlarge"], ["t3.xlarge", "t3.2xlarge"], True),
-        ([], None, True),
-        (["--enable-performance"], None, False),
+        ([], [], True),
+        (["--enable-performance"], [], False),
     ],
 )
 def test_create_cluster(


### PR DESCRIPTION
## What does this PR do?

This PR fixes the wrong type being supplied to the cluster on creation if no `instance-types` argument was specified. 
The problem was that we used `None`, where the requesting side assumes an `Iterable` type - which None is not.

This wasn't caught by mypy because it seems we don't include lightning_app cli in the list of checked packages.

I've verified this manually to ensure it works end-to-end without the argument.

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @borda