### PR TITLE
User-friendly exception when `LightningWork.run()` method is missing

### DIFF
--- a/src/lightning_app/CHANGELOG.md
+++ b/src/lightning_app/CHANGELOG.md
@@ -22,6 +22,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Improve Lightning App connect logic by disconnecting automatically ([#14532](https://github.com/Lightning-AI/lightning/pull/14532))
 
 
+- Improved the error messsage when the `LightningWork` is missing the `run` method ([#14759](https://github.com/Lightning-AI/lightning/pull/14759))
+
+
+
 ### Fixed
 
 - Making threadpool non default from LightningCloud client  ([#14757](https://github.com/Lightning-AI/lightning/pull/14757))

--- a/src/lightning_app/core/work.py
+++ b/src/lightning_app/core/work.py
@@ -563,7 +563,7 @@ class LightningWork:
 
     def _check_run_is_implemented(self) -> None:
         if not is_overridden("run", instance=self, parent=LightningWork):
-            raise NotImplementedError(
+            raise TypeError(
                 f"The work `{self.__class__.__name__}` is missing the `run()` method. This is required. Implement it"
                 " first and then call it in your Flow."
             )

--- a/src/lightning_app/core/work.py
+++ b/src/lightning_app/core/work.py
@@ -1,4 +1,3 @@
-import abc
 import time
 import warnings
 from copy import deepcopy
@@ -11,7 +10,7 @@ from lightning_app.core.queues import BaseQueue
 from lightning_app.storage import Path
 from lightning_app.storage.drive import _maybe_create_drive, Drive
 from lightning_app.storage.payload import Payload
-from lightning_app.utilities.app_helpers import _is_json_serializable, _LightningAppRef
+from lightning_app.utilities.app_helpers import _is_json_serializable, _LightningAppRef, is_overridden
 from lightning_app.utilities.component import _is_flow_context, _sanitize_state
 from lightning_app.utilities.enum import (
     CacheCallsKeys,
@@ -29,7 +28,7 @@ from lightning_app.utilities.packaging.cloud_compute import CloudCompute
 from lightning_app.utilities.proxies import LightningWorkSetAttrProxy, ProxyWorkRun, unwrap
 
 
-class LightningWork(abc.ABC):
+class LightningWork:
 
     _INTERNAL_STATE_VARS = (
         # Internal protected variables that are still part of the state (even though they are prefixed with "_")
@@ -139,6 +138,7 @@ class LightningWork(abc.ABC):
         self._cloud_build_config = cloud_build_config or BuildConfig()
         self._cloud_compute = cloud_compute or CloudCompute()
         self._backend: Optional[Backend] = None
+        self._check_run_is_implemented()
         self._on_init_end()
 
     @property
@@ -516,14 +516,12 @@ class LightningWork(abc.ABC):
                         final_statuses.append(status)
                 calls[call_hash]["statuses"] = final_statuses
 
-    @abc.abstractmethod
     def run(self, *args, **kwargs):
         """Override to add your own logic.
 
         Raises:
             LightningPlatformException: If resource exceeds platform quotas or other constraints.
         """
-        pass
 
     def on_exception(self, exception: BaseException):
         """Override to customize how to handle exception in the run method."""
@@ -562,3 +560,10 @@ class LightningWork(abc.ABC):
         self._calls[latest_hash]["statuses"].append(stop_status)
         app = _LightningAppRef().get_current()
         self._backend.stop_work(app, self)
+
+    def _check_run_is_implemented(self) -> None:
+        if not is_overridden("run", instance=self, parent=LightningWork):
+            raise NotImplementedError(
+                f"The work `{self.__class__.__name__}` is missing the `run()` method. This is required. Implement it"
+                " first and then call it in your Flow."
+            )

--- a/tests/tests_app/core/test_lightning_work.py
+++ b/tests/tests_app/core/test_lightning_work.py
@@ -17,7 +17,7 @@ from lightning_app.utilities.proxies import ProxyWorkRun, WorkRunner
 def test_lightning_work_run_method_required():
     """Test that a helpful exception is raised when the user did not implement the `LightningWork.run()` method."""
 
-    with pytest.raises(NotImplementedError, match=escape("The work `LightningWork` is missing the `run()` method")):
+    with pytest.raises(TypeError, match=escape("The work `LightningWork` is missing the `run()` method")):
         LightningWork()
 
     class WorkWithoutRun(LightningWork):
@@ -25,7 +25,7 @@ def test_lightning_work_run_method_required():
             super().__init__()
             self.started = False
 
-    with pytest.raises(NotImplementedError, match=escape("The work `WorkWithoutRun` is missing the `run()` method")):
+    with pytest.raises(TypeError, match=escape("The work `WorkWithoutRun` is missing the `run()` method")):
         WorkWithoutRun()
 
     class WorkWithRun(WorkWithoutRun):

--- a/tests/tests_app/core/test_lightning_work.py
+++ b/tests/tests_app/core/test_lightning_work.py
@@ -21,47 +21,40 @@ def test_lightning_work_run_method_required():
         LightningWork()
 
     class WorkWithoutRun(LightningWork):
-        pass
-
-    with pytest.raises(NotImplementedError, match=escape("The work `WorkWithoutRun` is missing the `run()` method")):
-        WorkWithoutRun()
-
-    class WorkWithRun(LightningWork):
-        def run(self):
-            pass
-
-    WorkWithRun()  # no error
-
-
-def test_simple_lightning_work():
-    class Work_A(LightningWork):
         def __init__(self):
             super().__init__()
             self.started = False
 
-    with pytest.raises(TypeError, match="Work_A"):
-        Work_A()
+    with pytest.raises(NotImplementedError, match=escape("The work `WorkWithoutRun` is missing the `run()` method")):
+        WorkWithoutRun()
 
-    class Work_B(Work_A):
+    class WorkWithRun(WorkWithoutRun):
         def run(self, *args, **kwargs):
             self.started = True
 
-    work_b = Work_B()
-    work_b.run()
-    assert work_b.started
+    work = WorkWithRun()
+    work.run()
+    assert work.started
 
-    class Work_C(LightningWork):
+
+def test_lightning_work_no_children_allowed():
+    """Test that a LightningWork can't have any children (work or flow)."""
+
+    class ChildWork(EmptyWork):
+        pass
+
+    class ParentWork(LightningWork):
         def __init__(self):
             super().__init__()
-            self.work_b = Work_B()
+            self.work_b = ChildWork()
 
         def run(self, *args, **kwargs):
             pass
 
     with pytest.raises(LightningWorkException, match="isn't allowed to take any children such as"):
-        Work_C()
+        ParentWork()
 
-    class Work_C(LightningWork):
+    class ParentWork(LightningWork):
         def __init__(self):
             super().__init__()
             self.flow = LightningFlow()
@@ -70,7 +63,7 @@ def test_simple_lightning_work():
             pass
 
     with pytest.raises(LightningWorkException, match="LightningFlow"):
-        Work_C()
+        ParentWork()
 
 
 def test_forgot_to_call_init():

--- a/tests/tests_app/core/test_lightning_work.py
+++ b/tests/tests_app/core/test_lightning_work.py
@@ -1,4 +1,5 @@
 from queue import Empty
+from re import escape
 from unittest.mock import Mock
 
 import pytest
@@ -11,6 +12,25 @@ from lightning_app.storage import Path
 from lightning_app.testing.helpers import EmptyFlow, EmptyWork, MockQueue
 from lightning_app.utilities.enum import WorkStageStatus
 from lightning_app.utilities.proxies import ProxyWorkRun, WorkRunner
+
+
+def test_lightning_work_run_method_required():
+    """Test that a helpful exception is raised when the user did not implement the `LightningWork.run()` method."""
+
+    with pytest.raises(NotImplementedError, match=escape("The work `LightningWork` is missing the `run()` method")):
+        LightningWork()
+
+    class WorkWithoutRun(LightningWork):
+        pass
+
+    with pytest.raises(NotImplementedError, match=escape("The work `WorkWithoutRun` is missing the `run()` method")):
+        WorkWithoutRun()
+
+    class WorkWithRun(LightningWork):
+        def run(self):
+            pass
+
+    WorkWithRun()  # no error
 
 
 def test_simple_lightning_work():


### PR DESCRIPTION
## What does this PR do?

Fixes #14677

The LightningWork no longer is an abstract class, and the run() method is no longer abstract. 
When you try to instantiate a work without a run method overridden, you will get an error message saying:

> The work `name of the class` is missing the `run()` method. This is required. Implement it first and then call it in your Flow.


### Does your PR introduce any breaking changes? If yes, please list them.

No.


## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃


cc @borda