### PR TITLE
Better error message when dataloader or datamodule is None

### DIFF
--- a/examples/pl_bug_report/bug_report_model.py
+++ b/examples/pl_bug_report/bug_report_model.py
@@ -1,21 +1,5 @@
-import os
-
 import torch
-from torch.utils.data import DataLoader, Dataset
-
 from pytorch_lightning import LightningModule, Trainer
-
-
-class RandomDataset(Dataset):
-    def __init__(self, size, length):
-        self.len = length
-        self.data = torch.randn(length, size)
-
-    def __getitem__(self, index):
-        return self.data[index]
-
-    def __len__(self):
-        return self.len
 
 
 class BoringModel(LightningModule):
@@ -31,35 +15,15 @@ class BoringModel(LightningModule):
         self.log("train_loss", loss)
         return {"loss": loss}
 
-    def validation_step(self, batch, batch_idx):
-        loss = self(batch).sum()
-        self.log("valid_loss", loss)
-
-    def test_step(self, batch, batch_idx):
-        loss = self(batch).sum()
-        self.log("test_loss", loss)
-
     def configure_optimizers(self):
         return torch.optim.SGD(self.layer.parameters(), lr=0.1)
 
 
 def run():
-    train_data = DataLoader(RandomDataset(32, 64), batch_size=2)
-    val_data = DataLoader(RandomDataset(32, 64), batch_size=2)
-    test_data = DataLoader(RandomDataset(32, 64), batch_size=2)
-
     model = BoringModel()
-    trainer = Trainer(
-        default_root_dir=os.getcwd(),
-        limit_train_batches=1,
-        limit_val_batches=1,
-        limit_test_batches=1,
-        num_sanity_val_steps=0,
-        max_epochs=1,
-        enable_model_summary=False,
-    )
-    trainer.fit(model, train_dataloaders=train_data, val_dataloaders=val_data)
-    trainer.test(model, dataloaders=test_data)
+    trainer = Trainer()
+    trainer.fit(model, train_dataloaders=None)
+    # trainer.fit(model, datamodule=None)
 
 
 if __name__ == "__main__":

--- a/examples/pl_bug_report/bug_report_model.py
+++ b/examples/pl_bug_report/bug_report_model.py
@@ -1,9 +1,11 @@
 import torch
-from pytorch_lightning import LightningModule, Trainer, LightningDataModule
+
+from pytorch_lightning import LightningDataModule, LightningModule, Trainer
 
 
 class BoringData(LightningDataModule):
     pass
+
 
 class BoringModel(LightningModule):
     def __init__(self):

--- a/examples/pl_bug_report/bug_report_model.py
+++ b/examples/pl_bug_report/bug_report_model.py
@@ -1,10 +1,21 @@
+import os
+
 import torch
+from torch.utils.data import DataLoader, Dataset
 
-from pytorch_lightning import LightningDataModule, LightningModule, Trainer
+from pytorch_lightning import LightningModule, Trainer
 
 
-class BoringData(LightningDataModule):
-    pass
+class RandomDataset(Dataset):
+    def __init__(self, size, length):
+        self.len = length
+        self.data = torch.randn(length, size)
+
+    def __getitem__(self, index):
+        return self.data[index]
+
+    def __len__(self):
+        return self.len
 
 
 class BoringModel(LightningModule):
@@ -20,16 +31,35 @@ class BoringModel(LightningModule):
         self.log("train_loss", loss)
         return {"loss": loss}
 
+    def validation_step(self, batch, batch_idx):
+        loss = self(batch).sum()
+        self.log("valid_loss", loss)
+
+    def test_step(self, batch, batch_idx):
+        loss = self(batch).sum()
+        self.log("test_loss", loss)
+
     def configure_optimizers(self):
         return torch.optim.SGD(self.layer.parameters(), lr=0.1)
 
 
 def run():
+    train_data = DataLoader(RandomDataset(32, 64), batch_size=2)
+    val_data = DataLoader(RandomDataset(32, 64), batch_size=2)
+    test_data = DataLoader(RandomDataset(32, 64), batch_size=2)
+
     model = BoringModel()
-    trainer = Trainer()
-    trainer.fit(model, BoringData())
-    # trainer.fit(model, train_dataloaders=None)
-    # trainer.fit(model, datamodule=None)
+    trainer = Trainer(
+        default_root_dir=os.getcwd(),
+        limit_train_batches=1,
+        limit_val_batches=1,
+        limit_test_batches=1,
+        num_sanity_val_steps=0,
+        max_epochs=1,
+        enable_model_summary=False,
+    )
+    trainer.fit(model, train_dataloaders=train_data, val_dataloaders=val_data)
+    trainer.test(model, dataloaders=test_data)
 
 
 if __name__ == "__main__":

--- a/examples/pl_bug_report/bug_report_model.py
+++ b/examples/pl_bug_report/bug_report_model.py
@@ -1,6 +1,9 @@
 import torch
-from pytorch_lightning import LightningModule, Trainer
+from pytorch_lightning import LightningModule, Trainer, LightningDataModule
 
+
+class BoringData(LightningDataModule):
+    pass
 
 class BoringModel(LightningModule):
     def __init__(self):
@@ -22,7 +25,8 @@ class BoringModel(LightningModule):
 def run():
     model = BoringModel()
     trainer = Trainer()
-    trainer.fit(model, train_dataloaders=None)
+    trainer.fit(model, BoringData())
+    # trainer.fit(model, train_dataloaders=None)
     # trainer.fit(model, datamodule=None)
 
 

--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -61,6 +61,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - When using multiple loggers, by default checkpoints and profiler output now get saved to the log dir of the first logger in the list ([14325](https://github.com/Lightning-AI/lightning/pull/14325))
 
 
+- Explicitly passing `train_dataloaders=None`, `val_dataloaders=None`, `dataloaders=None` or `datamodule=None` is officially no longer supported and will inform using a better error message than before ([14614](https://github.com/Lightning-AI/lightning/pull/14614))
+
+
 
 ### Deprecated
 

--- a/src/pytorch_lightning/trainer/configuration_validator.py
+++ b/src/pytorch_lightning/trainer/configuration_validator.py
@@ -308,3 +308,13 @@ def _check_datamodule_checkpoint_hooks(trainer: "pl.Trainer") -> None:
             "`LightningDataModule.on_load_checkpoint` was deprecated in"
             " v1.6 and will be removed in v1.8. Use `load_state_dict` instead."
         )
+
+
+def _check_dataloader_none(dataloader, dataloader_name: str, trainer_fn: str) -> None:
+    if dataloader is None:
+        # TODO: make it a deprecation warning
+        rank_zero_warn(
+            f"You explicitly passed `Trainer.{trainer_fn}]({dataloader_name}=None, ...)`, is this intentional?"
+            f" We recommend that you either pass in valid dataloader(s) or define def {dataloader_name} in your"
+            f" LightningModule/LightningDataModule."
+        )

--- a/src/pytorch_lightning/trainer/configuration_validator.py
+++ b/src/pytorch_lightning/trainer/configuration_validator.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any
+from typing import Any, Optional
 
 import pytorch_lightning as pl
 from lightning_lite.utilities.warnings import PossibleUserWarning
@@ -324,7 +324,7 @@ def _check_dataloader_none(stage: str, **dataloader_args: Any) -> None:
             )
 
 
-def _check_datamodule_none(stage: str, datamodule) -> None:
+def _check_datamodule_none(stage: str, datamodule: Optional["pl.LightningDataModule"]) -> None:
     if datamodule is None:
         raise ValueError(
             f"You explicitly passed `Trainer.{stage}(datamodule=None, ...)`, but this is not supported."

--- a/src/pytorch_lightning/trainer/trainer.py
+++ b/src/pytorch_lightning/trainer/trainer.py
@@ -77,8 +77,11 @@ from pytorch_lightning.profilers import (
     XLAProfiler,
 )
 from pytorch_lightning.strategies import ParallelStrategy, Strategy
-from pytorch_lightning.trainer.configuration_validator import verify_loop_configurations, _check_dataloader_none, \
-    _check_datamodule_none
+from pytorch_lightning.trainer.configuration_validator import (
+    _check_dataloader_none,
+    _check_datamodule_none,
+    verify_loop_configurations,
+)
 from pytorch_lightning.trainer.connectors.accelerator_connector import _LITERAL_WARN, AcceleratorConnector
 from pytorch_lightning.trainer.connectors.callback_connector import CallbackConnector
 from pytorch_lightning.trainer.connectors.checkpoint_connector import CheckpointConnector
@@ -729,7 +732,6 @@ class Trainer(
         )
         train_dataloaders = None if train_dataloaders is _NO_DATALOADER else train_dataloaders
         val_dataloaders = None if val_dataloaders is _NO_DATALOADER else val_dataloaders
-
         _check_datamodule_none(stage=self.state.fn, datamodule=datamodule)
         datamodule = None if datamodule is _NO_DATAMODULE else datamodule
 
@@ -796,10 +798,10 @@ class Trainer(
     def _validate_impl(
         self,
         model: Optional["pl.LightningModule"] = None,
-        dataloaders: Optional[Union[EVAL_DATALOADERS, LightningDataModule]] = None,
+        dataloaders: Union[EVAL_DATALOADERS, LightningDataModule] = _NO_DATALOADER,
         ckpt_path: Optional[str] = None,
         verbose: bool = True,
-        datamodule: Optional[LightningDataModule] = None,
+        datamodule: LightningDataModule = _NO_DATAMODULE,
     ) -> _EVALUATE_OUTPUT:
         # --------------------
         # SETUP HOOK
@@ -814,7 +816,13 @@ class Trainer(
         # if a datamodule comes in as the second arg, then fix it for the user
         if isinstance(dataloaders, LightningDataModule):
             datamodule = dataloaders
-            dataloaders = None
+            dataloaders = _NO_DATALOADER
+
+        _check_dataloader_none(stage=self.state.fn, dataloaders=dataloaders)
+        dataloaders = None if dataloaders is _NO_DATALOADER else dataloaders
+        _check_datamodule_none(stage=self.state.fn, datamodule=datamodule)
+        datamodule = None if datamodule is _NO_DATAMODULE else datamodule
+
         # If you supply a datamodule you can't supply val_dataloaders
         if dataloaders is not None and datamodule:
             raise MisconfigurationException("You cannot pass both `trainer.validate(dataloaders=..., datamodule=...)`")
@@ -886,10 +894,10 @@ class Trainer(
     def _test_impl(
         self,
         model: Optional["pl.LightningModule"] = None,
-        dataloaders: Optional[Union[EVAL_DATALOADERS, LightningDataModule]] = None,
+        dataloaders: Union[EVAL_DATALOADERS, LightningDataModule] = _NO_DATALOADER,
         ckpt_path: Optional[str] = None,
         verbose: bool = True,
-        datamodule: Optional[LightningDataModule] = None,
+        datamodule: LightningDataModule = _NO_DATAMODULE,
     ) -> _EVALUATE_OUTPUT:
         # --------------------
         # SETUP HOOK
@@ -904,7 +912,13 @@ class Trainer(
         # if a datamodule comes in as the second arg, then fix it for the user
         if isinstance(dataloaders, LightningDataModule):
             datamodule = dataloaders
-            dataloaders = None
+            dataloaders = _NO_DATALOADER
+
+        _check_dataloader_none(stage=self.state.fn, dataloaders=dataloaders)
+        dataloaders = None if dataloaders is _NO_DATALOADER else dataloaders
+        _check_datamodule_none(stage=self.state.fn, datamodule=datamodule)
+        datamodule = None if datamodule is _NO_DATAMODULE else datamodule
+
         # If you supply a datamodule you can't supply test_dataloaders
         if dataloaders is not None and datamodule:
             raise MisconfigurationException("You cannot pass both `trainer.test(dataloaders=..., datamodule=...)`")
@@ -977,8 +991,8 @@ class Trainer(
     def _predict_impl(
         self,
         model: Optional["pl.LightningModule"] = None,
-        dataloaders: Optional[Union[EVAL_DATALOADERS, LightningDataModule]] = None,
-        datamodule: Optional[LightningDataModule] = None,
+        dataloaders: Union[EVAL_DATALOADERS, LightningDataModule] = _NO_DATALOADER,
+        datamodule: LightningDataModule = _NO_DATAMODULE,
         return_predictions: Optional[bool] = None,
         ckpt_path: Optional[str] = None,
     ) -> Optional[_PREDICT_OUTPUT]:
@@ -998,6 +1012,12 @@ class Trainer(
         if isinstance(dataloaders, LightningDataModule):
             datamodule = dataloaders
             dataloaders = None
+
+        _check_dataloader_none(stage=self.state.fn, dataloaders=dataloaders)
+        dataloaders = None if dataloaders is _NO_DATALOADER else dataloaders
+        _check_datamodule_none(stage=self.state.fn, datamodule=datamodule)
+        datamodule = None if datamodule is _NO_DATAMODULE else datamodule
+
         if dataloaders is not None and datamodule:
             raise MisconfigurationException("You cannot pass both `trainer.predict(dataloaders=..., datamodule=...)`")
 

--- a/src/pytorch_lightning/trainer/trainer.py
+++ b/src/pytorch_lightning/trainer/trainer.py
@@ -118,10 +118,10 @@ from pytorch_lightning.utilities.rank_zero import rank_zero_deprecation, rank_ze
 from pytorch_lightning.utilities.seed import isolate_rng
 from pytorch_lightning.utilities.types import (
     _EVALUATE_OUTPUT,
+    _NO_DATA,
     _PREDICT_OUTPUT,
     EVAL_DATALOADERS,
     LRSchedulerConfig,
-    Sentinel,
     TRAIN_DATALOADERS,
 )
 
@@ -130,10 +130,6 @@ log = logging.getLogger(__name__)
 warnings.filterwarnings(
     "ignore", message="torch.distributed.reduce_op is deprecated, please use torch.distributed.ReduceOp instead"
 )
-
-
-class _NO_DATA(Sentinel):
-    """A sentinel representing the default value for 'no dataloader passed to Trainer method'."""
 
 
 class Trainer(
@@ -1013,7 +1009,7 @@ class Trainer(
         # if a datamodule comes in as the second arg, then fix it for the user
         if isinstance(dataloaders, LightningDataModule):
             datamodule = dataloaders
-            dataloaders = None
+            dataloaders = _NO_DATA
 
         _check_dataloader_none(stage=self.state.fn, dataloaders=dataloaders)
         dataloaders = None if dataloaders is _NO_DATA else dataloaders

--- a/src/pytorch_lightning/tuner/tuning.py
+++ b/src/pytorch_lightning/tuner/tuning.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Type, Union
 
 from typing_extensions import NotRequired, TypedDict
 
@@ -20,7 +20,7 @@ from pytorch_lightning.trainer.states import TrainerStatus
 from pytorch_lightning.tuner.batch_size_scaling import scale_batch_size
 from pytorch_lightning.tuner.lr_finder import _LRFinder, lr_find
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
-from pytorch_lightning.utilities.types import EVAL_DATALOADERS, TRAIN_DATALOADERS
+from pytorch_lightning.utilities.types import _NO_DATA, EVAL_DATALOADERS, TRAIN_DATALOADERS
 
 
 class _TunerResult(TypedDict):
@@ -83,9 +83,9 @@ class Tuner:
     def scale_batch_size(
         self,
         model: "pl.LightningModule",
-        train_dataloaders: Optional[Union[TRAIN_DATALOADERS, "pl.LightningDataModule"]] = None,
-        val_dataloaders: Optional[EVAL_DATALOADERS] = None,
-        datamodule: Optional["pl.LightningDataModule"] = None,
+        train_dataloaders: Union[TRAIN_DATALOADERS, "pl.LightningDataModule", Type[_NO_DATA]] = _NO_DATA,
+        val_dataloaders: Union[EVAL_DATALOADERS, Type[_NO_DATA]] = _NO_DATA,
+        datamodule: Union["pl.LightningDataModule", Type[_NO_DATA]] = _NO_DATA,
         mode: str = "power",
         steps_per_trial: int = 3,
         init_val: int = 2,
@@ -149,9 +149,9 @@ class Tuner:
     def lr_find(
         self,
         model: "pl.LightningModule",
-        train_dataloaders: Optional[Union[TRAIN_DATALOADERS, "pl.LightningDataModule"]] = None,
-        val_dataloaders: Optional[EVAL_DATALOADERS] = None,
-        datamodule: Optional["pl.LightningDataModule"] = None,
+        train_dataloaders: Union[TRAIN_DATALOADERS, "pl.LightningDataModule", Type[_NO_DATA]] = _NO_DATA,
+        val_dataloaders: Union[EVAL_DATALOADERS, Type[_NO_DATA]] = _NO_DATA,
+        datamodule: Union["pl.LightningDataModule", Type[_NO_DATA]] = _NO_DATA,
         min_lr: float = 1e-8,
         max_lr: float = 1,
         num_training: int = 100,

--- a/src/pytorch_lightning/utilities/types.py
+++ b/src/pytorch_lightning/utilities/types.py
@@ -20,13 +20,12 @@ from argparse import _ArgumentGroup, ArgumentParser
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, Dict, Generator, List, Mapping, Optional, Sequence, Type, Union
-from typing_extensions import Literal
 
 import torch
 from torch import Tensor
 from torch.utils.data import DataLoader
 from torchmetrics import Metric
-from typing_extensions import Protocol, runtime_checkable
+from typing_extensions import Literal, Protocol, runtime_checkable
 
 from lightning_lite.utilities.types import _LRScheduler, ReduceLROnPlateau
 

--- a/src/pytorch_lightning/utilities/types.py
+++ b/src/pytorch_lightning/utilities/types.py
@@ -157,3 +157,7 @@ class _SentinelMeta(type):
 
 class Sentinel(metaclass=_SentinelMeta):
     """Subclass this to create a new sentinel."""
+
+
+class _NO_DATA(Sentinel):
+    """A sentinel representing the default value for 'no dataloader passed to Trainer method'."""

--- a/src/pytorch_lightning/utilities/types.py
+++ b/src/pytorch_lightning/utilities/types.py
@@ -19,7 +19,8 @@ Convention:
 from argparse import _ArgumentGroup, ArgumentParser
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Dict, Generator, List, Literal, Mapping, Optional, Sequence, Type, Union
+from typing import Any, Dict, Generator, List, Mapping, Optional, Sequence, Type, Union
+from typing_extensions import Literal
 
 import torch
 from torch import Tensor

--- a/src/pytorch_lightning/utilities/types.py
+++ b/src/pytorch_lightning/utilities/types.py
@@ -19,7 +19,7 @@ Convention:
 from argparse import _ArgumentGroup, ArgumentParser
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Dict, Generator, List, Mapping, Optional, Sequence, Type, Union
+from typing import Any, Dict, Generator, List, Literal, Mapping, Optional, Sequence, Type, Union
 
 import torch
 from torch import Tensor
@@ -139,3 +139,21 @@ class LRSchedulerConfig:
     strict: bool = True
     # opt_idx assigned internally if not assigned by user
     opt_idx: Optional[int] = None
+
+
+class _SentinelMeta(type):
+    """Metaclass representing a sentinel value by the name of the class.
+
+    Reference: https://stackoverflow.com/a/69243488/1162383
+    See also: https://peps.python.org/pep-0661/
+    """
+
+    def __repr__(cls) -> str:
+        return f"<{cls.__name__}>"
+
+    def __bool__(cls) -> Literal[False]:
+        return False
+
+
+class Sentinel(metaclass=_SentinelMeta):
+    """Subclass this to create a new sentinel."""

--- a/tests/tests_pytorch/helpers/pipelines.py
+++ b/tests/tests_pytorch/helpers/pipelines.py
@@ -26,7 +26,10 @@ def run_model_test_without_loggers(
 
     # fit model
     trainer = Trainer(**trainer_options)
-    trainer.fit(model, datamodule=data)
+    if data is not None:
+        trainer.fit(model, datamodule=data)
+    else:
+        trainer.fit(model)
 
     # correct result and ok accuracy
     assert trainer.state.finished, f"Training failed with {trainer.state}"
@@ -59,7 +62,10 @@ def run_model_test(
     trainer_options.update(logger=logger)
     trainer = Trainer(**trainer_options)
     initial_values = torch.tensor([torch.sum(torch.abs(x)) for x in model.parameters()])
-    trainer.fit(model, datamodule=data)
+    if data is not None:
+        trainer.fit(model, datamodule=data)
+    else:
+        trainer.fit(model)
     post_train_values = torch.tensor([torch.sum(torch.abs(x)) for x in model.parameters()])
 
     assert trainer.state.finished, f"Training failed with {trainer.state}"

--- a/tests/tests_pytorch/helpers/test_models.py
+++ b/tests/tests_pytorch/helpers/test_models.py
@@ -39,7 +39,10 @@ def test_models(tmpdir, data_class, model_class):
     model = model_class()
     trainer = Trainer(default_root_dir=tmpdir, max_epochs=1)
 
-    trainer.fit(model, datamodule=dm)
+    if dm is not None:
+        trainer.fit(model, datamodule=dm)
+    else:
+        trainer.fit(model)
 
     if dm is not None:
         trainer.test(model, datamodule=dm)

--- a/tests/tests_pytorch/models/test_hparams.py
+++ b/tests/tests_pytorch/models/test_hparams.py
@@ -100,7 +100,10 @@ def _run_standard_hparams_test(tmpdir, model, cls, datamodule=None, try_overwrit
 
     # verify we can train
     trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, overfit_batches=2)
-    trainer.fit(model, datamodule=datamodule if issubclass(cls, LightningDataModule) else None)
+    if issubclass(cls, LightningDataModule):
+        trainer.fit(model, datamodule=datamodule)
+    else:
+        trainer.fit(model)
 
     # make sure the raw checkpoint saved the properties
     raw_checkpoint_path = _raw_checkpoint_path(trainer)

--- a/tests/tests_pytorch/trainer/test_config_validator.py
+++ b/tests/tests_pytorch/trainer/test_config_validator.py
@@ -185,3 +185,34 @@ def test_raise_exception_with_batch_transfer_hooks(monkeypatch, hook, trainer_kw
 
     with pytest.raises(MisconfigurationException, match=match_pattern):
         trainer.fit(model)
+
+
+@pytest.mark.parametrize(
+    "trainer_fn, dataloader_name",
+    [
+        ("fit", "train_dataloaders"),
+        ("fit", "val_dataloaders"),
+        ("validate", "dataloaders"),
+        ("test", "dataloaders"),
+        ("predict", "dataloaders"),
+    ],
+)
+def test_raise_exception_with_explicit_none_dataloader(trainer_fn, dataloader_name, tmpdir):
+    """Test that explicitly passing `Trainer.method(x_dataloader=None)` raises an error."""
+    trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=True)
+    model = BoringModel()
+
+    with pytest.raises(ValueError, match="You explicitly passed .*dataloaders=None.* but this is not supported"):
+        trainer_fn = getattr(trainer, trainer_fn)
+        trainer_fn(model, **{dataloader_name: None})
+
+
+@pytest.mark.parametrize("trainer_fn", ["fit", "validate", "test", "predict"])
+def test_raise_exception_with_explicit_none_datamodule(trainer_fn, tmpdir):
+    """Test that explicitly passing `Trainer.method(datamodule=None)` raises an error."""
+    trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=True)
+    model = BoringModel()
+
+    with pytest.raises(ValueError, match="You explicitly passed .*datamodule=None.* but this is not supported"):
+        trainer_fn = getattr(trainer, trainer_fn)
+        trainer_fn(model, datamodule=None)

--- a/tests/tests_pytorch/tuner/test_scale_batch_size.py
+++ b/tests/tests_pytorch/tuner/test_scale_batch_size.py
@@ -61,7 +61,11 @@ def test_scale_batch_size_method_with_model_or_datamodule(tmpdir, model_bs, dm_b
     model = BatchSizeModel(model_bs)
     datamodule = BatchSizeDataModule(tmpdir, dm_bs) if dm_bs != -1 else None
 
-    new_batch_size = tuner.scale_batch_size(model, mode="binsearch", init_val=4, max_trials=2, datamodule=datamodule)
+    kwargs = dict(mode="binsearch", init_val=4, max_trials=2)
+    if datamodule is not None:
+        kwargs["datamodule"] = datamodule
+
+    new_batch_size = tuner.scale_batch_size(model, **kwargs)
     assert new_batch_size == 16
 
     if model_bs is not None:


### PR DESCRIPTION
## What does this PR do?

Fixes #14601
Fixes #14602


### Does your PR introduce any breaking changes? If yes, please list them.

Yes, when the user set None explicitly before but had dataloader methods implemented in the module. 
But I couldn't find another way to provide a meaningful error message. 


## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃
