### PR TITLE
[Lite] Force tests to manage their envvars

### DIFF
--- a/tests/tests_lite/conftest.py
+++ b/tests/tests_lite/conftest.py
@@ -40,22 +40,6 @@ def restore_env_variables():
     # restore environment as it was before running the test
     os.environ.clear()
     os.environ.update(env_backup)
-    # these are currently known leakers - ideally these would not be allowed
-    # TODO(lite): this list can be trimmed, maybe PL's too after moving tests
-    allowlist = {
-        "CUDA_DEVICE_ORDER",
-        "LOCAL_RANK",
-        "NODE_RANK",
-        "WORLD_SIZE",
-        "MASTER_ADDR",
-        "MASTER_PORT",
-        "PL_GLOBAL_SEED",
-        "PL_SEED_WORKERS",
-        "HOROVOD_FUSION_THRESHOLD",
-        "RANK",  # set by DeepSpeed
-        "POPLAR_ENGINE_OPTIONS",  # set by IPUStrategy
-    }
-    leaked_vars.difference_update(allowlist)
     assert not leaked_vars, f"test is leaking environment variable(s): {set(leaked_vars)}"
 
 


### PR DESCRIPTION
## What does this PR do?

Having an allowlist defeats the purpose of this fixture. We should remove it and have tests clean up after themselves

### Does your PR introduce any breaking changes? If yes, please list them.

None
