### PR TITLE
Support Slurm Autorequeue for Array Jobs

### DIFF
--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added support for requeueing slurm array jobs ([#15022](https://github.com/Lightning-AI/lightning/issues/15022))
+
+
 - Added native AMP support for `ddp_fork` (and associated alias strategies) with CUDA GPUs ([#14983](https://github.com/Lightning-AI/lightning/pull/14983))
 
 

--- a/src/pytorch_lightning/trainer/connectors/signal_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/signal_connector.py
@@ -78,7 +78,13 @@ class SignalConnector:
 
         if self.trainer.is_global_zero:
             # find job id
-            job_id = os.environ["SLURM_JOB_ID"]
+            array_job_id = os.getenv("SLURM_ARRAY_JOB_ID")
+            if array_job_id is not None:
+                array_task_id = os.environ["SLURM_ARRAY_TASK_ID"]
+                job_id = f"{array_job_id}_{array_task_id}"
+            else:
+                job_id = os.environ["SLURM_JOB_ID"]
+
             cmd = ["scontrol", "requeue", job_id]
 
             # requeue job

--- a/tests/tests_pytorch/trainer/connectors/test_signal_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_signal_connector.py
@@ -100,6 +100,36 @@ def test_auto_requeue_custom_signal_flag(auto_requeue, requeue_signal):
     connector.teardown()
 
 
+@mock.patch("pytorch_lightning.trainer.connectors.signal_connector.call", mock.MagicMock(return_value=0))
+@mock.patch("pytorch_lightning.trainer.Trainer.save_checkpoint", mock.MagicMock())
+@mock.patch.dict(os.environ, {"SLURM_JOB_ID": "12345"})
+def test_auto_requeue_job():
+    from pytorch_lightning.trainer.connectors.signal_connector import call
+
+    trainer = Trainer(plugins=[SLURMEnvironment()])
+    connector = SignalConnector(trainer)
+    connector.slurm_sigusr_handler_fn(signal.SIGUSR1, None)
+
+    assert call.call_args_list[0].args[0] == ["scontrol", "requeue", "12345"]
+
+    connector.teardown()
+
+
+@mock.patch("pytorch_lightning.trainer.connectors.signal_connector.call", mock.MagicMock(return_value=0))
+@mock.patch("pytorch_lightning.trainer.Trainer.save_checkpoint", mock.MagicMock())
+@mock.patch.dict(os.environ, {"SLURM_JOB_ID": "12345", "SLURM_ARRAY_JOB_ID": "12345", "SLURM_ARRAY_TASK_ID": "1"})
+def test_auto_requeue_array_job():
+    from pytorch_lightning.trainer.connectors.signal_connector import call
+
+    trainer = Trainer(plugins=[SLURMEnvironment()])
+    connector = SignalConnector(trainer)
+    connector.slurm_sigusr_handler_fn(signal.SIGUSR1, None)
+
+    assert call.call_args_list[0].args[0] == ["scontrol", "requeue", "12345_1"]
+
+    connector.teardown()
+
+
 def _registering_signals():
     trainer = Trainer()
     trainer._signal_connector.register_signal_handlers()

--- a/tests/tests_pytorch/trainer/connectors/test_signal_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_signal_connector.py
@@ -100,6 +100,7 @@ def test_auto_requeue_custom_signal_flag(auto_requeue, requeue_signal):
     connector.teardown()
 
 
+@RunIf(skip_windows=True)
 @mock.patch("pytorch_lightning.trainer.connectors.signal_connector.call", mock.MagicMock(return_value=0))
 @mock.patch("pytorch_lightning.trainer.Trainer.save_checkpoint", mock.MagicMock())
 @mock.patch.dict(os.environ, {"SLURM_JOB_ID": "12345"})
@@ -115,6 +116,7 @@ def test_auto_requeue_job():
     connector.teardown()
 
 
+@RunIf(skip_windows=True)
 @mock.patch("pytorch_lightning.trainer.connectors.signal_connector.call", mock.MagicMock(return_value=0))
 @mock.patch("pytorch_lightning.trainer.Trainer.save_checkpoint", mock.MagicMock())
 @mock.patch.dict(os.environ, {"SLURM_JOB_ID": "12346", "SLURM_ARRAY_JOB_ID": "12345", "SLURM_ARRAY_TASK_ID": "2"})

--- a/tests/tests_pytorch/trainer/connectors/test_signal_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_signal_connector.py
@@ -117,7 +117,7 @@ def test_auto_requeue_job():
 
 @mock.patch("pytorch_lightning.trainer.connectors.signal_connector.call", mock.MagicMock(return_value=0))
 @mock.patch("pytorch_lightning.trainer.Trainer.save_checkpoint", mock.MagicMock())
-@mock.patch.dict(os.environ, {"SLURM_JOB_ID": "12345", "SLURM_ARRAY_JOB_ID": "12345", "SLURM_ARRAY_TASK_ID": "1"})
+@mock.patch.dict(os.environ, {"SLURM_JOB_ID": "12346", "SLURM_ARRAY_JOB_ID": "12345", "SLURM_ARRAY_TASK_ID": "2"})
 def test_auto_requeue_array_job():
     from pytorch_lightning.trainer.connectors.signal_connector import call
 
@@ -125,7 +125,7 @@ def test_auto_requeue_array_job():
     connector = SignalConnector(trainer)
     connector.slurm_sigusr_handler_fn(signal.SIGUSR1, None)
 
-    assert call.call_args_list[0].args[0] == ["scontrol", "requeue", "12345_1"]
+    assert call.call_args_list[0].args[0] == ["scontrol", "requeue", "12345_2"]
 
     connector.teardown()
 

--- a/tests/tests_pytorch/trainer/connectors/test_signal_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_signal_connector.py
@@ -105,33 +105,24 @@ def test_auto_requeue_custom_signal_flag(auto_requeue, requeue_signal):
 @mock.patch("pytorch_lightning.trainer.Trainer.save_checkpoint", mock.MagicMock())
 @mock.patch.dict(os.environ, {"SLURM_JOB_ID": "12345"})
 def test_auto_requeue_job(call_mock):
-    # from pytorch_lightning.trainer.connectors.signal_connector import call
     call_mock.return_value = 0
-
     trainer = Trainer(plugins=[SLURMEnvironment()])
     connector = SignalConnector(trainer)
-    connector.slurm_sigusr_handler_fn(signal.SIGUSR1, None)
-
-    print("list", call_mock.call_args_list[0])
-    print("args", call_mock.call_args_list[0].args)
-    assert call_mock.call_args_list[0].args[0] == ["scontrol", "requeue", "12345"]
-
+    connector.slurm_sigusr_handler_fn(None, None)
+    call_mock.assert_called_once_with(["scontrol", "requeue", "12345"])
     connector.teardown()
 
 
 @RunIf(skip_windows=True)
-@mock.patch("pytorch_lightning.trainer.connectors.signal_connector.call", mock.MagicMock(return_value=0))
+@mock.patch("pytorch_lightning.trainer.connectors.signal_connector.call")
 @mock.patch("pytorch_lightning.trainer.Trainer.save_checkpoint", mock.MagicMock())
 @mock.patch.dict(os.environ, {"SLURM_JOB_ID": "12346", "SLURM_ARRAY_JOB_ID": "12345", "SLURM_ARRAY_TASK_ID": "2"})
-def test_auto_requeue_array_job():
-    from pytorch_lightning.trainer.connectors.signal_connector import call
-
+def test_auto_requeue_array_job(call_mock):
+    call_mock.return_value = 0
     trainer = Trainer(plugins=[SLURMEnvironment()])
     connector = SignalConnector(trainer)
-    connector.slurm_sigusr_handler_fn(signal.SIGUSR1, None)
-
-    assert call.call_args_list[0].args[0] == ["scontrol", "requeue", "12345_2"]
-
+    connector.slurm_sigusr_handler_fn(None, None)
+    call_mock.assert_called_once_with(["scontrol", "requeue", "12345_2"])
     connector.teardown()
 
 

--- a/tests/tests_pytorch/trainer/connectors/test_signal_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_signal_connector.py
@@ -101,17 +101,20 @@ def test_auto_requeue_custom_signal_flag(auto_requeue, requeue_signal):
 
 
 @RunIf(skip_windows=True)
-@mock.patch("pytorch_lightning.trainer.connectors.signal_connector.call", mock.MagicMock(return_value=0))
+@mock.patch("pytorch_lightning.trainer.connectors.signal_connector.call")
 @mock.patch("pytorch_lightning.trainer.Trainer.save_checkpoint", mock.MagicMock())
 @mock.patch.dict(os.environ, {"SLURM_JOB_ID": "12345"})
-def test_auto_requeue_job():
-    from pytorch_lightning.trainer.connectors.signal_connector import call
+def test_auto_requeue_job(call_mock):
+    # from pytorch_lightning.trainer.connectors.signal_connector import call
+    call_mock.return_value = 0
 
     trainer = Trainer(plugins=[SLURMEnvironment()])
     connector = SignalConnector(trainer)
     connector.slurm_sigusr_handler_fn(signal.SIGUSR1, None)
 
-    assert call.call_args_list[0].args[0] == ["scontrol", "requeue", "12345"]
+    print("list", call_mock.call_args_list[0])
+    print("args", call_mock.call_args_list[0].args)
+    assert call_mock.call_args_list[0].args[0] == ["scontrol", "requeue", "12345"]
 
     connector.teardown()
 


### PR DESCRIPTION
## What does this PR do?

This PR adds support for autorequeueing slurm array jobs. 

Array jobs are groups of jobs which are grouped in some meaningful way. Slurm provides facilities to quickly (i.e. with less load on the scheduler) create such jobs. 

These jobs behave slightly differently from regular jobs. 

Although they have `SLURM_JOB_ID` set, and it is unique for each job in the array, some commands, notably `scontrol`, differ in their meaning when the `JOB_ID` is used vs. the array specific `SLURM_ARRAY_JOB_ID` and `SLURM_ARRAY_TASK_ID`. For example, if `scontrol` is called with the `SLURM_JOB_ID` of the "parent job" it will apply the `scontrol` command to all array jobs. In order to requeue (for example) only a specific array job, the string `<array job id>_<array_task_id>` needs to be used.

For example if a job has `JOB_ID` 1234, the first array job will have `ARRAY_JOB_ID` 1234 and `TASK_ID` 1 and the second job will have `JOB_ID` 1235 `ARRAY_JOB_ID` 1234 and `TASK_ID` 2. In this case  `scontrol requeue 1234`  would requeue both jobs in the array. `scontrol requeue 1234_1` would requeue only the first job in the array and `scontrol requeue 1234_2` would requeue only the second.

Since lightning was only checking the `JOB_ID` this was causing it to prematurely requeue some array jobs. This was causing lots of weird issues like failed requeues and timeouts with no requeue attempted. 

Fixes #15022

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
