### PR TITLE
Use `torch.testing.assert_close` everywhere

### DIFF
--- a/tests/tests_pytorch/callbacks/progress/test_tqdm_progress_bar.py
+++ b/tests/tests_pytorch/callbacks/progress/test_tqdm_progress_bar.py
@@ -30,13 +30,7 @@ from pytorch_lightning.callbacks.progress.tqdm_progress import Tqdm
 from pytorch_lightning.core.module import LightningModule
 from pytorch_lightning.demos.boring_classes import BoringModel, RandomDataset
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
-from pytorch_lightning.utilities.imports import _TORCH_GREATER_EQUAL_1_12
 from tests_pytorch.helpers.runif import RunIf
-
-if _TORCH_GREATER_EQUAL_1_12:
-    torch_test_assert_close = torch.testing.assert_close
-else:
-    torch_test_assert_close = torch.testing.assert_allclose
 
 
 class MockTqdm(Tqdm):
@@ -421,7 +415,7 @@ def test_tensor_to_float_conversion(tmpdir):
     )
     trainer.fit(TestModel())
 
-    torch_test_assert_close(trainer.progress_bar_metrics["a"], 0.123)
+    torch.testing.assert_close(trainer.progress_bar_metrics["a"], 0.123)
     assert trainer.progress_bar_metrics["b"] == {"b1": 1.0}
     assert trainer.progress_bar_metrics["c"] == {"c1": 2.0}
     pbar = trainer.progress_bar_callback.main_progress_bar

--- a/tests/tests_pytorch/plugins/test_amp_plugins.py
+++ b/tests/tests_pytorch/plugins/test_amp_plugins.py
@@ -22,14 +22,8 @@ from pytorch_lightning import Trainer
 from pytorch_lightning.demos.boring_classes import BoringModel
 from pytorch_lightning.plugins import ApexMixedPrecisionPlugin, NativeMixedPrecisionPlugin
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
-from pytorch_lightning.utilities.imports import _TORCH_GREATER_EQUAL_1_12
 from tests_pytorch.conftest import mock_cuda_count
 from tests_pytorch.helpers.runif import RunIf
-
-if _TORCH_GREATER_EQUAL_1_12:
-    torch_test_assert_close = torch.testing.assert_close
-else:
-    torch_test_assert_close = torch.testing.assert_allclose
 
 
 class MyNativeAMP(NativeMixedPrecisionPlugin):
@@ -104,13 +98,13 @@ class TestPrecisionModel(BoringModel):
         grads = [p.grad for p in self.parameters()]
         assert len(grads) == len(self.original_grads)
         for actual, expected in zip(grads, self.original_grads):
-            torch_test_assert_close(actual, expected, equal_nan=True)
+            torch.testing.assert_close(actual, expected, equal_nan=True)
 
     def check_grads_clipped(self):
         parameters = list(self.parameters())
         assert len(parameters) == len(self.clipped_parameters)
         for actual, expected in zip(parameters, self.clipped_parameters):
-            torch_test_assert_close(actual.grad, expected.grad, equal_nan=True)
+            torch.testing.assert_close(actual.grad, expected.grad, equal_nan=True)
 
     def on_before_optimizer_step(self, optimizer, *_):
         self.check_grads_unscaled(optimizer)

--- a/tests/tests_pytorch/strategies/test_common.py
+++ b/tests/tests_pytorch/strategies/test_common.py
@@ -19,15 +19,9 @@ from lightning_lite.utilities.seed import seed_everything
 from pytorch_lightning import Trainer
 from pytorch_lightning.demos.boring_classes import BoringModel
 from pytorch_lightning.strategies import DDPStrategy
-from pytorch_lightning.utilities.imports import _TORCH_GREATER_EQUAL_1_12
 from tests_pytorch.helpers.datamodules import ClassifDataModule
 from tests_pytorch.helpers.runif import RunIf
 from tests_pytorch.strategies.test_dp import CustomClassificationModelDP
-
-if _TORCH_GREATER_EQUAL_1_12:
-    torch_test_assert_close = torch.testing.assert_close
-else:
-    torch_test_assert_close = torch.testing.assert_allclose
 
 
 @pytest.mark.parametrize(
@@ -58,7 +52,7 @@ def test_evaluate(tmpdir, trainer_kwargs):
 
     # make sure weights didn't change
     new_weights = model.layer_0.weight.clone().detach().cpu()
-    torch_test_assert_close(old_weights, new_weights)
+    torch.testing.assert_close(old_weights, new_weights)
 
 
 def test_model_parallel_setup_called(tmpdir):

--- a/tests/tests_pytorch/trainer/optimization/test_manual_optimization.py
+++ b/tests/tests_pytorch/trainer/optimization/test_manual_optimization.py
@@ -25,13 +25,7 @@ from pytorch_lightning import seed_everything, Trainer
 from pytorch_lightning.demos.boring_classes import BoringModel
 from pytorch_lightning.plugins.precision.apex_amp import ApexMixedPrecisionPlugin
 from pytorch_lightning.strategies import Strategy
-from pytorch_lightning.utilities.imports import _TORCH_GREATER_EQUAL_1_12
 from tests_pytorch.helpers.runif import RunIf
-
-if _TORCH_GREATER_EQUAL_1_12:
-    torch_test_assert_close = torch.testing.assert_close
-else:
-    torch_test_assert_close = torch.testing.assert_allclose
 
 
 class ManualOptModel(BoringModel):
@@ -461,7 +455,7 @@ def test_multiple_optimizers_step(tmpdir):
             grads = [p.grad for p in self.parameters()]
             assert len(grads) == len(self.original_grads)
             for actual, expected in zip(grads, self.original_grads):
-                torch_test_assert_close(actual, expected)
+                torch.testing.assert_close(actual, expected)
 
         def on_before_optimizer_step(self, optimizer, *_):
             self.check_grads_unscaled(optimizer)

--- a/tests/tests_pytorch/trainer/optimization/test_multiple_optimizers.py
+++ b/tests/tests_pytorch/trainer/optimization/test_multiple_optimizers.py
@@ -17,12 +17,6 @@ import torch
 
 import pytorch_lightning as pl
 from pytorch_lightning.demos.boring_classes import BoringModel
-from pytorch_lightning.utilities.imports import _TORCH_GREATER_EQUAL_1_12
-
-if _TORCH_GREATER_EQUAL_1_12:
-    torch_test_assert_close = torch.testing.assert_close
-else:
-    torch_test_assert_close = torch.testing.assert_allclose
 
 
 class MultiOptModel(BoringModel):
@@ -58,7 +52,7 @@ def test_unbalanced_logging_with_multiple_optimizers(tmpdir):
     for k, v in model.actual.items():
         assert torch.equal(trainer.callback_metrics[f"loss_{k}_step"], v[-1])
         # test loss is properly reduced
-        torch_test_assert_close(trainer.callback_metrics[f"loss_{k}_epoch"], torch.tensor(v).mean())
+        torch.testing.assert_close(trainer.callback_metrics[f"loss_{k}_epoch"], torch.tensor(v).mean())
 
 
 def test_multiple_optimizers(tmpdir):

--- a/tests/tests_pytorch/trainer/test_trainer.py
+++ b/tests/tests_pytorch/trainer/test_trainer.py
@@ -61,7 +61,7 @@ from pytorch_lightning.strategies import (
 )
 from pytorch_lightning.trainer.states import RunningStage, TrainerFn
 from pytorch_lightning.utilities.exceptions import DeadlockDetectedException, MisconfigurationException
-from pytorch_lightning.utilities.imports import _OMEGACONF_AVAILABLE, _TORCH_GREATER_EQUAL_1_12
+from pytorch_lightning.utilities.imports import _OMEGACONF_AVAILABLE
 from tests_pytorch.conftest import mock_cuda_count, mock_mps_count
 from tests_pytorch.helpers.datamodules import ClassifDataModule
 from tests_pytorch.helpers.runif import RunIf
@@ -69,11 +69,6 @@ from tests_pytorch.helpers.simple_models import ClassificationModel
 
 if _OMEGACONF_AVAILABLE:
     from omegaconf import OmegaConf
-
-if _TORCH_GREATER_EQUAL_1_12:
-    torch_test_assert_close = torch.testing.assert_close
-else:
-    torch_test_assert_close = torch.testing.assert_allclose
 
 
 def test_trainer_error_when_input_not_lightning_module():
@@ -1125,7 +1120,7 @@ def test_gradient_clipping_by_norm(tmpdir, precision):
             # test that gradient is clipped correctly
             parameters = self.parameters()
             grad_norm = torch.norm(torch.stack([torch.norm(p.grad.detach(), 2) for p in parameters]), 2)
-            torch_test_assert_close(grad_norm, torch.tensor(0.05, device=self.device))
+            torch.testing.assert_close(grad_norm, torch.tensor(0.05, device=self.device))
             self.assertion_called = True
 
     model = TestModel()
@@ -1156,7 +1151,7 @@ def test_gradient_clipping_by_value(tmpdir, precision):
             parameters = self.parameters()
             grad_max_list = [torch.max(p.grad.detach().abs()) for p in parameters]
             grad_max = torch.max(torch.stack(grad_max_list))
-            torch_test_assert_close(grad_max.abs(), torch.tensor(1e-10, device=self.device))
+            torch.testing.assert_close(grad_max.abs(), torch.tensor(1e-10, device=self.device))
             self.assertion_called = True
 
     model = TestModel()

--- a/tests/tests_pytorch/utilities/test_auto_restart.py
+++ b/tests/tests_pytorch/utilities/test_auto_restart.py
@@ -55,14 +55,9 @@ from pytorch_lightning.utilities.auto_restart import (
 from pytorch_lightning.utilities.enums import _FaultTolerantMode, AutoRestartBatchKeys
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.fetching import DataFetcher
-from pytorch_lightning.utilities.imports import _fault_tolerant_training, _TORCH_GREATER_EQUAL_1_12
+from pytorch_lightning.utilities.imports import _fault_tolerant_training
 from tests_pytorch.core.test_results import spawn_launch
 from tests_pytorch.helpers.runif import RunIf
-
-if _TORCH_GREATER_EQUAL_1_12:
-    torch_test_assert_close = torch.testing.assert_close
-else:
-    torch_test_assert_close = torch.testing.assert_allclose
 
 
 def test_fast_forward_getattr():
@@ -946,9 +941,9 @@ def test_auto_restart_within_validation_loop(train_datasets, val_datasets, val_c
     pre_fail_train_batches, pre_fail_val_batches = run(should_fail=True, resume=False)
     post_fail_train_batches, post_fail_val_batches = run(should_fail=False, resume=True)
 
-    torch_test_assert_close(total_train_batches, pre_fail_train_batches + post_fail_train_batches)
+    torch.testing.assert_close(total_train_batches, pre_fail_train_batches + post_fail_train_batches)
     for k in total_val_batches:
-        torch_test_assert_close(total_val_batches[k], pre_fail_val_batches[k] + post_fail_val_batches[k])
+        torch.testing.assert_close(total_val_batches[k], pre_fail_val_batches[k] + post_fail_val_batches[k])
 
 
 class TestAutoRestartModelUnderSignal(BoringModel):
@@ -1482,6 +1477,6 @@ def test_fault_tolerant_manual_mode(val_check_interval, train_dataset_cls, val_d
     trainer.train_dataloader = None
     restart_batches = model.batches
 
-    torch_test_assert_close(total_batches, failed_batches + restart_batches)
+    torch.testing.assert_close(total_batches, failed_batches + restart_batches)
     assert not torch.equal(total_weight, failed_weight)
     assert torch.equal(total_weight, model.layer.weight)


### PR DESCRIPTION
## What does this PR do?

In the PR https://github.com/Lightning-AI/lightning/pull/13123#discussion_r881498811, we introduced a convention of checking for version to use torch-version-appropriate function for checking closeness of tensors. However, according to https://github.com/pytorch/pytorch/issues/61844, the `torch.testing.assert_close` was introduced in `1.9`, therefore we should be able to call it in all versions we currently support.

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @carmocca @akihironitta @borda