### PR TITLE
Fix locally failing lite tests

### DIFF
--- a/tests/tests_lite/plugins/precision/test_deepspeed.py
+++ b/tests/tests_lite/plugins/precision/test_deepspeed.py
@@ -57,7 +57,7 @@ def test_deepspeed_engine_is_steppable():
     """
     from deepspeed import DeepSpeedEngine
 
-    engine = DeepSpeedEngine(Mock(), Mock())
+    engine = DeepSpeedEngine(Mock(), Mock(named_modules=lambda : [(Mock(), Mock())], named_parameters=lambda: [(Mock(), Mock())]))
     assert isinstance(engine, Steppable)
 
 

--- a/tests/tests_lite/plugins/precision/test_deepspeed_integration.py
+++ b/tests/tests_lite/plugins/precision/test_deepspeed_integration.py
@@ -27,7 +27,7 @@ def test_deepspeed_precision_choice(precision, tmpdir):
     DeepSpeed handles precision via custom DeepSpeedPrecision.
     """
     connector = _Connector(
-        accelerator="gpu",
+        accelerator="auto",
         strategy="deepspeed",
         precision=precision,
     )


### PR DESCRIPTION
- Change accelerator to `'auto'` for precision integration test to avoid assumption on gpus for precision checks
- More explicitly mock module methods for deepspeed as `named_modules` and `named_parameters` need to return iterables of tuples