### PR TITLE
Proper check for availability of bagua

### DIFF
--- a/src/pytorch_lightning/strategies/bagua.py
+++ b/src/pytorch_lightning/strategies/bagua.py
@@ -16,7 +16,7 @@ import os
 from typing import Any, Dict, List, Optional, Union
 
 import torch
-from lightning_utilities.core.imports import package_available
+from lightning_utilities.core.imports import module_available
 from torch import Tensor
 from torch.nn import Module
 
@@ -32,7 +32,7 @@ from pytorch_lightning.strategies.strategy import TBroadcast
 from pytorch_lightning.trainer.states import TrainerFn
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 
-_BAGUA_AVAILABLE = package_available("bagua")
+_BAGUA_AVAILABLE = module_available("bagua.torch_api")
 
 if _BAGUA_AVAILABLE:
     import bagua.torch_api as bagua


### PR DESCRIPTION
Discovered during #15122, that our check for availability of `package_available("bagua")` is not strong enough and somehow it can happen, that `package_available("bagua") != module_available("bagua.torch_api")`.

Given that we're interested in `module_available("bagua.torch_api")` since that's from where we're importing, this replaces such check.

cc @borda @justusschock 