### PR TITLE
Fix TensorBoardLogger creating redundant experiment when finalizing

### DIFF
--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -7,9 +7,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [unReleased] - 2022-MM-DD
 
 
-- Added an option to configure the signal SLURM sends when a job is preempted or requeued ([#14610](https://github.com/Lightning-AI/lightning/issues/14610))
-
-
 ### Added
 
 
@@ -38,6 +35,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
 - Added `WandbLogger.download_artifact` and `WandbLogger.use_artifact` for managing artifacts with Weights and Biases ([#14551](https://github.com/Lightning-AI/lightning/issues/14551))
+
+
+- Added an option to configure the signal SLURM sends when a job is preempted or requeued ([#14610](https://github.com/Lightning-AI/lightning/issues/14610))
 
 
 ### Changed
@@ -184,6 +184,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
 - Fixed torchscript error with ensembles of LightningModules ([#14657](https://github.com/Lightning-AI/lightning/pull/14657), [#14724](https://github.com/Lightning-AI/lightning/pull/14724))
+
+
+- Fixed an issue with `TensorBoardLogger.finalize` creating a new experiment when none was created during the Trainer's execution ([#14762](https://github.com/Lightning-AI/lightning/pull/14762)
+
 
 
 ## [1.7.6] - 2022-09-13

--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -186,7 +186,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed torchscript error with ensembles of LightningModules ([#14657](https://github.com/Lightning-AI/lightning/pull/14657), [#14724](https://github.com/Lightning-AI/lightning/pull/14724))
 
 
-- Fixed an issue with `TensorBoardLogger.finalize` creating a new experiment when none was created during the Trainer's execution ([#14762](https://github.com/Lightning-AI/lightning/pull/14762)
+- Fixed an issue with `TensorBoardLogger.finalize` creating a new experiment when none was created during the Trainer's execution ([#14762](https://github.com/Lightning-AI/lightning/pull/14762))
 
 
 

--- a/src/pytorch_lightning/loggers/tensorboard.py
+++ b/src/pytorch_lightning/loggers/tensorboard.py
@@ -268,8 +268,9 @@ class TensorBoardLogger(Logger):
 
     @rank_zero_only
     def finalize(self, status: str) -> None:
-        self.experiment.flush()
-        self.experiment.close()
+        if self._experiment is not None:
+            self.experiment.flush()
+            self.experiment.close()
         self.save()
 
     @property

--- a/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
+++ b/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
@@ -880,7 +880,6 @@ def test_checkpoint_repeated_strategy(tmpdir):
         # load from checkpoint
         trainer = Trainer(**trainer_kwargs)
         trainer.fit(model, ckpt_path=checkpoint_callback.best_model_path)
-        # assert trainer.logger._experiment, str(idx)
         trainer.test(ckpt_path=checkpoint_callback.best_model_path, verbose=False)
 
         assert set(os.listdir(tmpdir)) == {"epoch=00.ckpt", "lightning_logs"}

--- a/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
+++ b/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
@@ -886,7 +886,7 @@ def test_checkpoint_repeated_strategy(tmpdir):
         assert set(os.listdir(tmpdir)) == {"epoch=00.ckpt", "lightning_logs"}
 
     # no new versions created after the initial fit, because the ones that resume from ckpt do not log anything
-    assert set(os.listdir(tmpdir / "lightning_logs")) == {f"version_0"}
+    assert set(os.listdir(tmpdir / "lightning_logs")) == {"version_0"}
 
 
 def test_checkpoint_repeated_strategy_extended(tmpdir):

--- a/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
+++ b/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
@@ -874,7 +874,7 @@ def test_checkpoint_repeated_strategy(tmpdir):
     }
     trainer = Trainer(**trainer_kwargs, callbacks=[checkpoint_callback])
     trainer.fit(model)
-    assert os.listdir(tmpdir) == ["epoch=00.ckpt", "lightning_logs"]
+    assert set(os.listdir(tmpdir)) == {"epoch=00.ckpt", "lightning_logs"}
 
     for idx in range(4):
         # load from checkpoint

--- a/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
+++ b/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
@@ -869,18 +869,24 @@ def test_checkpoint_repeated_strategy(tmpdir):
         "limit_test_batches": 2,
         "enable_progress_bar": False,
         "enable_model_summary": False,
+        "log_every_n_steps": 1,
+        "default_root_dir": tmpdir,
     }
     trainer = Trainer(**trainer_kwargs, callbacks=[checkpoint_callback])
     trainer.fit(model)
-    assert os.listdir(tmpdir) == ["epoch=00.ckpt"]
+    assert os.listdir(tmpdir) == ["epoch=00.ckpt", "lightning_logs"]
 
     for idx in range(4):
         # load from checkpoint
-        trainer = pl.Trainer(**trainer_kwargs, default_root_dir=tmpdir)
+        trainer = Trainer(**trainer_kwargs)
         trainer.fit(model, ckpt_path=checkpoint_callback.best_model_path)
+        # assert trainer.logger._experiment, str(idx)
         trainer.test(ckpt_path=checkpoint_callback.best_model_path, verbose=False)
+
         assert set(os.listdir(tmpdir)) == {"epoch=00.ckpt", "lightning_logs"}
-    assert set(os.listdir(tmpdir / "lightning_logs")) == {f"version_{i}" for i in range(4)}
+
+    # no new versions created after the initial fit, because the ones that resume from ckpt do not log anything
+    assert set(os.listdir(tmpdir / "lightning_logs")) == {f"version_0"}
 
 
 def test_checkpoint_repeated_strategy_extended(tmpdir):
@@ -891,6 +897,7 @@ def test_checkpoint_repeated_strategy_extended(tmpdir):
         def validation_step(self, batch, batch_idx):
             output = self.layer(batch)
             loss = self.loss(batch, output)
+            self.log("val_loss", loss)
             return {"val_loss": loss}
 
         def validation_epoch_end(self, *_):
@@ -930,7 +937,7 @@ def test_checkpoint_repeated_strategy_extended(tmpdir):
         limit_test_batches=4,
         callbacks=[checkpoint_cb],
     )
-    trainer = pl.Trainer(**trainer_config)
+    trainer = Trainer(**trainer_config)
     assert_trainer_init(trainer)
 
     model = ExtendedBoringModel()

--- a/tests/tests_pytorch/loggers/test_tensorboard.py
+++ b/tests/tests_pytorch/loggers/test_tensorboard.py
@@ -275,7 +275,17 @@ def test_tensorboard_with_accummulated_gradients(mock_log_metrics, tmpdir):
 def test_tensorboard_finalize(summary_writer, tmpdir):
     """Test that the SummaryWriter closes in finalize."""
     logger = TensorBoardLogger(save_dir=tmpdir)
+    assert logger._experiment is None
     logger.finalize("any")
+
+    # no log calls, no experiment created -> nothing to flush
+    summary_writer.assert_not_called()
+
+    logger = TensorBoardLogger(save_dir=tmpdir)
+    logger.log_metrics({"flush_me": 11.1})  # trigger creation of an experiment
+    logger.finalize("any")
+
+    # finalize flushes to experiment directory
     summary_writer().flush.assert_called()
     summary_writer().close.assert_called()
 


### PR DESCRIPTION
## What does this PR do?

Unblocks #12292, as I found a bug while helping out there.

The newly added test in test_tensorboard.py illustrates the issue: When nothing is logged, no experiment exists, but the call to finalize() would create a new experiment, then close it immediately again, leaving useless summary files behind.
This PR changes this to only flush/close or create directories when an experiment actually exists. This is consistent with all other loggers. 

### Does your PR introduce any breaking changes? If yes, please list them.

I don't think so. This was a peculiar edge case I can't believe anyone would need to rely on for a serious use case. 

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃

cc @borda @awaelchli @edward-io @rohitgr7 @akihironitta