### PR TITLE
E2E fix for custom base image

### DIFF
--- a/tests/tests_app_examples/custom_work_dependencies/app.py
+++ b/tests/tests_app_examples/custom_work_dependencies/app.py
@@ -28,7 +28,7 @@ class WorkWithCustomBaseImage(LightningWork):
     def __init__(self, cloud_compute: CloudCompute = CloudCompute(), **kwargs):
         # this image has been created from ghcr.io/gridai/base-images:v1.8-cpu
         # by just adding an empty file at /content/.e2e_test
-        custom_image = "ghcr.io/gridai/image-for-testing-custom-images-in-e2e"
+        custom_image = "ghcr.io/gridai/image-for-testing-custom-images-in-e2e:v0.0.1"
         build_config = BuildConfig(image=custom_image)
         super().__init__(parallel=True, **kwargs, cloud_compute=cloud_compute, cloud_build_config=build_config)
 

--- a/tests/tests_app_examples/custom_work_dependencies/app.py
+++ b/tests/tests_app_examples/custom_work_dependencies/app.py
@@ -34,7 +34,7 @@ class WorkWithCustomBaseImage(LightningWork):
 
     def run(self):
         # checking the existence of the file - this file had been added to the custom base image
-        assert ".e2e_test" in os.listdir("/content/"), "file not found"
+        assert ".e2e_test" in os.listdir("/testdir/"), "file not found"
 
 
 class CustomWorkBuildConfigChecker(LightningFlow):


### PR DESCRIPTION
## What does this PR do?

LightningCloud has changed the home directory mount behaviour and this affected our e2es. This PR is to use the new custom base image in the e2e test

<!-- FILL IN or None -->

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @borda