### PR TITLE
Set `running_torchscript` recursively

### DIFF
--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -159,6 +159,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed an issue to keep downscaling the batch size in case there hasn't been even a single successful optimal batch size with `mode="power"` ([#14372](https://github.com/Lightning-AI/lightning/pull/14372))
 
 
+- Fixed compatibility when `torch.distributed` is not available ([#14454](https://github.com/Lightning-AI/lightning/pull/14454))
+
+
+- Fixed torchscript error with ensembles of LightningModules ([#14657](https://github.com/Lightning-AI/lightning/pull/14657))
+
+
 ## [1.7.5] - 2022-09-06
 
 ### Fixed
@@ -180,9 +186,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Reset epoch progress with batch size scaler ([#13846](https://github.com/Lightning-AI/lightning/pull/13846))
 - Fixed restoring the trainer after using `lr_find()` so that the correct LR schedule is used for the actual training ([#14113](https://github.com/Lightning-AI/lightning/pull/14113))
 - Fixed incorrect values after transferring data to an MPS device ([#14368](https://github.com/Lightning-AI/lightning/pull/14368))
-
-
-- Fixed compatibility when `torch.distributed` is not available ([#14454](https://github.com/Lightning-AI/lightning/pull/14454))
 
 
 ## [1.7.3] - 2022-08-25

--- a/tests/tests_pytorch/models/test_torchscript.py
+++ b/tests/tests_pytorch/models/test_torchscript.py
@@ -18,8 +18,10 @@ import fsspec
 import pytest
 import torch
 from fsspec.implementations.local import LocalFileSystem
+from torch.jit import RecursiveScriptModule
 
 from lightning_lite.utilities.cloud_io import get_filesystem
+from pytorch_lightning.core.module import LightningModule
 from pytorch_lightning.demos.boring_classes import BoringModel
 from tests_pytorch.helpers.advanced_models import BasicGAN, ParityModuleRNN
 from tests_pytorch.helpers.runif import RunIf
@@ -170,3 +172,25 @@ def test_torchscript_with_no_input(tmpdir):
 
     with pytest.raises(ValueError, match="requires either `example_inputs` or `model.example_input_array`"):
         model.to_torchscript(method="trace")
+
+
+def test_torchscript_script_recursively():
+    class Child(LightningModule):
+        def __init__(self):
+            super().__init__()
+            self.model = torch.nn.Linear(1, 1)
+
+        def forward(self, inputs):
+            return self.model(inputs)
+
+    class Parent(LightningModule):
+        def __init__(self):
+            super().__init__()
+            self.model = Child()
+
+        def forward(self, inputs):
+            return self.model(inputs)
+
+    lm = Parent()
+    script = lm.to_torchscript(method="script")
+    assert isinstance(script, RecursiveScriptModule)

--- a/tests/tests_pytorch/models/test_torchscript.py
+++ b/tests/tests_pytorch/models/test_torchscript.py
@@ -18,7 +18,6 @@ import fsspec
 import pytest
 import torch
 from fsspec.implementations.local import LocalFileSystem
-from torch.jit import RecursiveScriptModule
 
 from lightning_lite.utilities.cloud_io import get_filesystem
 from pytorch_lightning.core.module import LightningModule
@@ -193,4 +192,4 @@ def test_torchscript_script_recursively():
 
     lm = Parent()
     script = lm.to_torchscript(method="script")
-    assert isinstance(script, RecursiveScriptModule)
+    assert isinstance(script, torch.jit.RecursiveScriptModule)


### PR DESCRIPTION
## What does this PR do?

Fixes bug reported in Slack:

```python
Traceback (most recent call last):
  File "t.py", line 23, in <module>
    lm.to_torchscript(method='script')
  File "/home/pete/.pyenv/versions/3.8.6/envs/python38/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/home/pete/.pyenv/versions/3.8.6/envs/python38/lib/python3.8/site-packages/pytorch_lightning/core/module.py", line 1926, in to_torchscript
    torchscript_module = torch.jit.script(self.eval(), **kwargs)
  File "/home/pete/.pyenv/versions/3.8.6/envs/python38/lib/python3.8/site-packages/torch/jit/_script.py", line 1265, in script
    return torch.jit._recursive.create_script_module(
  File "/home/pete/.pyenv/versions/3.8.6/envs/python38/lib/python3.8/site-packages/torch/jit/_recursive.py", line 451, in create_script_module
    concrete_type = get_module_concrete_type(nn_module, share_types)
  File "/home/pete/.pyenv/versions/3.8.6/envs/python38/lib/python3.8/site-packages/torch/jit/_recursive.py", line 402, in get_module_concrete_type
    concrete_type = concrete_type_store.get_or_create_concrete_type(nn_module)
  File "/home/pete/.pyenv/versions/3.8.6/envs/python38/lib/python3.8/site-packages/torch/jit/_recursive.py", line 343, in get_or_create_concrete_type
    concrete_type_builder = infer_concrete_type_builder(nn_module)
  File "/home/pete/.pyenv/versions/3.8.6/envs/python38/lib/python3.8/site-packages/torch/jit/_recursive.py", line 208, in infer_concrete_type_builder
    sub_concrete_type = get_module_concrete_type(item, share_types)
  File "/home/pete/.pyenv/versions/3.8.6/envs/python38/lib/python3.8/site-packages/torch/jit/_recursive.py", line 402, in get_module_concrete_type
    concrete_type = concrete_type_store.get_or_create_concrete_type(nn_module)
  File "/home/pete/.pyenv/versions/3.8.6/envs/python38/lib/python3.8/site-packages/torch/jit/_recursive.py", line 343, in get_or_create_concrete_type
    concrete_type_builder = infer_concrete_type_builder(nn_module)
  File "/home/pete/.pyenv/versions/3.8.6/envs/python38/lib/python3.8/site-packages/torch/jit/_recursive.py", line 251, in infer_concrete_type_builder
    overloads.update(get_overload_name_mapping(get_overload_annotations(nn_module, ignored_properties)))
  File "/home/pete/.pyenv/versions/3.8.6/envs/python38/lib/python3.8/site-packages/torch/jit/_recursive.py", line 617, in get_overload_annotations
    item = getattr(mod, name, None)
  File "/home/pete/.pyenv/versions/3.8.6/envs/python38/lib/python3.8/site-packages/pytorch_lightning/core/module.py", line 180, in trainer
    raise RuntimeError(f"{self.__class__.__qualname__} is not attached to a `Trainer`.")
RuntimeError: Child is not attached to a `Trainer`.
```
### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified