### PR TITLE
Pin protobuf

### DIFF
--- a/requirements/pytorch/base.txt
+++ b/requirements/pytorch/base.txt
@@ -10,3 +10,4 @@ tensorboard>=2.9.1, <2.11.0
 torchmetrics>=0.7.0, <0.9.3  # needed for using fixed compare_version
 packaging>=17.0, <=21.3
 typing-extensions>=4.0.0, <4.3.1
+protobuf<=3.20.1 # strict  # prevents TensorBoard failure

--- a/requirements/pytorch/base.txt
+++ b/requirements/pytorch/base.txt
@@ -10,4 +10,3 @@ tensorboard>=2.9.1, <2.11.0
 torchmetrics>=0.7.0, <0.9.3  # needed for using fixed compare_version
 packaging>=17.0, <=21.3
 typing-extensions>=4.0.0, <4.3.1
-protobuf<=3.20.1 # strict  # prevents TensorBoard failure

--- a/requirements/pytorch/extra.txt
+++ b/requirements/pytorch/extra.txt
@@ -8,3 +8,4 @@ hydra-core>=1.0.5, <1.3.0
 jsonargparse[signatures]>=4.12.0, <=4.12.0
 gcsfs>=2021.5.0, <2022.8.0
 rich>=10.14.0, !=10.15.0.a, <13.0.0
+protobuf<=3.20.1 # strict  # an extra is updating protobuf, this pin prevents TensorBoard failure


### PR DESCRIPTION
## What does this PR do?

Alternative to https://github.com/Lightning-AI/lightning/pull/14510

I don't know which dependency is updating protobuf, but it doesn't seem to be tensorboard. This can be a quick fix until we know which one did it.

![image](https://user-images.githubusercontent.com/11067892/188267305-fbdce31b-9167-4ede-872b-b17684a69865.png)

The left dependencies are the ones that failed, and the right dependencies passed. It must be one of these but I don't know where they come from.

### Does your PR introduce any breaking changes? If yes, please list them.

None

cc @borda @carmocca @akihironitta