### PR TITLE
Integrate lightning_utilities `is_overridden`

### DIFF
--- a/src/lightning_app/utilities/app_helpers.py
+++ b/src/lightning_app/utilities/app_helpers.py
@@ -12,7 +12,6 @@ from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Generator, List, Mapping, Optional, Tuple, Type, TYPE_CHECKING
-from unittest.mock import Mock
 
 import websockets
 from deepdiff import Delta
@@ -231,12 +230,9 @@ class StreamLitStatePlugin(BaseStatePlugin):
         pass
 
 
-# Adapted from
-# https://github.com/Lightning-AI/pytorch-lightning/blob/master/pytorch_lightning/utilities/model_helpers.py#L21
 def is_overridden(method_name: str, instance: Optional[object] = None, parent: Optional[Type[object]] = None) -> bool:
     if instance is None:
         return False
-
     if parent is None:
         if isinstance(instance, lightning_app.LightningFlow):
             parent = lightning_app.LightningFlow
@@ -244,22 +240,9 @@ def is_overridden(method_name: str, instance: Optional[object] = None, parent: O
             parent = lightning_app.LightningWork
         if parent is None:
             raise ValueError("Expected a parent")
+    from lightning_utilities.core.overrides import is_overridden
 
-    instance_attr = getattr(instance, method_name, None)
-    if instance_attr is None:
-        return False
-    # `Mock(wraps=...)` support
-    if isinstance(instance_attr, Mock):
-        # access the wrapped function
-        instance_attr = instance_attr._mock_wraps
-    if instance_attr is None:
-        return False
-
-    parent_attr = getattr(parent, method_name, None)
-    if parent_attr is None:
-        raise ValueError("The parent should define the method")
-
-    return instance_attr.__code__ != parent_attr.__code__
+    return is_overridden(method_name, instance, parent)
 
 
 def _is_json_serializable(x: Any) -> bool:

--- a/src/pytorch_lightning/utilities/model_helpers.py
+++ b/src/pytorch_lightning/utilities/model_helpers.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from functools import partial
 from typing import Optional, Type
-from unittest.mock import Mock
 
 import pytorch_lightning as pl
 
@@ -22,7 +20,6 @@ def is_overridden(method_name: str, instance: Optional[object] = None, parent: O
     if instance is None:
         # if `self.lightning_module` was passed as instance, it can be `None`
         return False
-
     if parent is None:
         if isinstance(instance, pl.LightningModule):
             parent = pl.LightningModule
@@ -32,25 +29,6 @@ def is_overridden(method_name: str, instance: Optional[object] = None, parent: O
             parent = pl.Callback
         if parent is None:
             raise ValueError("Expected a parent")
+    from lightning_utilities.core.overrides import is_overridden
 
-    instance_attr = getattr(instance, method_name, None)
-    if instance_attr is None:
-        return False
-    # `functools.wraps()` support
-    if hasattr(instance_attr, "__wrapped__"):
-        instance_attr = instance_attr.__wrapped__
-    # `Mock(wraps=...)` support
-    if isinstance(instance_attr, Mock):
-        # access the wrapped function
-        instance_attr = instance_attr._mock_wraps
-    # `partial` support
-    elif isinstance(instance_attr, partial):
-        instance_attr = instance_attr.func
-    if instance_attr is None:
-        return False
-
-    parent_attr = getattr(parent, method_name, None)
-    if parent_attr is None:
-        raise ValueError("The parent should define the method")
-
-    return instance_attr.__code__ != parent_attr.__code__
+    return is_overridden(method_name, instance, parent)

--- a/tests/tests_app/utilities/test_app_helpers.py
+++ b/tests/tests_app/utilities/test_app_helpers.py
@@ -1,5 +1,4 @@
 from unittest import mock
-from unittest.mock import Mock
 
 import pytest
 
@@ -25,38 +24,17 @@ class Flow(LightningFlow):
 
 
 def test_is_overridden():
-    flow = Flow()
-    work = Work()
-
     # edge cases
     assert not is_overridden("whatever", None)
     with pytest.raises(ValueError, match="Expected a parent"):
         is_overridden("whatever", object())
+    flow = Flow()
     assert not is_overridden("whatever", flow)
     assert not is_overridden("whatever", flow, parent=Flow)
-
-    class TestFlow(LightningFlow):
-        def run(self):
-            pass
-
-        def foo(self):
-            pass
-
-        def bar(self):
-            return 1
-
-    with pytest.raises(ValueError, match="The parent should define the method"):
-        is_overridden("foo", TestFlow())
-
     # normal usage
     assert is_overridden("run", flow)
+    work = Work()
     assert is_overridden("run", work)
-
-    # `Mock` support
-    mock = Mock(spec=Flow, wraps=flow)
-    assert is_overridden("run", mock)
-    mock = Mock(spec=LightningWork, wraps=work)
-    assert is_overridden("run", mock)
 
 
 def test_simple_app_store():


### PR DESCRIPTION
## What does this PR do?

Follo-up to https://github.com/Lightning-AI/utilities/pull/35

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified