### PR TITLE
Optimize required checks when Lite tests are modified

### DIFF
--- a/.github/checkgroup.yml
+++ b/.github/checkgroup.yml
@@ -152,7 +152,6 @@ subprojects:
     paths:
       - "requirements/lite/**"
       - "src/lightning_lite/**"
-      - "tests/tests_lite/**"
       - "setup.cfg"  # includes pytest config
       - ".actions/**"
     checks:
@@ -193,10 +192,26 @@ subprojects:
       - "pl-slow (windows-2022, 3.7, 1.11)"
       #- "test-on-tpus"
 
+  - id: "lightning_lite: Tests"
+    paths:
+      - "tests/tests_lite/**"
+    checks:
+      - "lite-cpu (macOS-11, 3.10, latest, stable)"
+      - "lite-cpu (macOS-11, 3.7, latest, stable)"
+      - "lite-cpu (macOS-11, 3.7, oldest, stable)"
+      - "lite-cpu (ubuntu-20.04, 3.10, latest, stable)"
+      - "lite-cpu (ubuntu-20.04, 3.7, latest, stable)"
+      - "lite-cpu (ubuntu-20.04, 3.7, oldest, stable)"
+      - "lite-cpu (windows-2022, 3.10, latest, stable)"
+      - "lite-cpu (windows-2022, 3.7, latest, stable)"
+      - "lite-cpu (windows-2022, 3.7, oldest, stable)"
+      - "lightning-lite (GPUs)"
+
   - id: "lightning_lite: Azure GPU"
     paths:
       - ".azure/gpu-tests-lite.yml"
       - "tests/tests_lite/run_standalone_*.sh"
+      - "tests/tests_pytorch/run_standalone_tests.sh"  # used by Lite through a symlink
     checks:
       - "lightning-lite (GPUs)"
 

--- a/.github/workflows/ci-pytorch-test-full.yml
+++ b/.github/workflows/ci-pytorch-test-full.yml
@@ -15,7 +15,6 @@ on:
       - ".github/workflows/ci-pytorch-test-full.yml"
       - "requirements/lite/**"
       - "src/lightning_lite/**"
-      - "tests/tests_lite/**"
       - ".actions/**"
 
 concurrency:

--- a/.github/workflows/ci-pytorch-test-slow.yml
+++ b/.github/workflows/ci-pytorch-test-slow.yml
@@ -15,7 +15,6 @@ on:
       - "setup.cfg"  # includes pytest config
       - "requirements/lite/**"
       - "src/lightning_lite/**"
-      - "tests/tests_lite/**"
       - ".actions/**"
 
 concurrency:


### PR DESCRIPTION
## What does this PR do?

When Lite tests are modified, we don't need to launch or require PL jobs since they don't depend on Lite's tests

This should really improve the experience of PRs that just touch Lite tests

### Does your PR introduce any breaking changes? If yes, please list them.

None

cc @carmocca @akihironitta @borda @justusschock @awaelchli