### PR TITLE
Fix CC-bot for non-forks

### DIFF
--- a/.github/workflows/probot-auto-cc.yml
+++ b/.github/workflows/probot-auto-cc.yml
@@ -3,7 +3,10 @@ name: Probot
 on:
   issues:
     types: [labeled]
-  pull_request_target:
+  # should use `pull_request_target` but it's blocked by
+  # https://github.com/probot/probot/issues/1635
+  # so this job will not run on forks until the above is fixed
+  pull_request:
     types: [labeled, ready_for_review]
 
 jobs:


### PR DESCRIPTION
## What does this PR do?

Partially revert #14603. Blocked by https://github.com/probot/probot/issues/1635

I really tried everything but couldn't find a workaround without the above. So cc-bot cannot run on PRs from forks :(

### Does your PR introduce any breaking changes? If yes, please list them.

None

cc @carmocca @akihironitta @borda