### PR TITLE
Checkout the HEAD SHA for docs builds

### DIFF
--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -4,6 +4,8 @@ name: Check Docs
 on:
   push:
     branches: ["master", "release/*"]
+  # use this event type to share secrets with forks.
+  # it's important that the PR head SHA is checked out to run the changes
   pull_request_target:
     branches: ["master", "release/*"]
     paths:
@@ -30,6 +32,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
@@ -56,6 +60,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/download-artifact@v3
         with:
           name: ci-packages-${{ github.sha }}
@@ -130,6 +135,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/download-artifact@v3
         with:
           name: ci-packages-${{ github.sha }}


### PR DESCRIPTION
## What does this PR do?

https://github.com/Lightning-AI/lightning/commit/0a3db23cc4471d00ab94d3976579b331443470dc#diff-02dbc35a6a8a8f65d291727a704a253056019b7ea277be0160c4843567def6e3R7 changed the event type to `pull_request_target`. 

This event type has the advantage sharing secrets with forks. This is important so fork PRs can build docs or they would be blocked.
By design, this event type runs using master's changes (the PR base) for security reasons.

One workaround for this (at the cost of security) is to checkout the PR head SHA.

Not doing this is what caused #15473 to appear as green when in reality the changes were broken.
**Since that has been merged and the errors now appear in master, this PR needs to be force merged. Failures here are expected and caused by #15473**

This will help unblock #15508 

### Does your PR introduce any breaking changes? If yes, please list them.

None

cc @tchaton @rohitgr7 @carmocca @akihironitta @borda