### PR TITLE
Fix GPU tests that fail to raise expected configuration error when run in a CUDA environment

### DIFF
--- a/tests/tests_pytorch/models/test_gpu.py
+++ b/tests/tests_pytorch/models/test_gpu.py
@@ -83,9 +83,7 @@ def test_single_gpu_model(tmpdir, devices):
         "-1",
     ],
 )
-@mock.patch.object(CUDAAccelerator, "is_available", return_value=False)
-@mock.patch("lightning_lite.accelerators.mps.MPSAccelerator.is_available", return_value=False)
-def test_root_gpu_property_0_raising(n_avail, m_avail, devices):
+def test_root_gpu_property_0_raising(mps_count_0, cuda_count_0, devices):
     """Test that asking for a GPU when none are available will result in a MisconfigurationException."""
     with pytest.raises(MisconfigurationException, match="No supported gpu backend found!"):
         Trainer(accelerator="gpu", devices=devices, strategy="ddp")

--- a/tests/tests_pytorch/models/test_gpu.py
+++ b/tests/tests_pytorch/models/test_gpu.py
@@ -83,8 +83,9 @@ def test_single_gpu_model(tmpdir, devices):
         "-1",
     ],
 )
+@mock.patch.object(CUDAAccelerator, "is_available", return_value=False)
 @mock.patch("lightning_lite.accelerators.mps.MPSAccelerator.is_available", return_value=False)
-def test_root_gpu_property_0_raising(_, devices):
+def test_root_gpu_property_0_raising(n_avail, m_avail, devices):
     """Test that asking for a GPU when none are available will result in a MisconfigurationException."""
     with pytest.raises(MisconfigurationException, match="No supported gpu backend found!"):
         Trainer(accelerator="gpu", devices=devices, strategy="ddp")


### PR DESCRIPTION
## What does this PR do?

Fixes #14980 

The following test(s) (7 tests when parameterized) were failing to raise the expected the configuration error when run in a CUDA environment:
tests/tests_pytorch/models/test_gpu.py::test_root_gpu_property_0_raising

This PR adds an additional mock decorator to avoid the test failure in an environment where CUDA is available.

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [X] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [X] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [X] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [X] Did you make sure to **update the documentation** with your changes? (if necessary)
- [X] Did you write any **new necessary tests**? (not for typos and docs)
- [X] Did you verify new and **existing tests pass** locally with your changes?
- [X] Did you list all the **breaking changes** introduced by this pull request?
- N/A: Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
