### PR TITLE
Revert "Update tensorboard requirement from <2.10.0,>=2.9.1 to >=2.9.…

### DIFF
--- a/.github/workflows/ci-pytorch-dockers.yml
+++ b/.github/workflows/ci-pytorch-dockers.yml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: ${{ ! (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) }}
 
 env:
-  PUSH_TO_HUB: ${{ github.event_name == 'schedule' }}
+  PUSH_TO_HUB: true
 
 jobs:
   build-pl:

--- a/requirements/pytorch/base.txt
+++ b/requirements/pytorch/base.txt
@@ -6,7 +6,7 @@ torch>=1.9.*, <1.13.0
 tqdm>=4.57.0, <4.65.0
 PyYAML>=5.4, <=6.0
 fsspec[http]>=2021.05.0, !=2021.06.0, <2022.6.0
-tensorboard>=2.9.1, <2.10.0
+tensorboard>=2.9.1, <2.10.0  # do not upgrade until https://github.com/tensorflow/tensorboard/issues/5708
 torchmetrics>=0.7.0, <0.9.3  # needed for using fixed compare_version
 packaging>=17.0, <=21.3
 typing-extensions>=4.0.0, <4.3.1

--- a/requirements/pytorch/base.txt
+++ b/requirements/pytorch/base.txt
@@ -6,7 +6,7 @@ torch>=1.9.*, <1.13.0
 tqdm>=4.57.0, <4.65.0
 PyYAML>=5.4, <=6.0
 fsspec[http]>=2021.05.0, !=2021.06.0, <2022.6.0
-tensorboard>=2.9.1, <2.11.0
+tensorboard>=2.9.1, <2.10.0
 torchmetrics>=0.7.0, <0.9.3  # needed for using fixed compare_version
 packaging>=17.0, <=21.3
 typing-extensions>=4.0.0, <4.3.1


### PR DESCRIPTION
…1,<2.11.0 in /requirements (#14200)"

This reverts commit 401eb2c535f3b34b39313fbe58407fb8cbc56a24.

This shows another example of how `dependabot` update PRs cannot be trusted until we update the docker environments in the PR. The CI in the reverted PR did not use the new upgraded version. Doing so would have shown this error.

Happened already with DeepSpeed: https://github.com/Lightning-AI/lightning/pull/13048#issuecomment-1142399958

Meant to fix:

```py
Traceback (most recent call last):
  File "c:\hostedtoolcache\windows\python\3.7.9\x64\lib\site-packages\_pytest\config\__init__.py", line 1638, in parse_warning_filter
Warning: ory: Type[Warning] = _resolve_warning_category(category_)
  File "c:\hostedtoolcache\windows\python\3.7.9\x64\lib\site-packages\_pytest\config\__init__.py", line 1676, in _resolve_warning_category
    m = __import__(module, None, None, [klass])
  File "D:\a\lightning\lightning\src\pytorch_lightning\__init__.py", line 34, in <module>
    from pytorch_lightning.callbacks import Callback  # noqa: E402
  File "D:\a\lightning\lightning\src\pytorch_lightning\callbacks\__init__.py", line 26, in <module>
    from pytorch_lightning.callbacks.pruning import ModelPruning
  File "D:\a\lightning\lightning\src\pytorch_lightning\callbacks\pruning.py", line 30, in <module>
    from pytorch_lightning.core.module import LightningModule
  File "D:\a\lightning\lightning\src\pytorch_lightning\core\__init__.py", line 16, in <module>
    from pytorch_lightning.core.module import LightningModule
  File "D:\a\lightning\lightning\src\pytorch_lightning\core\module.py", line 40, in <module>
    from pytorch_lightning.loggers import Logger, LoggerCollection
  File "D:\a\lightning\lightning\src\pytorch_lightning\loggers\__init__.py", line 23, in <module>
    from pytorch_lightning.loggers.tensorboard import TensorBoardLogger
  File "D:\a\lightning\lightning\src\pytorch_lightning\loggers\tensorboard.py", line 26, in <module>
    from torch.utils.tensorboard import SummaryWriter
  File "c:\hostedtoolcache\windows\python\3.7.9\x64\lib\site-packages\torch\utils\tensorboard\__init__.py", line 12, in <module>
    from .writer import FileWriter, SummaryWriter  # noqa: F401
  File "c:\hostedtoolcache\windows\python\3.7.9\x64\lib\site-packages\torch\utils\tensorboard\writer.py", line 9, in <module>
    from tensorboard.compat.proto.event_pb2 import SessionLog
  File "c:\hostedtoolcache\windows\python\3.7.9\x64\lib\site-packages\tensorboard\compat\proto\event_pb2.py", line [17](https://github.com/Lightning-AI/lightning/runs/8164093298?check_suite_focus=true#step:20:18), in <module>
    from tensorboard.compat.proto import summary_pb2 as tensorboard_dot_compat_dot_proto_dot_summary__pb2
  File "c:\hostedtoolcache\windows\python\3.7.9\x64\lib\site-packages\tensorboard\compat\proto\summary_pb2.py", line 17, in <module>
    from tensorboard.compat.proto import tensor_pb2 as tensorboard_dot_compat_dot_proto_dot_tensor__pb2
  File "c:\hostedtoolcache\windows\python\3.7.9\x64\lib\site-packages\tensorboard\compat\proto\tensor_pb2.py", line 16, in <module>
    from tensorboard.compat.proto import resource_handle_pb2 as tensorboard_dot_compat_dot_proto_dot_resource__handle__pb2
  File "c:\hostedtoolcache\windows\python\3.7.9\x64\lib\site-packages\tensorboard\compat\proto\resource_handle_pb2.py", line 16, in <module>
    from tensorboard.compat.proto import tensor_shape_pb2 as tensorboard_dot_compat_dot_proto_dot_tensor__shape__pb2
  File "c:\hostedtoolcache\windows\python\3.7.9\x64\lib\site-packages\tensorboard\compat\proto\tensor_shape_pb2.py", line 42, in <module>
    serialized_options=None, file=DESCRIPTOR),
  File "c:\hostedtoolcache\windows\python\3.7.9\x64\lib\site-packages\google\protobuf\descriptor.py", line 560, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.[19](https://github.com/Lightning-AI/lightning/runs/8164093298?check_suite_focus=true#step:20:20).0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.[20](https://github.com/Lightning-AI/lightning/runs/8164093298?check_suite_focus=true#step:20:21).x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

More information: https://developers.google.com/protocol-buffers/docs/news/20[22](https://github.com/Lightning-AI/lightning/runs/8164093298?check_suite_focus=true#step:20:23)-05-06#python-updates
```

cc @carmocca @akihironitta @borda