### PR TITLE
Remove deprecated trainer.verbose_evaluate

### DIFF
--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -225,7 +225,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed the deprecated `SimpleProfiler.profile_iterable` and `AdvancedProfiler.profile_iterable` attributes ([#14864](https://github.com/Lightning-AI/lightning/pull/14864))
 
 
-- Removed the deprecated `Trainer.verbose_evaluate`
+- Removed the deprecated `Trainer.verbose_evaluate` ([#14884](https://github.com/Lightning-AI/lightning/pull/14884))
 
 
 - Remove the deprecated `Trainer.should_rank_save_checkpoint` ([#14885](https://github.com/Lightning-AI/lightning/pull/14885))

--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -224,6 +224,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Removed the deprecated `SimpleProfiler.profile_iterable` and `AdvancedProfiler.profile_iterable` attributes ([#14864](https://github.com/Lightning-AI/lightning/pull/14864))
 
+- Removed the deprecated `Trainer.verbose_evaluate`
+
 
 ### Fixed
 

--- a/src/pytorch_lightning/trainer/trainer.py
+++ b/src/pytorch_lightning/trainer/trainer.py
@@ -2246,26 +2246,6 @@ class Trainer(
         self._predict_loop = loop
 
     @property
-    def verbose_evaluate(self) -> bool:
-        rank_zero_deprecation(
-            "The `Trainer.verbose_evaluate` property has been deprecated and will be removed in v1.8. The current value"
-            " returned is the union of the validate and test loop values. You can choose which one to access with"
-            " `trainer.{validate,test}_loop.verbose`.",
-            stacklevel=5,
-        )
-        return self.validate_loop.verbose or self.test_loop.verbose
-
-    @verbose_evaluate.setter
-    def verbose_evaluate(self, verbose: bool) -> None:
-        rank_zero_deprecation(
-            "The `Trainer.verbose_evaluate` property has been deprecated and will be removed in v1.8. This will set"
-            " the value for both trainer.{validate,test}_loop.verbose`.",
-            stacklevel=5,
-        )
-        self.validate_loop.verbose = verbose
-        self.test_loop.verbose = verbose
-
-    @property
     def _evaluation_loop(self) -> EvaluationLoop:
         if self.state.fn in (TrainerFn.FITTING, TrainerFn.TUNING):
             return self.fit_loop.epoch_loop.val_loop

--- a/tests/tests_pytorch/deprecated_api/test_remove_1-8.py
+++ b/tests/tests_pytorch/deprecated_api/test_remove_1-8.py
@@ -72,15 +72,6 @@ def test_v1_8_0_deprecated_run_stage():
         trainer.run_stage()
 
 
-def test_v1_8_0_trainer_verbose_evaluate():
-    trainer = Trainer()
-    with pytest.deprecated_call(match="verbose_evaluate` property has been deprecated and will be removed in v1.8"):
-        assert trainer.verbose_evaluate
-
-    with pytest.deprecated_call(match="verbose_evaluate` property has been deprecated and will be removed in v1.8"):
-        trainer.verbose_evaluate = False
-
-
 @pytest.mark.parametrize("fn_prefix", ["validated", "tested", "predicted"])
 def test_v1_8_0_trainer_ckpt_path_attributes(fn_prefix: str):
     test_attr = f"{fn_prefix}_ckpt_path"


### PR DESCRIPTION
## What does this PR do?

Removes deprecated API.

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
