### PR TITLE
Introduce `ckpt_path="hpc"` keyword for checkpoint loading

### DIFF
--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -51,6 +51,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added a warning when the model passed to `LightningLite.setup()` does not have all parameters on the same device ([#14822](https://github.com/Lightning-AI/lightning/pull/14822))
 
 
+- Introduce `ckpt_path="hpc"` keyword for checkpoint loading ([#14911](https://github.,com/Lightning-AI/lightning/pull/14911))
+
 
 ### Changed
 
@@ -100,6 +102,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
 - It is no longer needed to call `model.double()` when using `precision=64` in Lightning Lite ([#14827](https://github.com/Lightning-AI/lightning/pull/14827))
+
+
+- HPC checkpoints are now loaded automatically only in slurm environment when no specific value for `ckpt_path` has been set ([#14911](https://github.com/Lightning-AI/lightning/pull/14911))
 
 
 ### Deprecated

--- a/src/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -146,18 +146,16 @@ class CheckpointConnector:
                 )
 
             if not self.trainer.checkpoint_callback:
-                raise MisconfigurationException(
-                    f'`.{fn}(ckpt_path="best")` is set but `ModelCheckpoint` is not configured.'
-                )
+                raise ValueError(f'`.{fn}(ckpt_path="best")` is set but `ModelCheckpoint` is not configured.')
 
             has_best_model_path = self.trainer.checkpoint_callback.best_model_path
             if hasattr(self.trainer.checkpoint_callback, "best_model_path") and not has_best_model_path:
                 if self.trainer.fast_dev_run:
-                    raise MisconfigurationException(
+                    raise ValueError(
                         f'You cannot execute `.{fn}(ckpt_path="best")` with `fast_dev_run=True`.'
                         f" Please pass an exact checkpoint path to `.{fn}(ckpt_path=...)`"
                     )
-                raise MisconfigurationException(
+                raise ValueError(
                     f'`.{fn}(ckpt_path="best")` is set but `ModelCheckpoint` is not configured to save the best model.'
                 )
             # load best weights
@@ -179,10 +177,15 @@ class CheckpointConnector:
             ckpt_path = max(candidates_ts.keys(), key=partial(operator.getitem, candidates_ts))
 
         elif ckpt_path == "hpc":
+            if not self._hpc_resume_path:
+                raise ValueError(
+                    f'`.{fn}(ckpt_path="hpc")` is set but no HPC checkpoint was found.'
+                    " Please pass an exact checkpoint path to `.{fn}(ckpt_path=...)`"
+                )
             ckpt_path = self._hpc_resume_path
 
         if not ckpt_path:
-            raise MisconfigurationException(
+            raise ValueError(
                 f"`.{fn}()` found no path for the best weights: {ckpt_path!r}. Please"
                 f" specify a path for a checkpoint `.{fn}(ckpt_path=PATH)`"
             )

--- a/src/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -71,7 +71,7 @@ class CheckpointConnector:
     def resume_start(self, checkpoint_path: Optional[_PATH] = None) -> None:
         """Attempts to pre-load the checkpoint file to memory, with the source path determined in this priority:
 
-        1. from HPC weights if found
+        1. from HPC weights if `checkpoint_path` is ``None`` and on SLURM or passed keyword `"hpc"`.
         2. from fault-tolerant auto-saved checkpoint if found
         3. from `checkpoint_path` file if provided
         4. don't restore
@@ -163,7 +163,7 @@ class CheckpointConnector:
             # load best weights
             ckpt_path = getattr(self.trainer.checkpoint_callback, "best_model_path", None)
 
-        if ckpt_path == "last":
+        elif ckpt_path == "last":
             candidates = [getattr(ft, "ckpt_path", None) for ft in ft_checkpoints] + [
                 getattr(cb, "last_model_path", None) for cb in self.trainer.checkpoint_callbacks
             ]
@@ -178,7 +178,7 @@ class CheckpointConnector:
                 return None
             ckpt_path = max(candidates_ts.keys(), key=partial(operator.getitem, candidates_ts))
 
-        if ckpt_path == "hpc":
+        elif ckpt_path == "hpc":
             ckpt_path = self._hpc_resume_path
 
         if not ckpt_path:

--- a/src/pytorch_lightning/trainer/trainer.py
+++ b/src/pytorch_lightning/trainer/trainer.py
@@ -559,9 +559,9 @@ class Trainer:
 
             val_dataloaders: A :class:`torch.utils.data.DataLoader` or a sequence of them specifying validation samples.
 
-            ckpt_path: Path/URL of the checkpoint from which training is resumed. If there is
-                no checkpoint file at the path, an exception is raised. If resuming from mid-epoch checkpoint,
-                training will start from the beginning of the next epoch.
+            ckpt_path: Path/URL of the checkpoint from which training is resumed. Could also be one of two special
+                keywords ``"last"`` and ``"hpc"``. If there is no checkpoint file at the path, an exception is raised.
+                If resuming from mid-epoch checkpoint, training will start from the beginning of the next epoch.
 
             datamodule: An instance of :class:`~pytorch_lightning.core.datamodule.LightningDataModule`.
         """
@@ -630,7 +630,7 @@ class Trainer:
             dataloaders: A :class:`torch.utils.data.DataLoader` or a sequence of them,
                 or a :class:`~pytorch_lightning.core.datamodule.LightningDataModule` specifying validation samples.
 
-            ckpt_path: Either ``best`` or path to the checkpoint you wish to validate.
+            ckpt_path: Either ``"best"``, ``"last"``, ``"hpc"`` or path to the checkpoint you wish to validate.
                 If ``None`` and the model instance was passed, use the current weights.
                 Otherwise, the best model checkpoint from the previous ``trainer.fit`` call will be loaded
                 if a checkpoint callback is configured.
@@ -722,7 +722,7 @@ class Trainer:
             dataloaders: A :class:`torch.utils.data.DataLoader` or a sequence of them,
                 or a :class:`~pytorch_lightning.core.datamodule.LightningDataModule` specifying test samples.
 
-            ckpt_path: Either ``best`` or path to the checkpoint you wish to test.
+            ckpt_path: Either ``"best"``, ``"last"``, ``"hpc"`` or path to the checkpoint you wish to test.
                 If ``None`` and the model instance was passed, use the current weights.
                 Otherwise, the best model checkpoint from the previous ``trainer.fit`` call will be loaded
                 if a checkpoint callback is configured.
@@ -820,7 +820,7 @@ class Trainer:
             return_predictions: Whether to return predictions.
                 ``True`` by default except when an accelerator that spawns processes is used (not supported).
 
-            ckpt_path: Either ``best`` or path to the checkpoint you wish to predict.
+            ckpt_path: Either ``"best"``, ``"last"``, ``"hpc"`` or path to the checkpoint you wish to predict.
                 If ``None`` and the model instance was passed, use the current weights.
                 Otherwise, the best model checkpoint from the previous ``trainer.fit`` call will be loaded
                 if a checkpoint callback is configured.

--- a/tests/tests_pytorch/models/test_cpu.py
+++ b/tests/tests_pytorch/models/test_cpu.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+from unittest import mock
 
 import torch
 
@@ -25,7 +26,8 @@ from tests_pytorch.helpers.runif import RunIf
 from tests_pytorch.helpers.simple_models import ClassificationModel
 
 
-def test_cpu_slurm_save_load(tmpdir):
+@mock.patch("lightning_lite.plugins.environments.slurm_environment.SLURMEnvironment.detect", return_value=True)
+def test_cpu_slurm_save_load(_, tmpdir):
     """Verify model save/load/checkpoint on CPU."""
     model = BoringModel()
 

--- a/tests/tests_pytorch/trainer/connectors/test_checkpoint_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_checkpoint_connector.py
@@ -77,7 +77,7 @@ def test_hpc_restore_attempt(_, tmpdir):
         assert param.abs().sum() > 0
         torch.nn.init.constant_(param, 0)
 
-    # case 2: explicit resume path provided, restore hpc anyway
+    # case 2: explicit resume path provided, file not found
     trainer = Trainer(default_root_dir=tmpdir, max_steps=3)
 
     with pytest.raises(FileNotFoundError, match="Checkpoint at not existing not found. Aborting training."):

--- a/tests/tests_pytorch/trainer/connectors/test_checkpoint_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_checkpoint_connector.py
@@ -14,6 +14,7 @@
 import os
 from unittest import mock
 
+import pytest
 import torch
 
 from pytorch_lightning import Trainer
@@ -75,6 +76,12 @@ def test_hpc_restore_attempt(_, tmpdir):
     for param in model.parameters():
         assert param.abs().sum() > 0
         torch.nn.init.constant_(param, 0)
+
+    # case 2: explicit resume path provided, restore hpc anyway
+    trainer = Trainer(default_root_dir=tmpdir, max_steps=3)
+
+    with pytest.raises(FileNotFoundError, match="Checkpoint at not existing not found. Aborting training."):
+        trainer.fit(model, ckpt_path="not existing")
 
 
 def test_hpc_max_ckpt_version(tmpdir):

--- a/tests/tests_pytorch/trainer/test_trainer.py
+++ b/tests/tests_pytorch/trainer/test_trainer.py
@@ -810,9 +810,9 @@ def test_checkpoint_path_input(tmpdir, ckpt_path, save_top_k, fn):
     if ckpt_path == "best":
         # ckpt_path is 'best', meaning we load the best weights
         if save_top_k == 0:
-            with pytest.raises(MisconfigurationException, match=".*is not configured to save the best.*"):
+            with pytest.raises(ValueError, match=".*is not configured to save the best.*"):
                 trainer_fn(ckpt_path=ckpt_path)
-            with pytest.raises(MisconfigurationException, match=".*is not configured to save the best.*"):
+            with pytest.raises(ValueError, match=".*is not configured to save the best.*"):
                 trainer_fn(model, ckpt_path=ckpt_path)
         else:
             trainer_fn(ckpt_path=ckpt_path)
@@ -885,9 +885,9 @@ def test_tested_checkpoint_path_best(tmpdir, enable_checkpointing, fn):
         trainer_fn(model, ckpt_path="best")
         assert trainer.ckpt_path == trainer.checkpoint_callback.best_model_path
     else:
-        with pytest.raises(MisconfigurationException, match="`ModelCheckpoint` is not configured."):
+        with pytest.raises(ValueError, match="`ModelCheckpoint` is not configured."):
             trainer_fn(ckpt_path="best")
-        with pytest.raises(MisconfigurationException, match="`ModelCheckpoint` is not configured."):
+        with pytest.raises(ValueError, match="`ModelCheckpoint` is not configured."):
             trainer_fn(model, ckpt_path="best")
 
 
@@ -1681,7 +1681,7 @@ def test_check_val_every_n_epoch_exception(tmpdir):
 def test_exception_when_testing_or_validating_with_fast_dev_run():
     trainer = Trainer(fast_dev_run=True)
     trainer.state.fn = TrainerFn.TESTING
-    with pytest.raises(MisconfigurationException, match=r"with `fast_dev_run=True`. .* pass an exact checkpoint path"):
+    with pytest.raises(ValueError, match=r"with `fast_dev_run=True`. .* pass an exact checkpoint path"):
         trainer._checkpoint_connector._set_ckpt_path(
             trainer.state.fn, ckpt_path="best", model_provided=False, model_connected=True
         )


### PR DESCRIPTION
## What does this PR do?

Implements first two points from https://github.com/Lightning-AI/lightning/issues/13773#issuecomment-1227409044

### Does your PR introduce any breaking changes? If yes, please list them.

HPC checkpoints are now *NOT* being loaded first as a default. Instead, they are specifically loaded if a user passes keyword `"hpc"`. However, if a user is running with `SLURMEnvironment` and passes `ckpt_path=None` (which is a default value) and an HPC checkpoint is found, then it is automatically selected.

I'm not sure if we need more tests around this, if yes, I will implement them

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @borda @awaelchli @ananthsub @ninginthecloud @rohitgr7 @otaj @justusschock @akihironitta