### PR TITLE
Exclude Graveyard from noqa

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
         exclude: |
             (?x)^(
                 src/pytorch_lightning/_graveyard
-                
+
             )$
 
   - repo: https://github.com/PyCQA/isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,6 @@ repos:
         exclude: |
             (?x)^(
                 src/pytorch_lightning/_graveyard
-
             )$
 
   - repo: https://github.com/PyCQA/isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,11 @@ repos:
     hooks:
       - id: yesqa
         name: Unused noqa
+        exclude: |
+            (?x)^(
+                src/pytorch_lightning/_graveyard
+                
+            )$
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1


### PR DESCRIPTION
## What does this PR do?

excludes noqa fixes for graveyard as these are not used at import but actually do some patching.

cc @borda