### PR TITLE
Use the `pull_request_target` workflow event

### DIFF
--- a/.github/workflows/ci-app-examples.yml
+++ b/.github/workflows/ci-app-examples.yml
@@ -1,7 +1,7 @@
 name: Test App - examples
 
 # see: https://help.github.com/en/actions/reference/events-that-trigger-workflows
-on: # Trigger the workflow on push or pull request, but only for the master branch
+on:
   push:
     branches: [master, "release/*"]
   pull_request:

--- a/.github/workflows/ci-app-examples.yml
+++ b/.github/workflows/ci-app-examples.yml
@@ -6,6 +6,7 @@ on:
     branches: [master, "release/*"]
   pull_request:
     branches: [master, "release/*"]
+    types: [opened, reopened, ready_for_review, synchronize]  # add `ready_for_review` since draft is skipped
     paths:
       - ".github/workflows/ci-app-examples.yml"
       - "src/lightning_app/**"

--- a/.github/workflows/ci-app-tests.yml
+++ b/.github/workflows/ci-app-tests.yml
@@ -1,10 +1,11 @@
 name: Test App
 
 # see: https://help.github.com/en/actions/reference/events-that-trigger-workflows
-on: # Trigger the workflow on push or pull request, but only for the master branch
+on:
   push:
     branches: [master, "release/*"]
   pull_request:
+    branches: [master, "release/*"]
     paths:
       - ".github/workflows/ci-app-tests.yml"
       - "src/lightning_app/**"

--- a/.github/workflows/ci-circleci.yml
+++ b/.github/workflows/ci-circleci.yml
@@ -8,7 +8,7 @@ on:
       - "src/pytorch_lightning/**"
       - "tests/tests_pytorch/**"
       - "setup.cfg"  # includes pytest config
-  pull_request:
+  pull_request_target:
     branches: [master, "release/*"]
     paths:
       - ".github/workflows/ci-circleci.yml"

--- a/.github/workflows/ci-lite-test-full.yml
+++ b/.github/workflows/ci-lite-test-full.yml
@@ -6,6 +6,7 @@ on:
     branches: [master, "release/*"]
   pull_request:
     branches: [master, "release/*"]
+    types: [opened, reopened, ready_for_review, synchronize]  # add `ready_for_review` since draft is skipped
     paths:
       - "requirements/lite/**"
       - "src/lightning_lite/**"

--- a/.github/workflows/ci-lite-test-full.yml
+++ b/.github/workflows/ci-lite-test-full.yml
@@ -1,12 +1,11 @@
 name: Test Lite full
 
 # see: https://help.github.com/en/actions/reference/events-that-trigger-workflows
-on:  # Trigger the workflow on push or pull request, but only for the master branch
+on:
   push:
     branches: [master, "release/*"]
   pull_request:
     branches: [master, "release/*"]
-    types: [opened, reopened, ready_for_review, synchronize]
     paths:
       - "requirements/lite/**"
       - "src/lightning_lite/**"

--- a/.github/workflows/ci-pkg-install.yml
+++ b/.github/workflows/ci-pkg-install.yml
@@ -1,7 +1,7 @@
 name: Package
 
 # see: https://help.github.com/en/actions/reference/events-that-trigger-workflows
-on:  # Trigger the workflow on push or pull request, but only for the master branch
+on:
   push:
     branches: [master, "release/*"]
   pull_request:

--- a/.github/workflows/ci-pytorch-test-conda.yml
+++ b/.github/workflows/ci-pytorch-test-conda.yml
@@ -1,7 +1,7 @@
 name: Test PyTorch with Conda
 
 # see: https://help.github.com/en/actions/reference/events-that-trigger-workflows
-on:  # Trigger the workflow on push or pull request, but only for the master branch
+on:
   push:
     branches: [master, "release/*"]
   pull_request:

--- a/.github/workflows/ci-pytorch-test-full.yml
+++ b/.github/workflows/ci-pytorch-test-full.yml
@@ -6,6 +6,7 @@ on:
     branches: [master, "release/*"]
   pull_request:
     branches: [master, "release/*"]
+    types: [opened, reopened, ready_for_review, synchronize]  # add `ready_for_review` since draft is skipped
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref }}

--- a/.github/workflows/ci-pytorch-test-full.yml
+++ b/.github/workflows/ci-pytorch-test-full.yml
@@ -1,12 +1,11 @@
 name: Test PyTorch full
 
 # see: https://help.github.com/en/actions/reference/events-that-trigger-workflows
-on:  # Trigger the workflow on push or pull request, but only for the master branch
+on:
   push:
     branches: [master, "release/*"]
   pull_request:
     branches: [master, "release/*"]
-    types: [opened, reopened, ready_for_review, synchronize]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref }}

--- a/.github/workflows/ci-pytorch-test-slow.yml
+++ b/.github/workflows/ci-pytorch-test-slow.yml
@@ -6,6 +6,7 @@ on:
     branches: [master, "release/*"]
   pull_request:
     branches: [master, "release/*"]
+    types: [opened, reopened, ready_for_review, synchronize]  # add `ready_for_review` since draft is skipped
     paths:
       - "requirements/pytorch/**"
       - "src/pytorch_lightning/**"

--- a/.github/workflows/ci-pytorch-test-slow.yml
+++ b/.github/workflows/ci-pytorch-test-slow.yml
@@ -1,12 +1,11 @@
 name: Test PyTorch slow
 
 # see: https://help.github.com/en/actions/reference/events-that-trigger-workflows
-on:  # Trigger the workflow on push or pull request, but only for the master branch
+on:
   push:
     branches: [master, "release/*"]
   pull_request:
     branches: [master, "release/*"]
-    types: [opened, reopened, ready_for_review, synchronize]
     paths:
       - "requirements/pytorch/**"
       - "src/pytorch_lightning/**"

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -1,6 +1,6 @@
 name: Code check
 
-on:  # Trigger the workflow on push or pull request, but only for the master branch
+on:
   push:
     branches: [master, "release/*"]
   pull_request:

--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -1,7 +1,7 @@
 name: Check Docs
 # https://github.com/marketplace/actions/sphinx-build
 
-on:  # Trigger the workflow on push or pull request, but only for the master branch
+on:
   push:
     branches: [master, "release/*"]
   pull_request:

--- a/.github/workflows/probot-auto-cc.yml
+++ b/.github/workflows/probot-auto-cc.yml
@@ -3,7 +3,7 @@ name: Probot
 on:
   issues:
     types: [labeled]
-  pull_request:
+  pull_request_target:
     types: [labeled, ready_for_review]
 
 jobs:

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -1,7 +1,7 @@
 name: PyPI
 
 # https://help.github.com/en/actions/reference/events-that-trigger-workflows
-on:  # Trigger the workflow on push or pull request, but only for the master branch
+on:
   push:
     branches: [master, "release/*"]
   release:


### PR DESCRIPTION
## What does this PR do?

Docs: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
This is so that forks can access the secrets.

I think this needs to be merged to work. This would explain why probot-cc and circleci did not run