### PR TITLE
Fix default CloudCompute for flows

### DIFF
--- a/src/lightning_app/CHANGELOG.md
+++ b/src/lightning_app/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed an issue when using the CLI without arguments ([#14877](https://github.com/Lightning-AI/lightning/pull/14877))
 - Fixed a bug where the upload files endpoint would raise an error when running locally ([#14924](https://github.com/Lightning-AI/lightning/pull/14924))
 - Fixed a bug when launching an app on multiple clusters ([#15226](https://github.com/Lightning-AI/lightning/pull/15226))
+- Fixed a bug with a default CloudCompute for Lightning flows ([#15371](https://github.com/Lightning-AI/lightning/pull/15371))
 
 ## [0.6.2] - 2022-09-21
 

--- a/src/lightning_app/core/app.py
+++ b/src/lightning_app/core/app.py
@@ -103,7 +103,7 @@ class LightningApp:
 
         _validate_root_flow(root)
         self._root = root
-        self.flow_cloud_compute = flow_cloud_compute or lightning_app.CloudCompute()
+        self.flow_cloud_compute = flow_cloud_compute or lightning_app.CloudCompute(name="flow-lite")
 
         # queues definition.
         self.delta_queue: Optional[BaseQueue] = None

--- a/tests/tests_app/runners/test_cloud.py
+++ b/tests/tests_app/runners/test_cloud.py
@@ -65,21 +65,21 @@ class WorkWithTwoDrives(LightningWork):
         pass
 
 
-def get_cloud_runtime_request_body(**kwargs) -> 'Body8':
+def get_cloud_runtime_request_body(**kwargs) -> "Body8":
     default_request_body = dict(
-            app_entrypoint_file=mock.ANY,
-            enable_app_server=True,
-            flow_servers=[],
-            image_spec=None,
-            works=[],
-            local_source=True,
-            dependency_cache_key=mock.ANY,
-            user_requested_flow_compute_config=V1UserRequestedFlowComputeConfig(
-                name="flow-lite",
-                preemptible=False,
-                shm_size=0,
-            ),
-        )
+        app_entrypoint_file=mock.ANY,
+        enable_app_server=True,
+        flow_servers=[],
+        image_spec=None,
+        works=[],
+        local_source=True,
+        dependency_cache_key=mock.ANY,
+        user_requested_flow_compute_config=V1UserRequestedFlowComputeConfig(
+            name="flow-lite",
+            preemptible=False,
+            shm_size=0,
+        ),
+    )
 
     if kwargs.get("user_requested_flow_compute_config") is not None:
         default_request_body["user_requested_flow_compute_config"] = kwargs["user_requested_flow_compute_config"]
@@ -144,13 +144,7 @@ class TestAppCreationClient:
             body=V1ProjectClusterBinding(cluster_id=new_cluster, project_id="default-project-id"),
         )
 
-    @pytest.mark.parametrize(
-    'flow_cloud_compute',
-    [
-        None,
-        CloudCompute(name="t2.medium")
-    ]
-    )
+    @pytest.mark.parametrize("flow_cloud_compute", [None, CloudCompute(name="t2.medium")])
     @mock.patch("lightning_app.runners.backends.cloud.LightningClient", mock.MagicMock())
     def test_run_with_default_flow_compute_config(self, monkeypatch, flow_cloud_compute):
         mock_client = mock.MagicMock()

--- a/tests/tests_app/runners/test_cloud.py
+++ b/tests/tests_app/runners/test_cloud.py
@@ -81,7 +81,7 @@ def get_cloud_runtime_request_body(**kwargs) -> 'Body8':
             ),
         )
 
-    if "user_requested_flow_compute_config" in kwargs:
+    if kwargs.get("user_requested_flow_compute_config") is not None:
         default_request_body["user_requested_flow_compute_config"] = kwargs["user_requested_flow_compute_config"]
 
     return Body8(**default_request_body)
@@ -144,8 +144,15 @@ class TestAppCreationClient:
             body=V1ProjectClusterBinding(cluster_id=new_cluster, project_id="default-project-id"),
         )
 
+    @pytest.mark.parametrize(
+    'flow_cloud_compute',
+    [
+        None,
+        CloudCompute(name="t2.medium")
+    ]
+    )
     @mock.patch("lightning_app.runners.backends.cloud.LightningClient", mock.MagicMock())
-    def test_run_with_default_flow_compute_config(self, monkeypatch):
+    def test_run_with_default_flow_compute_config(self, monkeypatch, flow_cloud_compute):
         mock_client = mock.MagicMock()
         mock_client.projects_service_list_memberships.return_value = V1ListMembershipsResponse(
             memberships=[V1Membership(name="test-project", project_id="test-project-id")]
@@ -160,7 +167,10 @@ class TestAppCreationClient:
 
         dummy_flow = mock.MagicMock()
         monkeypatch.setattr(dummy_flow, "run", lambda *args, **kwargs: None)
-        app = LightningApp(dummy_flow)
+        if flow_cloud_compute is None:
+            app = LightningApp(dummy_flow)
+        else:
+            app = LightningApp(dummy_flow, flow_cloud_compute=flow_cloud_compute)
 
         cloud_runtime = cloud.CloudRuntime(app=app, entrypoint_file="entrypoint.py")
         cloud_runtime._check_uploaded_folder = mock.MagicMock()
@@ -168,41 +178,16 @@ class TestAppCreationClient:
         monkeypatch.setattr(Path, "is_file", lambda *args, **kwargs: False)
         monkeypatch.setattr(cloud, "Path", Path)
         cloud_runtime.dispatch()
-        body = get_cloud_runtime_request_body()
-        cloud_runtime.backend.client.lightningapp_v2_service_create_lightningapp_release.assert_called_once_with(
-            project_id="test-project-id", app_id=mock.ANY, body=body
-        )
 
-    @mock.patch("lightning_app.runners.backends.cloud.LightningClient", mock.MagicMock())
-    def test_run_with_custom_flow_compute_config(self, monkeypatch):
-        mock_client = mock.MagicMock()
-        mock_client.projects_service_list_memberships.return_value = V1ListMembershipsResponse(
-            memberships=[V1Membership(name="test-project", project_id="test-project-id")]
-        )
-        mock_client.lightningapp_instance_service_list_lightningapp_instances.return_value = (
-            V1ListLightningappInstancesResponse(lightningapps=[])
-        )
-        cloud_backend = mock.MagicMock()
-        cloud_backend.client = mock_client
-        monkeypatch.setattr(backends, "CloudBackend", mock.MagicMock(return_value=cloud_backend))
-        monkeypatch.setattr(cloud, "LocalSourceCodeDir", mock.MagicMock())
-        app = mock.MagicMock()
-        app.flows = []
-        app.frontend = {}
-        app.flow_cloud_compute = CloudCompute(name="t2.medium")
-        cloud_runtime = cloud.CloudRuntime(app=app, entrypoint_file="entrypoint.py")
-        cloud_runtime._check_uploaded_folder = mock.MagicMock()
-
-        monkeypatch.setattr(Path, "is_file", lambda *args, **kwargs: False)
-        monkeypatch.setattr(cloud, "Path", Path)
-        cloud_runtime.dispatch()
-        body = get_cloud_runtime_request_body(
-            user_requested_flow_compute_config=V1UserRequestedFlowComputeConfig(
-                name="t2.medium",
+        user_requested_flow_compute_config = None
+        if flow_cloud_compute is not None:
+            user_requested_flow_compute_config = V1UserRequestedFlowComputeConfig(
+                name=flow_cloud_compute.name,
                 preemptible=False,
                 shm_size=0,
-            ),
-        )
+            )
+
+        body = get_cloud_runtime_request_body(user_requested_flow_compute_config=user_requested_flow_compute_config)
         cloud_runtime.backend.client.lightningapp_v2_service_create_lightningapp_release.assert_called_once_with(
             project_id="test-project-id", app_id=mock.ANY, body=body
         )


### PR DESCRIPTION
## What does this PR do?

In the merged [Add support for custom cloud compute configurations for Flows](https://github.com/Lightning-AI/lightning/pull/14831/) PR, we set default `CloudCompute` name for flows to be `default` (https://github.com/Lightning-AI/lightning/pull/14831/files#diff-6cbbb993a8c2bf30a487086dcd4cf9a595ffc7399ecfc3efbb79f7568a3b74c8R106 ) - this is undesirable change. 
This PR fixes the issue, sets it to be default that is currently used for Lightning Flows - `flow-lite`.

### Does your PR introduce any breaking changes? If yes, please list them.

No.

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @borda