### PR TITLE
[App] Fix bug when preventing cross launch of apps

### DIFF
--- a/src/lightning_app/runners/cloud.py
+++ b/src/lightning_app/runners/cloud.py
@@ -293,6 +293,10 @@ class CloudRuntime(Runtime):
             if find_instances_resp.lightningapps:
                 existing_instance = find_instances_resp.lightningapps[0]
 
+                # if --cloud w/o --cluster-id, launch to same cluster as previous release
+                if cluster_id is None:
+                    cluster_id = existing_instance.spec.cluster_id
+
                 # TODO: support multiple instances / 1 instance per cluster
                 if existing_instance.spec.cluster_id != cluster_id:
                     raise ValueError(

--- a/tests/tests_app/runners/test_cloud.py
+++ b/tests/tests_app/runners/test_cloud.py
@@ -70,11 +70,14 @@ class TestAppCreationClient:
 
     # TODO: remove this test once there is support for multiple instances
     @mock.patch("lightning_app.runners.backends.cloud.LightningClient", mock.MagicMock())
-    @pytest.mark.parametrize('original_cluster,new_cluster,want_error', [
-        ('cluster-001', 'cluster-001', False),
-        ('cluster-001', None, False), # e.g. --cloud w/o --cluster-id
-        ('cluster-001', 'cluster-002', True),
-    ])
+    @pytest.mark.parametrize(
+        "original_cluster,new_cluster,want_error",
+        [
+            ("cluster-001", "cluster-001", False),
+            ("cluster-001", None, False),  # e.g. --cloud w/o --cluster-id
+            ("cluster-001", "cluster-002", True),
+        ],
+    )
     def test_new_instance_on_different_cluster_fails(self, monkeypatch, original_cluster, new_cluster, want_error):
         app_name = "test-app-name"
 


### PR DESCRIPTION
## What does this PR do?

Fixes bug introduced in #15226.

If you launch an app with `lightning run app app.py --cloud`, `--cluster-id` was not used so `cluster_id` is `None`. If the app has never ran before, and there are no BYOC clusters in the default project, the app will run on the global lightning cluster.

The bug occurs when launching the same app a second time using the same command. We checked to see if the `cluster_id` matches the cluster of the previous app instance (which was set by the platform to the global cluster). Essentially it was checking if `None == 'lightning-cluster'`.

This PR fixes the bug by setting `cluster_id` to the cluster of the previous instance, if it was not set by the user.

To run through some examples and desired behaviour:

### Scenario 1
1. `lightning run app app.py --cloud` -> creates the app on the global lightning cluster
2. `lightning run app app.py --cloud` -> updates the app instance on the global cluster

### Scenario 2
1. `lightning run app app.py --cloud --cluster-id my-cluster` -> creates the app on 'my-cluster'
2. `lightning run app app.py --cloud` -> updates the app instance on 'my-cluster'

### Scenario 3
1. `lightning run app app.py --cloud --cluster-id my-cluster` -> creates the app on 'my-cluster'
2. `lightning run app app.py --cloud --cluster-id some-other-cluster` -> Error: we don't support 1 app on multiple clusters (yet). See PR description in #15226.

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
