### PR TITLE
Remove deprecated call_hook

### DIFF
--- a/docs/source-pytorch/extensions/loops.rst
+++ b/docs/source-pytorch/extensions/loops.rst
@@ -140,8 +140,7 @@ For example with the :class:`~pytorch_lightning.loops.fit_loop.FitLoop`:
 
 A full list with all built-in loops and subloops can be found :ref:`here <loop-structure-extensions>`.
 
-To add your own modifications to a loop, simply subclass an existing loop class and override what you need.
-Here is a simple example how to add a new hook:
+To add your own modifications to a loop, simply subclass an existing loop class and override what you need:
 
 .. code-block:: python
 
@@ -150,12 +149,7 @@ Here is a simple example how to add a new hook:
 
     class CustomFitLoop(FitLoop):
         def advance(self):
-            # ... whatever code before
-
-            # pass anything you want to the hook
-            self.trainer.call_hook("my_new_hook", *args, **kwargs)
-
-            # ... whatever code after
+            # ... code
 
 Now simply attach the correct loop in the trainer directly:
 

--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -221,6 +221,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Removed the deprecated `Trainer.use_amp` and `LightningModule.use_amp` attributes ([#14832](https://github.com/Lightning-AI/lightning/pull/14832))
 
+- Removed the deprecated `Trainer.call_hook` in favor of `Trainer._call_callback_hooks`, `Trainer._call_lightning_module_hook`, `Trainer._call_ttp_hook`, and `Trainer._call_accelerator_hook`
+
 
 ### Fixed
 

--- a/tests/tests_pytorch/deprecated_api/test_remove_1-8.py
+++ b/tests/tests_pytorch/deprecated_api/test_remove_1-8.py
@@ -56,18 +56,6 @@ def test_v1_8_0_on_init_start_end(tmpdir):
         trainer.validate(model)
 
 
-def test_v1_8_0_deprecated_call_hook():
-    trainer = Trainer(
-        max_epochs=1,
-        limit_val_batches=0.1,
-        limit_train_batches=0.2,
-        enable_progress_bar=False,
-        logger=False,
-    )
-    with pytest.deprecated_call(match="was deprecated in v1.6 and will be removed in v1.8."):
-        trainer.call_hook("test_hook")
-
-
 def test_v1_8_0_deprecated_run_stage():
     trainer = Trainer()
     trainer._run_stage = Mock()


### PR DESCRIPTION
## What does this PR do?

Removes deprecated APIs for 1.8 release, #14841. More specifically, the removal of test_v1_8_0_deprecated_call_hook.

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
