### PR TITLE
Fix(ci) ONC-114: reduce the ci load by only installing lmdb in tests

### DIFF
--- a/tests/tests_app_examples/custom_work_dependencies/app.py
+++ b/tests/tests_app_examples/custom_work_dependencies/app.py
@@ -10,17 +10,13 @@ class CustomBuildConfig(BuildConfig):
 
 class WorkWithCustomDeps(LightningWork):
     def __init__(self, cloud_compute: CloudCompute = CloudCompute(), **kwargs):
-        build_config = CustomBuildConfig(requirements=["numpy", "pandas", "py"])
+        build_config = CustomBuildConfig(requirements=["py"])
         super().__init__(parallel=True, **kwargs, cloud_compute=cloud_compute, cloud_build_config=build_config)
 
     def run(self):
         # installed by the build commands and by requirements in the build config
         import lmdb
-        import numpy as np
-        import pandas as pd
 
-        print("installed numpy version:", np.__version__)
-        print("installed pandas version:", pd.__version__)
         print("installed lmdb version:", lmdb.__version__)
 
 


### PR DESCRIPTION
## What does this PR do?

See [internal ticket](https://linear.app/lightning-ai/issue/ONC-114/make-lighting-custom-work-deledency-test-faster-to-execute) for details. This reduces the CI load by only installing a single smaller package in the tests. 

Fixes ONC-114

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- ~[ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)~
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- ~[ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)~

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Yes I had fun coding