### PR TITLE
Fix pruning with non tensor params

### DIFF
--- a/src/pytorch_lightning/callbacks/pruning.py
+++ b/src/pytorch_lightning/callbacks/pruning.py
@@ -449,7 +449,10 @@ class ModelPruning(Callback):
 
         if not parameters_to_prune:
             parameters_to_prune = [
-                (m, p) for p in parameters for m in current_modules if getattr(m, p, None) is not None
+                (m, p)
+                for p in parameters
+                for m in current_modules
+                if getattr(m, p, None) is not None and isinstance(p, Tensor)
             ]
         elif (
             isinstance(parameters_to_prune, (list, tuple))


### PR DESCRIPTION
## What does this PR do?

This pull request fixes the pruning problem made when a model includes non-tensor parameters.  
The previous code added all parameters when _parameters_to_prune_ was not provided. However, this causes problems when parameters are not Tensors. I added a line so just Tensor parameters will be included.

Fixes #10835

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
