### PR TITLE
Correct false error message relating to Trainer(precision)

### DIFF
--- a/src/lightning_lite/connector.py
+++ b/src/lightning_lite/connector.py
@@ -104,7 +104,7 @@ class _Connector:
         # Get registered strategies, built-in accelerators and precision plugins
         self._registered_strategies = STRATEGY_REGISTRY.available_strategies()
         self._registered_accelerators = ACCELERATOR_REGISTRY.available_accelerators()
-        self._precision_types = ("16", "32", "64", "bf16", "mixed")
+        self._precision_types = ("16", "32", "64", "bf16")
 
         # Raise an exception if there are conflicts between flags
         # Set each valid flag to `self._x_flag` after validation

--- a/src/pytorch_lightning/trainer/connectors/accelerator_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/accelerator_connector.py
@@ -166,7 +166,7 @@ class AcceleratorConnector:
         # Get registered strategies, built-in accelerators and precision plugins
         self._registered_strategies = StrategyRegistry.available_strategies()
         self._accelerator_types = AcceleratorRegistry.available_accelerators()
-        self._precision_types = ("16", "32", "64", "bf16", "mixed")
+        self._precision_types = ("16", "32", "64", "bf16")
 
         # Raise an exception if there are conflicts between flags
         # Set each valid flag to `self._x_flag` after validation


### PR DESCRIPTION
## What does this PR do?
At L298, the error message shows that `_precision_types` can be "mixed", but that's not true, it's not a value that's handled. This patch changes `AcceleratorConnector._precision_types`, removing "mixed", to correct that message.

### Does your PR introduce any breaking changes? If yes, please list them.
No

## Before submitting

- No [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- No [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- Yes [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- N/A [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- N/A [ ] Did you write any **new necessary tests**? (not for typos and docs)
- N/A [ ] Did you verify new and **existing tests pass** locally with your changes?
- N/A [ ] Did you list all the **breaking changes** introduced by this pull request?
- N/A [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

-  Yes [ ] Is this pull request ready for review? (if not, please submit in draft mode)
-  No [ ] Check that all items from **Before submitting** are resolved
-  Yes [ ] Make sure the title is self-explanatory and the description concisely explains the PR
-  No [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified