### PR TITLE
Fix handling of script arguments in tracer

### DIFF
--- a/src/lightning_app/CHANGELOG.md
+++ b/src/lightning_app/CHANGELOG.md
@@ -21,9 +21,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Changed the `flow.flows` to be recursive wont to align the behavior with the `flow.works` ([#15466](https://github.com/Lightning-AI/lightning/pull/15466))
 
--
 
--
+- The `params` argument in `TracerPythonScript.run` no longer prepends `--` automatically to parameters ([#15518](https://github.com/Lightning-AI/lightning/pull/15518))
+
 
 
 ### Deprecated

--- a/src/lightning_app/components/python/tracer.py
+++ b/src/lightning_app/components/python/tracer.py
@@ -166,9 +166,7 @@ class TracerPythonScript(LightningWork):
 
     @staticmethod
     def _to_script_args(k: str, v: str) -> str:
-        if k.startswith("--"):
-            return f"{k}={v}"
-        return f"--{k}={v}"
+        return f"{k}={v}"
 
 
 __all__ = ["TracerPythonScript"]

--- a/tests/tests_app/components/python/test_python.py
+++ b/tests/tests_app/components/python/test_python.py
@@ -95,7 +95,7 @@ def test_tracer_component_with_code():
     os.remove("sample.tar.gz")
 
     python_script = TracerPythonScript("file.py", script_args=["--b=1"], raise_exception=False, code=code)
-    run_work_isolated(python_script, params={"a": "1"}, restart_count=0)
+    run_work_isolated(python_script, params={"--a": "1"}, restart_count=0)
     assert "An error" in python_script.status.message
 
     with open("file.py", "w") as f:
@@ -117,7 +117,7 @@ def test_tracer_component_with_code():
     python_script._calls[call_hash]["statuses"].pop(-1)
     python_script._calls[call_hash]["statuses"].pop(-1)
 
-    run_work_isolated(python_script, params={"a": "1"}, restart_count=1)
+    run_work_isolated(python_script, params={"--a": "1"}, restart_count=1)
     assert python_script.has_succeeded
     assert python_script.script_args == ["--b=1", "--a=1"]
     os.remove("file.py")


### PR DESCRIPTION
## What does this PR do?

`TracerPythonScript` assumes that additional `params` start with `--`

For instance, passing `params={"a": 1}` is turned into `script_args == "--a=1"`. This breaks when this assumption is not true, for instance when parsing arguments using hydra.cc

This PR removes this assumption. The (unavoidable) downside is a `params` argument needs to be provided as `{"--a": 1}` if it is meant to be turned into `--a=1`, otherwise it is converted to `a=1`.

Note that this is needed for https://github.com/Lightning-AI/lightning-hpo/pull/216 to work

Fixes #\<issue_number>

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @borda @justusschock