### PR TITLE
Remove the broken and unused `get_deprecated_arg_names`

### DIFF
--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -81,6 +81,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed the deprecated `DistributedType` and `DeviceType` enum classes ([#14045](https://github.com/Lightning-AI/lightning/pull/14045))
 
 
+- Removed the legacy and unused `Trainer.get_deprecated_arg_names()` ([#14415](https://github.com/Lightning-AI/lightning/pull/14415))
+
+
 - Removed the experimental `pytorch_lightning.utiltiies.meta` functions in favor of built-in https://github.com/pytorch/torchdistx support ([#13868](https://github.com/Lightning-AI/lightning/pull/13868))
 
 

--- a/src/pytorch_lightning/core/datamodule.py
+++ b/src/pytorch_lightning/core/datamodule.py
@@ -114,15 +114,6 @@ class LightningDataModule(CheckpointHooks, DataHooks, HyperparametersMixin):
         return get_init_arguments_and_types(cls)
 
     @classmethod
-    def get_deprecated_arg_names(cls) -> List:
-        """Returns a list with deprecated DataModule arguments."""
-        depr_arg_names: List[str] = []
-        for name, val in cls.__dict__.items():
-            if name.startswith("DEPRECATED") and isinstance(val, (tuple, list)):
-                depr_arg_names.extend(val)
-        return depr_arg_names
-
-    @classmethod
     def from_datasets(
         cls,
         train_dataset: Optional[Union[Dataset, Sequence[Dataset], Mapping[str, Dataset]]] = None,

--- a/src/pytorch_lightning/trainer/trainer.py
+++ b/src/pytorch_lightning/trainer/trainer.py
@@ -2435,15 +2435,6 @@ class Trainer(
         return {k: v.default for k, v in init_signature.parameters.items()}
 
     @classmethod
-    def get_deprecated_arg_names(cls) -> List:
-        """Returns a list with deprecated Trainer arguments."""
-        depr_arg_names = []
-        for name, val in cls.__dict__.items():
-            if name.startswith("DEPRECATED") and isinstance(val, (tuple, list)):
-                depr_arg_names.extend(val)
-        return depr_arg_names
-
-    @classmethod
     def from_argparse_args(cls: Any, args: Union[Namespace, ArgumentParser], **kwargs) -> Any:
         return from_argparse_args(cls, args, **kwargs)
 

--- a/src/pytorch_lightning/utilities/argparse.py
+++ b/src/pytorch_lightning/utilities/argparse.py
@@ -212,8 +212,6 @@ def add_argparse_args(
         parser = ArgumentParser(parents=[parent_parser], add_help=False)
 
     ignore_arg_names = ["self", "args", "kwargs"]
-    if hasattr(cls, "get_deprecated_arg_names"):
-        ignore_arg_names += cls.get_deprecated_arg_names()
 
     allowed_types = (str, int, float, bool)
 

--- a/tests/tests_pytorch/utilities/test_argparse.py
+++ b/tests/tests_pytorch/utilities/test_argparse.py
@@ -1,6 +1,6 @@
 import io
 from argparse import ArgumentParser, Namespace
-from typing import Generic, List, TypeVar
+from typing import Generic, TypeVar
 from unittest.mock import MagicMock
 
 import pytest
@@ -117,10 +117,6 @@ class AddArgparseArgsExampleClass:
 
     def __init__(self, my_parameter: int = 0):
         pass
-
-    @staticmethod
-    def get_deprecated_arg_names() -> List[str]:
-        return []
 
 
 class AddArgparseArgsExampleClassViaInit:


### PR DESCRIPTION
## What does this PR do?

Follow-up to https://github.com/Lightning-AI/lightning/pull/13693#discussion_r936602562

For the historians, this was added in https://github.com/Lightning-AI/lightning/pull/1147

### Does your PR introduce any breaking changes? If yes, please list them.

Removes the broken and unused method.

No public usage: https://grep.app/search?q=get_deprecated_arg_names

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [n/a] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

cc @justusschock @awaelchli @rohitgr7 @borda