### PR TITLE
Replace oldest versions also for Lite

### DIFF
--- a/.actions/assistant.py
+++ b/.actions/assistant.py
@@ -30,6 +30,10 @@ REQUIREMENT_FILES = {
         "requirements/app/ui.txt",
         "requirements/app/cloud.txt",
     ),
+    "lite": (
+        "requirements/lite/base.txt",
+        "requirements/lite/strategies.txt",
+    ),
 }
 REQUIREMENT_FILES_ALL = list(chain(*REQUIREMENT_FILES.values()))
 PACKAGE_MAPPING = {"app": "lightning-app", "pytorch": "pytorch-lightning"}


### PR DESCRIPTION
In CI, we are not replacing oldest version for Lite. Therefore, we're not really testing Lite with oldest specified version.

cc @carmocca 