### PR TITLE
Fix fault tolerant training in cases where num_workers > 0

### DIFF
--- a/src/pytorch_lightning/utilities/auto_restart.py
+++ b/src/pytorch_lightning/utilities/auto_restart.py
@@ -601,10 +601,11 @@ def _rotate_worker_indices(state: Dict[int, Any], latest_worker_id: int, num_wor
     on."""
     if num_workers == 0:
         return state
+    # the state of the first worker is the same as the state of all workers.
+    if len(state) == 1:
+        state = {i: state[0] for i in range(num_workers)}
     if latest_worker_id > num_workers - 1:
         raise MisconfigurationException("The `latest_worker_id` should be within [0, num_workers - 1].")
-    if len(state) != num_workers:
-        raise MisconfigurationException("The `state` should contain `num_workers - 1` values.")
     next_worker_id = latest_worker_id + 1
     old_to_new_worker_id_map = [((next_worker_id + i) % num_workers, i) for i in range(num_workers)]
     return {new_id: state[old_id] for old_id, new_id in old_to_new_worker_id_map if old_id in state}

--- a/src/pytorch_lightning/utilities/auto_restart.py
+++ b/src/pytorch_lightning/utilities/auto_restart.py
@@ -197,7 +197,10 @@ class MergedIteratorState:
         if self.represent_map_dataset:
             return {k: self.state[k].sampler_state[0] for k in self.state.keys()}
         else:
-            return {sampler_name: {k: value.sampler_state[k] for k, value in self.state[sampler_name].items()} for sampler_name in self.state.keys()}
+            return {
+                sampler_name: {k: value.sampler_state[k] for k, value in self.state[sampler_name].items()}
+                for sampler_name in self.state.keys()
+            }
 
     @property
     def dataset_states(self) -> Dict[int, Any]:
@@ -205,7 +208,10 @@ class MergedIteratorState:
         if self.represent_map_dataset:
             return {k: self.state[k].dataset_state[k] for k in self.state.keys()}
         else:
-            return {sampler_name: {k: value.dataset_state[k] for k, value in self.state[sampler_name].items()} for sampler_name in self.state.keys()}
+            return {
+                sampler_name: {k: value.dataset_state[k] for k, value in self.state[sampler_name].items()}
+                for sampler_name in self.state.keys()
+            }
 
     @classmethod
     def from_state_dict(cls, state_dict) -> "MergedIteratorState":
@@ -517,7 +523,9 @@ def _add_capture_metadata_collate(dataloader: DataLoader) -> None:
     )
 
 
-def _reload_dataloader_state_dict_automatic_map_dataset(dataloader: DataLoader, state_dict: MergedIteratorState) -> None:
+def _reload_dataloader_state_dict_automatic_map_dataset(
+    dataloader: DataLoader, state_dict: MergedIteratorState
+) -> None:
     # reload sampler state
     ff_sampler = _find_fast_forward_samplers(dataloader)
     ff_sampler.load_state_dict(state_dict.sampler_states)
@@ -533,9 +541,7 @@ def _reload_dataloader_state_dict_automatic_map_dataset(dataloader: DataLoader, 
 def _reload_dataloader_state_dict_automatic_iterable_dataset(
     dataset: CaptureIterableDataset, state_dict: MergedIteratorState
 ) -> None:
-    dataset.load_state_dict(
-        {sampler_name: state[0] for sampler_name, state in state_dict.sampler_states[0]}
-    )
+    dataset.load_state_dict({sampler_name: state[0] for sampler_name, state in state_dict.sampler_states[0]})
 
 
 def _reload_dataloader_state_dict_automatic(dataloader: DataLoader, state_dict: MergedIteratorState) -> None:
@@ -571,10 +577,7 @@ def _reload_dataloader_state_dict_manual(dataloader: DataLoader, state_dict: Mer
     if not isinstance(dataloader.dataset, _Stateful):
         return
 
-    dataset_state = {
-        worker_id: state_dict.dataset_states[worker_id]
-        for worker_id in state_dict.dataset_states.keys()
-    }
+    dataset_state = {worker_id: state_dict.dataset_states[worker_id] for worker_id in state_dict.dataset_states.keys()}
 
     dataloader.dataset.load_state_dict(_rotate_worker_indices(dataset_state, latest_worker_id, num_workers))
 

--- a/tests/tests_pytorch/utilities/test_auto_restart.py
+++ b/tests/tests_pytorch/utilities/test_auto_restart.py
@@ -1278,8 +1278,7 @@ def test_collect_states_with_collection():
     assert generated == [{"a": {0: state}, "b": [{"a": {0: state}}]}]
 
 
-# FIXME(@tchaton): >0 num_workers failing
-@pytest.mark.parametrize("num_workers", [0, pytest.param(2, marks=[RunIf(slow=True), pytest.mark.xfail()])])
+@pytest.mark.parametrize("num_workers", [0, 2])
 @mock.patch.dict(os.environ, {"PL_FAULT_TOLERANT_TRAINING": "2"})
 def test_stateful_workers(num_workers):
     seed_everything(42)


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fixes #12285

This fix assumes that the state of all DataLoader workers is the same, which should be the case following my understanding, but please correct me if I'm wrong. If that assumption is wrong, the solution would probably rather take place in `_collect_states_on_rank_zero_over_collection`, where we currently gather states only on rank 0, but we would need to collect state for all ranks.

In my understanding, including in the distributed setting, each worker might look at a different shard of data, but each process shares the same memory space apart from the rank, which should be naturally be populated by Pytorch at instanciation time, unless `rank` is set manually by the user at the sampler level. I do not cover this specific case, but this should already unblock the linked issue.
The corresponding fix was tested on our own codebase with success.

The fix allowed to re-enable a currently disabled test in `test_auto_restart.py`.

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [X] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [X] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [X] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [X] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
