### PR TITLE
Fix Broken Link in `lightning_app.core.work.LightningWork`

### DIFF
--- a/src/lightning_app/core/work.py
+++ b/src/lightning_app/core/work.py
@@ -90,7 +90,7 @@ class LightningWork:
             :header: The Lightning Work inner workings.
             :description: Learn more Lightning Work.
             :col_css: col-md-4
-            :button_link: ../../../core_api/lightning_work/index.html
+            :button_link: ../../core_api/lightning_work/index.html
             :height: 180
             :tag: Basic
 


### PR DESCRIPTION
## What does this PR do?

There is an issue accessing the `displayitem` in the link 
https://lightning.ai/lightning-docs/core_api/lightning_work/lightning_work.html

Leading to an Error 
<img width="422" alt="image" src="https://user-images.githubusercontent.com/4648995/194575533-277f5ab1-537b-4d67-a1c3-9dbb41749839.png">


### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
cc: @manskx @otaj 