### PR TITLE
Fix resetting internal bars in RichProgressBar after each trainer stage

### DIFF
--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -19,6 +19,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed a pickling error when using `RichProgressBar` together with checkpointing ([#15319](https://github.com/Lightning-AI/lightning/pull/15319))
 
 
+- Fixed an issue with `RichProgressBar` not resetting the internal state for the sanity check progress ([#15377](https://github.com/Lightning-AI/lightning/pull/15377))
+
+
 ## [1.8.0] - 2022-MM-DD
 
 

--- a/src/pytorch_lightning/callbacks/progress/rich_progress.py
+++ b/src/pytorch_lightning/callbacks/progress/rich_progress.py
@@ -512,6 +512,7 @@ class RichProgressBar(ProgressBarBase):
 
     def _reset_progress_bar_ids(self) -> None:
         self.main_progress_bar_id = None
+        self.val_sanity_progress_bar_id = None
         self.val_progress_bar_id = None
         self.test_progress_bar_id = None
         self.predict_progress_bar_id = None

--- a/tests/tests_pytorch/callbacks/progress/test_rich_progress_bar.py
+++ b/tests/tests_pytorch/callbacks/progress/test_rich_progress_bar.py
@@ -441,3 +441,37 @@ def test_rich_progress_bar_can_be_pickled():
     pickle.dumps(bar)
     trainer.predict(model)
     pickle.dumps(bar)
+
+
+@RunIf(rich=True)
+def test_rich_progress_bar_reset_bars():
+    """Test that the progress bar resets all internal bars when a new trainer stage begins."""
+    bar = RichProgressBar()
+    assert bar.is_enabled
+    assert bar.progress is None
+    assert bar._progress_stopped is False
+
+    def _set_fake_bar_ids():
+        bar.main_progress_bar_id = 0
+        bar.val_sanity_progress_bar_id = 1
+        bar.val_progress_bar_id = 2
+        bar.test_progress_bar_id = 3
+        bar.predict_progress_bar_id = 4
+
+    for stage in ("train", "sanity_check", "validation", "test", "predict"):
+        hook_name = f"on_{stage}_start"
+        hook = getattr(bar, hook_name)
+
+        _set_fake_bar_ids()  # pretend that bars are initialized from a previous run
+        hook(Mock(), Mock())
+        bar.teardown(Mock(), Mock(), Mock())
+
+        # assert all bars are reset
+        assert bar.main_progress_bar_id is None
+        assert bar.val_sanity_progress_bar_id is None
+        assert bar.val_progress_bar_id is None
+        assert bar.test_progress_bar_id is None
+        assert bar.predict_progress_bar_id is None
+
+        # the progress object remains in case we need it for the next stage
+        assert bar.progress is not None


### PR DESCRIPTION
## What does this PR do?

Fixes an issue in which the sanity check progress bar wasn't reset from a previous run of the trainer. 
Observed in #15321.


## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃





cc @borda @kaushikb11 @rohitgr7