### PR TITLE
Update mising CODEOWNERS for the PL package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,7 +26,7 @@
 /docs/source-app/expertise_levels           @williamfalcon @Felonious-Spellfire @RobertLaurella
 
 # Packages
-/src/pytorch_lightning                      @borda @awaelchli @carmocca @justusschock @rohitgr7
+/src/pytorch_lightning                      @borda @awaelchli @carmocca @justusschock @rohitgr7 @otaj
 /src/pytorch_lightning/accelerators         @williamfalcon @tchaton @SeanNaren @awaelchli @justusschock @kaushikb11
 /src/pytorch_lightning/callbacks            @williamfalcon @tchaton @carmocca @borda @kaushikb11
 /src/pytorch_lightning/core                 @tchaton @borda @carmocca @justusschock @kaushikb11

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,7 +26,7 @@
 /docs/source-app/expertise_levels           @williamfalcon @Felonious-Spellfire @RobertLaurella
 
 # Packages
-/src/pytorch_lightning                      @carmocca @justusschock
+/src/pytorch_lightning                      @borda @awaelchli @carmocca @justusschock @rohitgr7
 /src/pytorch_lightning/accelerators         @williamfalcon @tchaton @SeanNaren @awaelchli @justusschock @kaushikb11
 /src/pytorch_lightning/callbacks            @williamfalcon @tchaton @carmocca @borda @kaushikb11
 /src/pytorch_lightning/core                 @tchaton @borda @carmocca @justusschock @kaushikb11


### PR DESCRIPTION
## What does this PR do?

Since later matches take precedence, the codeowners need to be repeated from the match-all list

cc @borda