### PR TITLE
Check if GPU isn't being used by another process

### DIFF
--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -35,7 +35,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added a more descriptive error message when attempting to fork processes with pre-initialized CUDA context ([#14709](https://github.com/Lightning-AI/lightning/pull/14709))
 - Added support for custom parameters in subclasses of `SaveConfigCallback` ([#14998](https://github.com/Lightning-AI/lightning/pull/14998))
 - Added `inference_mode` flag to Trainer to let users enable/disable inference mode during evaluation ([#15034](https://github.com/Lightning-AI/lightning/pull/15034))
-- Added fix to auto_select_gpus to make it choose gpu's without any memory allocated to them. ([#15173](https://github.com/Lightning-AI/lightning/pull/15173))
 
 
 ### Changed
@@ -61,6 +60,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - It is no longer needed to call `model.double()` when using `precision=64` in Lightning Lite ([#14827](https://github.com/Lightning-AI/lightning/pull/14827))
 - HPC checkpoints are now loaded automatically only in slurm environment when no specific value for `ckpt_path` has been set ([#14911](https://github.com/Lightning-AI/lightning/pull/14911))
 - The `Callback.on_load_checkpoint` now gets the full checkpoint dictionary and the `callback_state` argument was renamed `checkpoint` ([#14835](https://github.com/Lightning-AI/lightning/pull/14835))
+- Added fix to auto_select_gpus to make it choose gpu's without any memory allocated to them. ([#15173](https://github.com/Lightning-AI/lightning/pull/15173))
 
 
 - From PyTorch 1.14 and higher, Lightning will configure PyTorch to use a NVML-based check for `torch.cuda.is_available` and `torch.cuda.device_count` to avoid issues with forking processes ([#15110](https://github.com/Lightning-AI/lightning/pull/15110))

--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added a more descriptive error message when attempting to fork processes with pre-initialized CUDA context ([#14709](https://github.com/Lightning-AI/lightning/pull/14709))
 - Added support for custom parameters in subclasses of `SaveConfigCallback` ([#14998](https://github.com/Lightning-AI/lightning/pull/14998))
 - Added `inference_mode` flag to Trainer to let users enable/disable inference mode during evaluation ([#15034](https://github.com/Lightning-AI/lightning/pull/15034))
+- Added fix to auto_select_gpus to make it choose gpu's without any memory allocated to them. ([#15173](https://github.com/Lightning-AI/lightning/pull/15173))
 
 
 ### Changed

--- a/src/pytorch_lightning/tuner/auto_gpu_select.py
+++ b/src/pytorch_lightning/tuner/auto_gpu_select.py
@@ -55,11 +55,12 @@ def pick_single_gpu(exclude_gpus: List[int]) -> int:
     for i in range(num_cuda_devices()):
         if i in exclude_gpus:
             continue
+        device = torch.device(f"{cuda:{i}")
         # Check if the device has memory used by another torch process
-        if torch.cuda.memory_usage(f"cuda:{i}") > 0:
+        if torch.cuda.memory_usage(device) > 0 and torch.cuda.utilization(device)
             continue
 
-        if torch.cuda.memory_reserved(f"cuda:{i}") > 0:
+        if torch.cuda.memory_reserved(device) > 0:
             previously_used_gpus.append(i)
         else:
             unused_gpus.append(i)
@@ -67,7 +68,6 @@ def pick_single_gpu(exclude_gpus: List[int]) -> int:
     # Prioritize previously used GPUs
     for i in previously_used_gpus + unused_gpus:
         # Try to allocate on device:
-        device = torch.device(f"cuda:{i}")
         try:
             torch.ones(1).to(device)
         except RuntimeError:

--- a/src/pytorch_lightning/tuner/auto_gpu_select.py
+++ b/src/pytorch_lightning/tuner/auto_gpu_select.py
@@ -55,6 +55,9 @@ def pick_single_gpu(exclude_gpus: List[int]) -> int:
     for i in range(num_cuda_devices()):
         if i in exclude_gpus:
             continue
+        # Check if the device has memory used by another torch process
+        if torch.cuda.memory_usage(f"cuda:{i}") > 0:
+            continue
 
         if torch.cuda.memory_reserved(f"cuda:{i}") > 0:
             previously_used_gpus.append(i)

--- a/src/pytorch_lightning/tuner/auto_gpu_select.py
+++ b/src/pytorch_lightning/tuner/auto_gpu_select.py
@@ -55,9 +55,9 @@ def pick_single_gpu(exclude_gpus: List[int]) -> int:
     for i in range(num_cuda_devices()):
         if i in exclude_gpus:
             continue
-        device = torch.device(f"{cuda:{i}")
+        device = torch.device(f"cuda:{i}")
         # Check if the device has memory used by another torch process
-        if torch.cuda.memory_usage(device) > 0 and torch.cuda.utilization(device)
+        if torch.cuda.memory_usage(device) > 0 and torch.cuda.utilization(device):
             continue
 
         if torch.cuda.memory_reserved(device) > 0:

--- a/src/pytorch_lightning/tuner/auto_gpu_select.py
+++ b/src/pytorch_lightning/tuner/auto_gpu_select.py
@@ -57,7 +57,7 @@ def pick_single_gpu(exclude_gpus: List[int]) -> int:
             continue
         device = torch.device(f"cuda:{i}")
         # Check if the device has memory used by another torch process
-        if torch.cuda.memory_usage(device) > 0 and torch.cuda.utilization(device):
+        if torch.cuda.memory_usage(device) > 0 and torch.cuda.utilization(device) > 0:
             continue
 
         if torch.cuda.memory_reserved(device) > 0:


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->
Adds a small check to see if the GPU isn't being used by any other torch process. 

This allows Trainer.auto_select_gpus to work as expected.

Suprised no one caught this :rofl: 

### Does your PR introduce any breaking changes? If yes, please list them.

No

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->