### PR TITLE
[LAI] Solve circular imports for combined package

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -5,7 +5,7 @@ pandoc>=1.0, <=2.2
 docutils>=0.16, <0.20
 sphinxcontrib-fulltoc>=1.0, <=1.2.0
 sphinxcontrib-mockautodoc
-sphinx-autodoc-typehints>=1.11, <1.15  # strict; v1.15 failing on master (#11405)
+sphinx-autodoc-typehints>=1.16
 sphinx-paramlinks>=0.5.1, <=0.5.4
 sphinx-togglebutton>=0.2, <=0.3.2
 sphinx-copybutton>=0.3, <=0.5.0

--- a/src/lightning_app/components/python/tracer.py
+++ b/src/lightning_app/components/python/tracer.py
@@ -2,7 +2,9 @@ import os
 import signal
 import sys
 from copy import deepcopy
-from typing import Any, Dict, List, Optional, TypedDict, Union
+from typing import Any, Dict, List, Optional, Union
+
+from typing_extensions import TypedDict
 
 from lightning_app import LightningWork
 from lightning_app.storage.drive import Drive

--- a/src/lightning_app/core/app.py
+++ b/src/lightning_app/core/app.py
@@ -90,6 +90,8 @@ class LightningApp:
 
         self.root_path = root_path  # when running behind a proxy
 
+        import lightning_app
+
         if isinstance(root, lightning_app.LightningWork):
             root = lightning_app.core.flow._RootFlow(root)
 

--- a/src/lightning_app/core/app.py
+++ b/src/lightning_app/core/app.py
@@ -11,7 +11,6 @@ from time import time
 from deepdiff import DeepDiff, Delta
 from lightning_utilities.core.apply_func import apply_to_collection
 
-import lightning_app
 from lightning_app import _console
 from lightning_app.api.request_types import APIRequest, CommandRequest, DeltaRequest
 from lightning_app.core.constants import (
@@ -38,6 +37,7 @@ from lightning_app.utilities.tree import breadth_first
 from lightning_app.utilities.warnings import LightningFlowWarning
 
 if t.TYPE_CHECKING:
+    import lightning_app
     from lightning_app.runners.backends.backend import Backend, WorkManager
 
 logger = Logger(__name__)
@@ -482,6 +482,8 @@ class LightningApp:
         return True
 
     def _update_layout(self) -> None:
+        import lightning_app
+
         if self.backend:
             self.backend.resolve_url(self, base_url=None)
 

--- a/src/lightning_app/core/constants.py
+++ b/src/lightning_app/core/constants.py
@@ -3,8 +3,6 @@ from pathlib import Path
 
 import lightning_cloud.env
 
-import lightning_app
-
 
 def get_lightning_cloud_url() -> str:
     # DO NOT CHANGE!
@@ -39,7 +37,7 @@ HTTP_QUEUE_REFRESH_INTERVAL = float(os.getenv("LIGHTNING_HTTP_QUEUE_REFRESH_INTE
 HTTP_QUEUE_TOKEN = os.getenv("LIGHTNING_HTTP_QUEUE_TOKEN", None)
 
 USER_ID = os.getenv("USER_ID", "1234")
-FRONTEND_DIR = os.path.join(os.path.dirname(lightning_app.__file__), "ui")
+FRONTEND_DIR = str(Path(__file__).parent.parent / "ui")
 PACKAGE_LIGHTNING = os.getenv("PACKAGE_LIGHTNING", None)
 CLOUD_UPLOAD_WARNING = int(os.getenv("CLOUD_UPLOAD_WARNING", "2"))
 DISABLE_DEPENDENCY_CACHE = bool(int(os.getenv("DISABLE_DEPENDENCY_CACHE", "0")))

--- a/src/lightning_app/frontend/streamlit_base.py
+++ b/src/lightning_app/frontend/streamlit_base.py
@@ -10,8 +10,6 @@ from lightning_app.frontend.utils import _reduce_to_flow_scope
 from lightning_app.utilities.app_helpers import StreamLitStatePlugin
 from lightning_app.utilities.state import AppState
 
-app_state = AppState(plugin=StreamLitStatePlugin())
-
 
 def _get_render_fn_from_environment() -> Callable:
     render_fn_name = os.environ["LIGHTNING_RENDER_FUNCTION"]
@@ -22,6 +20,8 @@ def _get_render_fn_from_environment() -> Callable:
 
 def main():
     """Run the render_fn with the current flow_state."""
+    app_state = AppState(plugin=StreamLitStatePlugin())
+
     # Fetch the information of which flow attaches to this streamlit instance
     flow_state = _reduce_to_flow_scope(app_state, flow=os.environ["LIGHTNING_FLOW_NAME"])
 

--- a/src/lightning_app/runners/backends/backend.py
+++ b/src/lightning_app/runners/backends/backend.py
@@ -2,12 +2,11 @@ from abc import ABC, abstractmethod
 from functools import partial
 from typing import Any, Callable, List, Optional, TYPE_CHECKING
 
-import lightning_app
 from lightning_app.core.queues import QueuingSystem
 from lightning_app.utilities.proxies import ProxyWorkRun, unwrap
 
 if TYPE_CHECKING:
-    from lightning_app import LightningApp
+    import lightning_app
 
 
 class Backend(ABC):
@@ -81,7 +80,7 @@ class Backend(ABC):
 
         work.run = partial(self._dynamic_run_wrapper, app=app, work=work, work_run=unwrap(work.run))
 
-    def _prepare_queues(self, app: "LightningApp"):
+    def _prepare_queues(self, app: "lightning_app.LightningApp"):
         kw = dict(queue_id=self.queue_id)
         app.delta_queue = self.queues.get_delta_queue(**kw)
         app.readiness_queue = self.queues.get_readiness_queue(**kw)

--- a/src/lightning_app/runners/backends/cloud.py
+++ b/src/lightning_app/runners/backends/cloud.py
@@ -1,9 +1,11 @@
-from typing import List, Optional
+from typing import List, Optional, TYPE_CHECKING
 
-import lightning_app
 from lightning_app.core.queues import QueuingSystem
 from lightning_app.runners.backends import Backend
 from lightning_app.utilities.network import LightningClient
+
+if TYPE_CHECKING:
+    import lightning_app
 
 
 class CloudBackend(Backend):

--- a/src/lightning_app/runners/runtime.py
+++ b/src/lightning_app/runners/runtime.py
@@ -3,10 +3,9 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from threading import Thread
-from typing import Any, Callable, Dict, List, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Type, TYPE_CHECKING, Union
 
-import lightning_app
-from lightning_app import LightningApp
+from lightning_app import LightningApp, LightningFlow
 from lightning_app.core.constants import APP_SERVER_HOST, APP_SERVER_PORT
 from lightning_app.runners.backends import Backend, BackendType
 from lightning_app.utilities.app_helpers import Logger
@@ -15,6 +14,9 @@ from lightning_app.utilities.load_app import load_app_from_file
 from lightning_app.utilities.proxies import WorkRunner
 
 logger = Logger(__name__)
+
+if TYPE_CHECKING:
+    import lightning_app
 
 
 def dispatch(
@@ -95,7 +97,7 @@ class Runtime:
         if isinstance(self.backend, str):
             self.backend = BackendType(self.backend).get_backend(self.entrypoint_file)
 
-        lightning_app.LightningFlow._attach_backend(self.app.root, self.backend)
+        LightningFlow._attach_backend(self.app.root, self.backend)
 
     def terminate(self) -> None:
         """This method is used to terminate all the objects (threads, processes, etc..) created by the app."""

--- a/src/lightning_app/storage/copier.py
+++ b/src/lightning_app/storage/copier.py
@@ -3,11 +3,10 @@ import pathlib
 import threading
 from threading import Thread
 from time import time
-from typing import Optional, Union
+from typing import Optional, TYPE_CHECKING, Union
 
 from fsspec.implementations.local import LocalFileSystem
 
-import lightning_app
 from lightning_app.core.queues import BaseQueue
 from lightning_app.storage.path import filesystem
 from lightning_app.storage.requests import ExistsRequest, GetRequest
@@ -18,6 +17,8 @@ _PathRequest = Union[GetRequest, ExistsRequest]
 _logger = Logger(__name__)
 
 num_workers = 8
+if TYPE_CHECKING:
+    import lightning_app
 
 
 class Copier(Thread):
@@ -81,7 +82,7 @@ class Copier(Thread):
         self.copy_response_queue.put(response)
 
 
-def _find_matching_path(work, request: GetRequest) -> Optional[lightning_app.storage.Path]:
+def _find_matching_path(work, request: GetRequest) -> Optional["lightning_app.storage.Path"]:
     for name in work._paths:
         candidate: lightning_app.storage.Path = getattr(work, name)
         if candidate.hash == request.hash:

--- a/src/lightning_app/storage/path.py
+++ b/src/lightning_app/storage/path.py
@@ -10,7 +10,6 @@ from typing import Any, List, Optional, Sequence, TYPE_CHECKING, Union
 from fsspec import AbstractFileSystem
 from fsspec.implementations.local import LocalFileSystem
 
-import lightning_app
 from lightning_app.core.queues import BaseQueue
 from lightning_app.storage.requests import ExistsRequest, ExistsResponse, GetRequest, GetResponse
 from lightning_app.utilities.app_helpers import Logger
@@ -23,7 +22,7 @@ if _is_s3fs_available():
 PathlibPath = type(pathlib.Path())  # PosixPath or a WindowsPath depending on the platform
 
 if TYPE_CHECKING:
-    from lightning_app.core.work import LightningWork
+    from lightning_app import LightningWork
 
 num_workers = 8
 
@@ -251,7 +250,7 @@ class Path(PathlibPath):
                 f" from Work {response.source} to {response.destination}. See the full stacktrace above."
             ) from response.exception
 
-    def _attach_work(self, work: "lightning_app.LightningWork") -> None:
+    def _attach_work(self, work: "LightningWork") -> None:
         """Attach a LightningWork to this Path.
 
         The first work to be attached becomes the `origin`, i.e., the Work that is meant to expose the file to other
@@ -323,7 +322,7 @@ class Path(PathlibPath):
         return self.to_dict()
 
     @staticmethod
-    def _handle_exists_request(work: "lightning_app.LightningWork", request: ExistsRequest) -> ExistsResponse:
+    def _handle_exists_request(work: "LightningWork", request: ExistsRequest) -> ExistsResponse:
         return ExistsResponse(
             source=request.source,
             name=request.name,
@@ -334,7 +333,7 @@ class Path(PathlibPath):
         )
 
     @staticmethod
-    def _handle_get_request(work: "lightning_app.LightningWork", request: GetRequest) -> GetResponse:
+    def _handle_get_request(work: "LightningWork", request: GetRequest) -> GetResponse:
         from lightning_app.storage.copier import copy_files
 
         source_path = pathlib.Path(request.path)

--- a/src/lightning_app/storage/path.py
+++ b/src/lightning_app/storage/path.py
@@ -5,12 +5,13 @@ import shutil
 from distutils.version import LooseVersion
 from platform import python_version
 from time import sleep
-from typing import Any, List, Optional, Sequence, TYPE_CHECKING, Union
+from typing import Any, List, Optional, Sequence, Union
 
 from fsspec import AbstractFileSystem
 from fsspec.implementations.local import LocalFileSystem
 
 from lightning_app.core.queues import BaseQueue
+from lightning_app.core.work import LightningWork
 from lightning_app.storage.requests import ExistsRequest, ExistsResponse, GetRequest, GetResponse
 from lightning_app.utilities.app_helpers import Logger
 from lightning_app.utilities.component import _is_flow_context
@@ -20,9 +21,6 @@ if _is_s3fs_available():
     from s3fs import S3FileSystem
 
 PathlibPath = type(pathlib.Path())  # PosixPath or a WindowsPath depending on the platform
-
-if TYPE_CHECKING:
-    from lightning_app import LightningWork
 
 num_workers = 8
 

--- a/src/lightning_app/storage/path.py
+++ b/src/lightning_app/storage/path.py
@@ -5,13 +5,12 @@ import shutil
 from distutils.version import LooseVersion
 from platform import python_version
 from time import sleep
-from typing import Any, List, Optional, Sequence, Union
+from typing import Any, List, Optional, Sequence, TYPE_CHECKING, Union
 
 from fsspec import AbstractFileSystem
 from fsspec.implementations.local import LocalFileSystem
 
 from lightning_app.core.queues import BaseQueue
-from lightning_app.core.work import LightningWork
 from lightning_app.storage.requests import ExistsRequest, ExistsResponse, GetRequest, GetResponse
 from lightning_app.utilities.app_helpers import Logger
 from lightning_app.utilities.component import _is_flow_context
@@ -21,6 +20,9 @@ if _is_s3fs_available():
     from s3fs import S3FileSystem
 
 PathlibPath = type(pathlib.Path())  # PosixPath or a WindowsPath depending on the platform
+
+if TYPE_CHECKING:
+    from lightning_app.core.work import LightningWork
 
 num_workers = 8
 

--- a/src/lightning_app/storage/payload.py
+++ b/src/lightning_app/storage/payload.py
@@ -3,16 +3,18 @@ import pathlib
 import pickle
 from abc import ABC, abstractmethod
 from time import sleep
-from typing import Any, Optional, Union
+from typing import Any, Optional, TYPE_CHECKING, Union
 
 from lightning_app.core.queues import BaseQueue
-from lightning_app.core.work import LightningWork
 from lightning_app.storage.path import filesystem, Path, shared_storage_path
 from lightning_app.storage.requests import ExistsRequest, ExistsResponse, GetRequest, GetResponse
 from lightning_app.utilities.app_helpers import Logger
 from lightning_app.utilities.component import _is_flow_context
 
 _logger = Logger(__name__)
+
+if TYPE_CHECKING:
+    from lightning_app.core.work import LightningWork
 
 
 class BasePayload(ABC):

--- a/src/lightning_app/storage/payload.py
+++ b/src/lightning_app/storage/payload.py
@@ -3,18 +3,16 @@ import pathlib
 import pickle
 from abc import ABC, abstractmethod
 from time import sleep
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, Union
 
 from lightning_app.core.queues import BaseQueue
+from lightning_app.core.work import LightningWork
 from lightning_app.storage.path import filesystem, Path, shared_storage_path
 from lightning_app.storage.requests import ExistsRequest, ExistsResponse, GetRequest, GetResponse
 from lightning_app.utilities.app_helpers import Logger
 from lightning_app.utilities.component import _is_flow_context
 
 _logger = Logger(__name__)
-
-if TYPE_CHECKING:
-    from lightning_app import LightningWork
 
 
 class BasePayload(ABC):

--- a/src/lightning_app/storage/payload.py
+++ b/src/lightning_app/storage/payload.py
@@ -3,9 +3,8 @@ import pathlib
 import pickle
 from abc import ABC, abstractmethod
 from time import sleep
-from typing import Any, Optional, Union
+from typing import Any, Optional, TYPE_CHECKING, Union
 
-import lightning_app
 from lightning_app.core.queues import BaseQueue
 from lightning_app.storage.path import filesystem, Path, shared_storage_path
 from lightning_app.storage.requests import ExistsRequest, ExistsResponse, GetRequest, GetResponse
@@ -14,6 +13,9 @@ from lightning_app.utilities.component import _is_flow_context
 
 _logger = Logger(__name__)
 
+if TYPE_CHECKING:
+    from lightning_app import LightningWork
+
 
 class BasePayload(ABC):
     def __init__(self, value: Any) -> None:
@@ -21,9 +23,9 @@ class BasePayload(ABC):
         # the attribute name given to the payload
         self._name: Optional[str] = None
         # the origin is the work that created this Path and wants to expose file(s)
-        self._origin: Optional[Union["lightning_app.LightningWork", str]] = None
+        self._origin: Optional[Union["LightningWork", str]] = None
         # the consumer is the Work that needs access to the file(s) from the consumer
-        self._consumer: Optional[Union["lightning_app.LightningWork", str]] = None
+        self._consumer: Optional[Union["LightningWork", str]] = None
         self._metadata = {}
         # request queue: used to transfer message to storage orchestrator
         self._request_queue: Optional[BaseQueue] = None
@@ -85,7 +87,7 @@ class BasePayload(ABC):
     def load(self, path: str) -> Any:
         """Override this method with your own loading logic."""
 
-    def _attach_work(self, work: "lightning_app.LightningWork") -> None:
+    def _attach_work(self, work: "LightningWork") -> None:
         """Attach a LightningWork to this PayLoad.
 
         Args:
@@ -202,7 +204,7 @@ class BasePayload(ABC):
         return payload
 
     @staticmethod
-    def _handle_exists_request(work: "lightning_app.LightningWork", request: ExistsRequest) -> ExistsResponse:
+    def _handle_exists_request(work: "LightningWork", request: ExistsRequest) -> ExistsResponse:
         return ExistsResponse(
             source=request.source,
             path=request.path,
@@ -213,7 +215,7 @@ class BasePayload(ABC):
         )
 
     @staticmethod
-    def _handle_get_request(work: "lightning_app.LightningWork", request: GetRequest) -> GetResponse:
+    def _handle_get_request(work: "LightningWork", request: GetRequest) -> GetResponse:
         from lightning_app.storage.copier import copy_files
 
         source_path = pathlib.Path(request.path)

--- a/src/lightning_app/utilities/name_generator.py
+++ b/src/lightning_app/utilities/name_generator.py
@@ -1334,9 +1334,9 @@ def get_unique_name():
 
     Examples
     --------
-    >>> get_unique_name()
+    >>> get_unique_name()  # doctest: +SKIP
     'focused-turing-23'
-    >>> get_unique_name()
+    >>> get_unique_name()  # doctest: +SKIP
     'thirsty-allen-9200'
     """
     adjective, surname, i = choice(_adjectives), choice(_surnames), randint(0, 9999)


### PR DESCRIPTION
Part of #15122.

When we create a combined package, `lightning_app` will no longer be a top-level package, therefore slightly different import machinery will be invoked. Due to this, we will get circular imports, because sub-package `lightning.app` will not be initialized yet. This PR should solve it for all such instances.

Taken from #15122, hopefully didn't miss anything

cc @carmocca @akihironitta @borda @justusschock @awaelchli @rohitgr7 