### PR TITLE
Deprecated the `on_hpc_save` and `on_hpc_load` override functions in `LightningModule`

### DIFF
--- a/docs/source-pytorch/common/lightning_module.rst
+++ b/docs/source-pytorch/common/lightning_module.rst
@@ -1345,18 +1345,6 @@ load_from_checkpoint
 .. automethod:: pytorch_lightning.core.module.LightningModule.load_from_checkpoint
     :noindex:
 
-on_hpc_save
-~~~~~~~~~~~
-
-.. automethod:: pytorch_lightning.core.module.LightningModule.on_hpc_save
-    :noindex:
-
-on_hpc_load
-~~~~~~~~~~~
-
-.. automethod:: pytorch_lightning.core.module.LightningModule.on_hpc_load
-    :noindex:
-
 on_train_start
 ~~~~~~~~~~~~~~
 

--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -58,7 +58,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Deprecated the `on_colab_kaggle` function ([#14247](https://github.com/Lightning-AI/lightning/pull/14247))
 
-- Deprecated the `on_hpc_save` and `on_hpc_load` override functions in `LightningModule`
+
+- Deprecated the `on_hpc_save` and `on_hpc_load` override functions in `LightningModule` ([#14407](https://github.com/Lightning-AI/lightning/pull/14407))
 
 
 ### Removed

--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -58,6 +58,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Deprecated the `on_colab_kaggle` function ([#14247](https://github.com/Lightning-AI/lightning/pull/14247))
 
+- Deprecated the `on_hpc_save` and `on_hpc_load` override functions in `LightningModule`
+
 
 ### Removed
 

--- a/src/pytorch_lightning/core/saving.py
+++ b/src/pytorch_lightning/core/saving.py
@@ -142,32 +142,6 @@ class ModelIO:
             **kwargs,
         )
 
-    # -------------------------
-    # OPTIONAL HOOKS
-    # -------------------------
-    def on_hpc_save(self, checkpoint: Dict[str, Any]) -> None:
-        """Hook to do whatever you need right before Slurm manager saves the model.
-
-        Args:
-            checkpoint: A dictionary in which you can save variables to save in a checkpoint.
-                Contents need to be pickleable.
-
-        .. deprecated:: v1.6
-            This method is deprecated in v1.6 and will be removed in v1.8.
-            Please use ``LightningModule.on_save_checkpoint`` instead.
-        """
-
-    def on_hpc_load(self, checkpoint: Dict[str, Any]) -> None:
-        """Hook to do whatever you need right before Slurm manager loads the model.
-
-        Args:
-            checkpoint: A dictionary with variables from the checkpoint.
-
-        .. deprecated:: v1.6
-            This method is deprecated in v1.6 and will be removed in v1.8.
-            Please use ``LightningModule.on_load_checkpoint`` instead.
-        """
-
 
 def _load_from_checkpoint(
     cls: Union[Type["ModelIO"], Type["pl.LightningModule"], Type["pl.LightningDataModule"]],

--- a/src/pytorch_lightning/trainer/configuration_validator.py
+++ b/src/pytorch_lightning/trainer/configuration_validator.py
@@ -48,8 +48,6 @@ def verify_loop_configurations(trainer: "pl.Trainer") -> None:
 
     __verify_batch_transfer_support(trainer, model)
     _check_deprecated_callback_hooks(trainer)
-    # TODO: Delete _check_on_hpc_hooks in v1.8
-    _check_on_hpc_hooks(model)
     # TODO: Delete on_epoch_start/on_epoch_end hooks in v1.8
     _check_on_epoch_start_end(model)
     # TODO: Delete CheckpointHooks off PrecisionPlugin in v1.8
@@ -205,21 +203,6 @@ def __check_training_step_requires_dataloader_iter(model: "pl.LightningModule") 
                 "The model taking a `dataloader_iter` argument in your `training_step` "
                 "is incompatible with `truncated_bptt_steps > 0`."
             )
-
-
-# TODO: Delete _check_on_hpc_hooks in v1.8
-def _check_on_hpc_hooks(model: "pl.LightningModule") -> None:
-    if is_overridden("on_hpc_save", model):
-        rank_zero_deprecation(
-            "Method `LightningModule.on_hpc_save` is deprecated in v1.6 and"
-            " will be removed in v1.8. Please use `LightningModule.on_save_checkpoint` instead."
-        )
-
-    if is_overridden("on_hpc_load", model):
-        rank_zero_deprecation(
-            "Method `LightningModule.on_hpc_load` is deprecated in v1.6 and"
-            " will be removed in v1.8. Please use `LightningModule.on_load_checkpoint` instead."
-        )
 
 
 # TODO: Remove on_epoch_start/on_epoch_end hooks in v1.8

--- a/src/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -23,7 +23,6 @@ from torch import Tensor
 from torchmetrics import Metric
 
 import pytorch_lightning as pl
-from pytorch_lightning.plugins.environments import SLURMEnvironment
 from pytorch_lightning.plugins.precision import ApexMixedPrecisionPlugin, NativeMixedPrecisionPlugin
 from pytorch_lightning.trainer.states import TrainerFn
 from pytorch_lightning.utilities import _OMEGACONF_AVAILABLE
@@ -168,15 +167,8 @@ class CheckpointConnector:
         if not self._loaded_checkpoint:
             return
 
-        model = self.trainer.lightning_module
-
         # hook: give user access to checkpoint if needed.
         self.trainer._call_lightning_module_hook("on_load_checkpoint", self._loaded_checkpoint)
-
-        # TODO: remove this in v1.8.
-        # call hpc specific hook
-        if self._hpc_resume_path is not None:
-            model.on_hpc_load(self._loaded_checkpoint)
 
         # restore model state_dict
         self.trainer.strategy.load_model_state_dict(self._loaded_checkpoint)
@@ -437,11 +429,6 @@ class CheckpointConnector:
         self.trainer._call_lightning_module_hook("on_save_checkpoint", checkpoint)
         if datamodule is not None:
             self.trainer._call_lightning_datamodule_hook("on_save_checkpoint", checkpoint)
-
-        # TODO: remove this in v1.8.
-        environment = self.trainer._accelerator_connector.cluster_environment
-        if isinstance(environment, SLURMEnvironment) and environment.auto_requeue:
-            model.on_hpc_save(checkpoint)
 
         return checkpoint
 

--- a/tests/tests_pytorch/deprecated_api/test_remove_1-8.py
+++ b/tests/tests_pytorch/deprecated_api/test_remove_1-8.py
@@ -97,29 +97,6 @@ def test_v1_8_0_deprecated_warning_positional_category():
         rank_zero_warn("foo", FutureWarning)
 
 
-def test_v1_8_0_deprecated_on_hpc_hooks(tmpdir):
-    class TestModelSave(BoringModel):
-        def on_hpc_save(self):
-            print("on_hpc_save override")
-
-    class TestModelLoad(BoringModel):
-        def on_hpc_load(self):
-            print("on_hpc_load override")
-
-    save_model = TestModelSave()
-    load_model = TestModelLoad()
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, fast_dev_run=True)
-
-    with pytest.deprecated_call(
-        match=r"Method `LightningModule.on_hpc_save` is deprecated in v1.6 and will be removed in v1.8."
-    ):
-        trainer.fit(save_model)
-    with pytest.deprecated_call(
-        match=r"Method `LightningModule.on_hpc_load` is deprecated in v1.6 and will be removed in v1.8."
-    ):
-        trainer.fit(load_model)
-
-
 def test_v1_8_0_deprecated_run_stage():
     trainer = Trainer()
     trainer._run_stage = Mock()


### PR DESCRIPTION
Deprecate functions for `1.8` release. 