### PR TITLE
Added support for custom parameters in subclasses of SaveConfigCallback

### DIFF
--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -61,6 +61,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added a more descriptive error message when attempting to fork processes with pre-initialized CUDA context ([#14709](https://github.com/Lightning-AI/lightning/issues/14709))
 
 
+- Added support for custom parameters in subclasses of `SaveConfigCallback` ([#14998](https://github.com/Lightning-AI/lightning/pull/14998)
+
 
 ### Changed
 
@@ -158,6 +160,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   * Deprecated the `pytorch_lightning.utilities.device_parser.parse_cpu_cores` in favor of `lightning_lite.accelerators.cpu.parse_cpu_cores`
   * Deprecated the `pytorch_lightning.utilities.device_parser.parse_tpu_cores` in favor of `lightning_lite.accelerators.tpu.parse_tpu_cores`
   * Deprecated the `pytorch_lightning.utilities.device_parser.parse_hpus` in favor of `pytorch_lightning.accelerators.hpu.parse_hpus`
+
+
+- Deprecated duplicate `SaveConfigCallback` parameters in `LightningCLI.__init__`: `save_config_kwargs`, `save_config_overwrite` and `save_config_multifile`. New `save_config_kwargs` parameter should be used instead ([#14998](https://github.com/Lightning-AI/lightning/pull/14998)
 
 
 ### Removed

--- a/tests/tests_pytorch/deprecated_api/test_remove_1-10.py
+++ b/tests/tests_pytorch/deprecated_api/test_remove_1-10.py
@@ -24,6 +24,7 @@ from lightning_lite.accelerators import CUDAAccelerator as LiteCUDAAccelerator
 from lightning_lite.accelerators import TPUAccelerator as LiteTPUAccelerator
 from pytorch_lightning import Trainer
 from pytorch_lightning.accelerators.cpu import CPUAccelerator
+from pytorch_lightning.cli import LightningCLI
 from pytorch_lightning.core.mixins.device_dtype_mixin import DeviceDtypeModuleMixin
 from pytorch_lightning.demos.boring_classes import BoringModel, RandomDataset
 from pytorch_lightning.lite import LightningLite
@@ -283,3 +284,12 @@ def test_lite_convert_deprecated_tpus_argument(*_):
         lite = EmptyLite(tpu_cores=8)
     assert isinstance(lite._accelerator, LiteTPUAccelerator)
     assert lite._connector._parallel_devices == list(range(8))
+
+
+@pytest.mark.parametrize(
+    ["name", "value"],
+    [("save_config_filename", "config.yaml"), ("save_config_overwrite", False), ("save_config_multifile", False)],
+)
+def test_lightningCLI_save_config_init_params_deprecation_warning(name, value):
+    with mock.patch("sys.argv", ["any.py"]), pytest.deprecated_call(match=f".*{name!r} init parameter is deprecated.*"):
+        LightningCLI(BoringModel, run=False, **{name: value})

--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -509,7 +509,7 @@ def test_cli_config_overwrite(tmpdir):
     with mock.patch("sys.argv", argv), pytest.raises(RuntimeError, match="Aborting to avoid overwriting"):
         LightningCLI(BoringModel, trainer_defaults=trainer_defaults)
     with mock.patch("sys.argv", argv):
-        LightningCLI(BoringModel, save_config_overwrite=True, trainer_defaults=trainer_defaults)
+        LightningCLI(BoringModel, save_config_kwargs={"overwrite": True}, trainer_defaults=trainer_defaults)
 
 
 @pytest.mark.parametrize("run", (False, True))


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Implements suggestion in https://github.com/Lightning-AI/lightning/issues/14628#issuecomment-1251241125. Does not close that issue, but it makes it possible for people to implement by themselves. 

This has the benefits that:
- We remove duplications of parameters that were in both `SaveConfigCallback` and in `LightningCLI.__init__`.
- Makes it possible for people to subclass `SaveConfigCallback` adding new parameters, and allow these be given on `LightningCLI` instantiation.

Currently the save of the config is not even mentioned in the docs. The pull requests https://github.com/Lightning-AI/lightning/pull/14976 adds it. Could be that this is added to the docs in that pull request.

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->
`SaveConfigCallback` parameters in `LightningCLI` instantiation must now be given in `save_config_kwargs`, and making `save_config_kwargs`, `save_config_overwrite` and `save_config_multifile` deprecated.

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
