### PR TITLE
Fix TPU CI for non-forks

### DIFF
--- a/.github/workflows/ci-circleci.yml
+++ b/.github/workflows/ci-circleci.yml
@@ -8,7 +8,10 @@ on:
       - "src/pytorch_lightning/**"
       - "tests/tests_pytorch/**"
       - "setup.cfg"  # includes pytest config
-  pull_request_target:
+  # should use `pull_request_target` but it's blocked by
+  # https://github.com/CircleCI-Public/trigger-circleci-pipeline-action/issues/27
+  # so this job will not run on forks until fixed
+  pull_request:
     branches: [master, "release/*"]
     paths:
       - ".github/workflows/ci-circleci.yml"

--- a/.github/workflows/ci-circleci.yml
+++ b/.github/workflows/ci-circleci.yml
@@ -10,7 +10,7 @@ on:
       - "setup.cfg"  # includes pytest config
   # should use `pull_request_target` but it's blocked by
   # https://github.com/CircleCI-Public/trigger-circleci-pipeline-action/issues/27
-  # so this job will not run on forks until fixed
+  # so this job will not run on forks until the above is fixed or we replace CircleCI for another provider
   pull_request:
     branches: [master, "release/*"]
     paths:

--- a/.github/workflows/ci-circleci.yml
+++ b/.github/workflows/ci-circleci.yml
@@ -26,9 +26,6 @@ jobs:
   trigger-circleci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
         env:
           CCI_TOKEN: ${{ secrets.CCI_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

Partially revert #14603 and https://github.com/Lightning-AI/lightning/pull/14625. Blocked by https://github.com/CircleCI-Public/trigger-circleci-pipeline-action/issues/27

https://github.com/Lightning-AI/lightning/pull/14687 or #14307 would be valid alternatives too.

### Does your PR introduce any breaking changes? If yes, please list them.

None