### PR TITLE
WandbLogger save_dir doesn't take effect when using CLI

### DIFF
--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -230,6 +230,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed an attribute error when running the tuner together with the `StochasticWeightAveraging` callback ([#14836](https://github.com/Lightning-AI/lightning/pull/14836))
 
 
+- Fixed wandb `save_dir` is overridden by `None` `dir` when using CLI ([#14878](https://github.com/Lightning-AI/lightning/pull/14878))
+
+
 ## [1.7.7] - 2022-09-22
 
 ### Fixed

--- a/src/pytorch_lightning/loggers/wandb.py
+++ b/src/pytorch_lightning/loggers/wandb.py
@@ -254,9 +254,10 @@ class WandbLogger(Logger):
     Args:
         name: Display name for the run.
         save_dir: Path where data is saved.
+        version: Sets the version, mainly used to resume a previous run.
         offline: Run offline (data can be streamed later to wandb servers).
-        id: Sets the version, mainly used to resume a previous run.
-        version: Same as id.
+        dir: Same as save_dir.
+        id: Same as version.
         anonymous: Enables or explicitly disables anonymous logging.
         project: The name of the project to which this run will belong.
         log_model: Log checkpoints created by :class:`~pytorch_lightning.callbacks.model_checkpoint.ModelCheckpoint`
@@ -286,10 +287,11 @@ class WandbLogger(Logger):
         self,
         name: Optional[str] = None,
         save_dir: str = ".",
+        version: Optional[str] = None,
         offline: bool = False,
+        dir: Optional[str] = None,
         id: Optional[str] = None,
         anonymous: Optional[bool] = None,
-        version: Optional[str] = None,
         project: str = "lightning_logs",
         log_model: Union[str, bool] = False,
         experiment: Union[Run, RunDisabled, None] = None,
@@ -327,8 +329,8 @@ class WandbLogger(Logger):
         self._wandb_init: Dict[str, Any] = dict(
             name=name,
             project=project,
+            dir=save_dir or dir,
             id=version or id,
-            dir=save_dir or kwargs.pop("dir"),
             resume="allow",
             anonymous=("allow" if anonymous else None),
         )

--- a/tests/tests_pytorch/loggers/test_wandb.py
+++ b/tests/tests_pytorch/loggers/test_wandb.py
@@ -64,7 +64,11 @@ def test_wandb_logger_init(wandb, monkeypatch):
     # test wandb.init set save_dir correctly after created
     wandb.run = None
     wandb.init.reset_mock()
-    logger = WandbLogger(project="test_project")
+    logger = WandbLogger()
+    assert logger.save_dir is not None
+    wandb.run = None
+    wandb.init.reset_mock()
+    logger = WandbLogger(save_dir=".", dir=None)
     assert logger.save_dir is not None
 
     # test wandb.init and setting logger experiment externally


### PR DESCRIPTION
## 🐛 Bug

WandbLogger `save_dir` doesn't take effect when using CLI

### To Reproduce
`cli.py`:
```python
from pytorch_lightning.cli import LightningCLI

from pytorch_lightning.demos.boring_classes import DemoModel, BoringDataModule

class LitCLI(LightningCLI):
    def before_instantiate_classes(self) -> None:
        print(self.config[self.subcommand].trainer.logger)

def run():
    cli = LitCLI(
        DemoModel,
        BoringDataModule,
        trainer_defaults={"max_epochs": 2},
        save_config_callback=False,
    )


if __name__ == "__main__":
    run()
```
run command:
```console
python cli.py fit --trainer.logger WandbLogger --trainer.logger.save_dir "results"
```

the wandb is initialize with `dir=None`

### Expected behavior

the wandb is initialize with `dir=results`

### Environment

<details>
  <summary>Details</summary>
    * CUDA:
	- GPU:               None
	- available:         False
	- version:           None
* Lightning:
	- pytorch-lightning: 1.7.1
	- torch:             1.12.1
	- torchmetrics:      0.9.3
	- torchtext:         0.13.1
* Packages:
	- absl-py:           1.2.0
	- aiohttp:           3.8.1
	- aiosignal:         1.2.0
	- antlr4-python3-runtime: 4.9.3
	- async-timeout:     4.0.2
	- attrs:             22.1.0
	- cachetools:        5.2.0
	- certifi:           2022.6.15
	- charset-normalizer: 2.1.0
	- click:             8.1.3
	- commonmark:        0.9.1
	- cycler:            0.11.0
	- decorator:         5.1.1
	- docker-pycreds:    0.4.0
	- docstring-parser:  0.14.1
	- fonttools:         4.35.0
	- frozenlist:        1.3.1
	- fsspec:            2022.7.1
	- gcsfs:             2022.7.1
	- gitdb:             4.0.9
	- gitpython:         3.1.27
	- google-api-core:   2.8.2
	- google-auth:       2.10.0
	- google-auth-oauthlib: 0.4.6
	- google-cloud-core: 2.3.2
	- google-cloud-storage: 2.5.0
	- google-crc32c:     1.3.0
	- google-resumable-media: 2.3.3
	- googleapis-common-protos: 1.56.4
	- grpcio:            1.47.0
	- hydra-core:        1.2.0
	- idna:              3.3
	- importlib-metadata: 4.12.0
	- jsonargparse:      4.13.1
	- kiwisolver:        1.4.4
	- markdown:          3.4.1
	- markupsafe:        2.1.1
	- matplotlib:        3.5.3
	- multidict:         6.0.2
	- numpy:             1.23.2
	- oauthlib:          3.2.0
	- omegaconf:         2.2.2
	- packaging:         21.3
	- pathtools:         0.1.2
	- pillow:            9.2.0
	- pip:               22.1.2
	- promise:           2.3
	- protobuf:          3.19.4
	- psutil:            5.9.1
	- pyasn1:            0.4.8
	- pyasn1-modules:    0.2.8
	- pydeprecate:       0.3.2
	- pygments:          2.13.0
	- pyparsing:         3.0.9
	- python-dateutil:   2.8.2
	- pytorch-lightning: 1.7.1
	- pyyaml:            6.0
	- requests:          2.28.1
	- requests-oauthlib: 1.3.1
	- rich:              12.5.1
	- rsa:               4.9
	- sentry-sdk:        1.9.4
	- setproctitle:      1.3.2
	- setuptools:        61.2.0
	- shortuuid:         1.0.9
	- six:               1.16.0
	- smmap:             5.0.0
	- tensorboard:       2.10.0
	- tensorboard-data-server: 0.6.1
	- tensorboard-plugin-wit: 1.8.1
	- torch:             1.12.1
	- torchmetrics:      0.9.3
	- torchtext:         0.13.1
	- tqdm:              4.64.0
	- typing-extensions: 4.3.0
	- urllib3:           1.26.11
	- wandb:             0.13.1
	- werkzeug:          2.2.2
	- wheel:             0.37.1
	- yarl:              1.8.1
	- zipp:              3.8.1
* System:
	- OS:                Darwin
	- architecture:
		- 64bit
		- 
	- processor:         arm
	- python:            3.9.12
	- version:           Darwin Kernel Version 21.6.0: Sat Jun 18 17:07:22 PDT 2022; root:xnu-8020.140.41~1/RELEASE_ARM64_T6000
</details>

### Additional context

As we can see, the Namespace of logger before instantiate is 
```
Namespace(class_path='pytorch_lightning.loggers.WandbLogger', init_args=Namespace(name=None, save_dir='results', offline=False, id=None, anonymous=None, version=None, project='bug_report', log_model=False, experiment=None, prefix='', agg_key_funcs=None, agg_default_func=None, job_type=None, dir=None, config=None, entity=None, reinit=None, tags=None, group=None, notes=None, magic=None, config_exclude_keys=None, config_include_keys=None, mode=None, allow_val_change=None, resume=None, force=None, tensorboard=None, sync_tensorboard=None, monitor_gym=None, save_code=None, settings=None))
```
and the `save_dir` is cover by `dir` at here https://github.com/Lightning-AI/lightning/blob/2622989b108368813fdd3850b002fd1ad69988c2/src/pytorch_lightning/loggers/wandb.py#L299-L307

cc @awaelchli @morganmcg1 @borisdayma @scottire @manangoel99 @carmocca @mauvilsa