### PR TITLE
Bump version of fsspec

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
     - future>=0.17.1
     - PyYAML>=5.1
     - tqdm>=4.41.0
-    - fsspec[http]>=2021.05.0, !=2021.06.0
+    - fsspec[http]>=2021.06.1
     #- tensorboard>=2.2.0  # not needed, already included in pytorch
 
     # Optional

--- a/requirements/lite/base.txt
+++ b/requirements/lite/base.txt
@@ -3,7 +3,7 @@
 
 numpy>=1.17.2, <1.23.1
 torch>=1.9.*, <1.13.0
-fsspec[http]>=2021.05.0, !=2021.06.0, <2022.6.0
+fsspec[http]>=2021.06.1, <2022.6.0
 packaging>=17.0, <=21.3
 typing-extensions>=4.0.0, <4.3.1
 lightning-utilities==0.3.*

--- a/requirements/pytorch/base.txt
+++ b/requirements/pytorch/base.txt
@@ -5,7 +5,7 @@ numpy>=1.17.2, <1.23.1
 torch>=1.9.*, <1.13.0
 tqdm>=4.57.0, <4.65.0
 PyYAML>=5.4, <=6.0
-fsspec[http]>=2021.05.0, !=2021.06.0, <2022.8.0
+fsspec[http]>=2021.06.1, <2022.8.0
 tensorboard>=2.9.1, <2.11.0
 torchmetrics>=0.7.0, <0.9.3  # needed for using fixed compare_version
 packaging>=17.0, <=21.3


### PR DESCRIPTION
## What does this PR do?

Yesterday, CI broke because of new release of `importlib_metadata` https://stackoverflow.com/questions/73929564/entrypoints-object-has-no-attribute-get-digital-ocean

It is actually caused by oldest possible `fsspec`, which we now have to bump a bit


cc @carmocca @akihironitta @borda