### PR TITLE
Only load global step when fitting

### DIFF
--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - From now on, Lightning Trainer and `LightningModule.load_from_checkpoint` automatically upgrade the loaded checkpoint if it was produced in an old version of Lightning ([#15237](https://github.com/Lightning-AI/lightning/pull/15237))
 
-- `Trainer.{validate,test,predict}(ckpt_path=...)` no longer restores the `Trainer.global_step` value from the checkpoints - From now on, only `Trainer.fit` will restore this value ([#15532](https://github.com/Lightning-AI/lightning/pull/15532))
+- `Trainer.{validate,test,predict}(ckpt_path=...)` no longer restores the `Trainer.global_step` and `trainer.current_epoch` value from the checkpoints - From now on, only `Trainer.fit` will restore this value ([#15532](https://github.com/Lightning-AI/lightning/pull/15532))
 
 -
 

--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -21,9 +21,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - From now on, Lightning Trainer and `LightningModule.load_from_checkpoint` automatically upgrade the loaded checkpoint if it was produced in an old version of Lightning ([#15237](https://github.com/Lightning-AI/lightning/pull/15237))
 
--
+- `Trainer.{validate,test,predict}(ckpt_path=...)` no longer restores the `Trainer.global_step` value from the checkpoints - From now on, only `Trainer.fit` will restore this value ([#15532](https://github.com/Lightning-AI/lightning/pull/15532))
 
--
+- 
 
 
 ### Deprecated

--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - `Trainer.{validate,test,predict}(ckpt_path=...)` no longer restores the `Trainer.global_step` value from the checkpoints - From now on, only `Trainer.fit` will restore this value ([#15532](https://github.com/Lightning-AI/lightning/pull/15532))
 
-- 
+-
 
 
 ### Deprecated

--- a/src/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -341,9 +341,9 @@ class CheckpointConnector:
         pl_module = self.trainer.lightning_module
         assert pl_module is not None
 
-        # set the `global_step` value for checkpoints before v1.6 without the progress tracking state.
-        # it will be overwritten by the loop's state if it was also saved
         if self.trainer.state.fn == TrainerFn.FITTING:
+            # set the `global_step` value for checkpoints before v1.6 without the progress tracking state.
+            # it will be overwritten by the loop's state if it was also saved
             batch_loop = fit_loop.epoch_loop.batch_loop
             if pl_module.automatic_optimization:
                 batch_loop.optimizer_loop.optim_progress.optimizer.step.total.completed = self._loaded_checkpoint[

--- a/src/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -343,17 +343,18 @@ class CheckpointConnector:
 
         # set the `global_step` value for checkpoints before v1.6 without the progress tracking state.
         # it will be overwritten by the loop's state if it was also saved
-        batch_loop = fit_loop.epoch_loop.batch_loop
-        if pl_module.automatic_optimization:
-            batch_loop.optimizer_loop.optim_progress.optimizer.step.total.completed = self._loaded_checkpoint[
-                "global_step"
-            ]
-        else:
-            batch_loop.manual_loop.optim_step_progress.total.completed = self._loaded_checkpoint["global_step"]
+        if self.trainer.state.fn == TrainerFn.FITTING:
+            batch_loop = fit_loop.epoch_loop.batch_loop
+            if pl_module.automatic_optimization:
+                batch_loop.optimizer_loop.optim_progress.optimizer.step.total.completed = self._loaded_checkpoint[
+                    "global_step"
+                ]
+            else:
+                batch_loop.manual_loop.optim_step_progress.total.completed = self._loaded_checkpoint["global_step"]
 
-        # set the `current_epoch` value for checkpoints before v1.6 without the progress tracking state.
-        # it will be overwritten by the loop's state if it was also saved
-        fit_loop.epoch_progress.current.completed = self._loaded_checkpoint["epoch"]
+            # set the `current_epoch` value for checkpoints before v1.6 without the progress tracking state.
+            # it will be overwritten by the loop's state if it was also saved
+            fit_loop.epoch_progress.current.completed = self._loaded_checkpoint["epoch"]
 
         assert self.trainer.state.fn is not None
         state_dict = self._loaded_checkpoint.get("loops")

--- a/tests/tests_pytorch/models/test_restore.py
+++ b/tests/tests_pytorch/models/test_restore.py
@@ -187,7 +187,7 @@ def test_trainer_properties_restore_ckpt_path(tmpdir):
 
         def _test_on_val_test_predict_start(self):
             assert self.trainer.current_epoch == state_dict["epoch"]
-            assert self.trainer.global_step == state_dict["global_step"]
+            assert self.trainer.global_step == 0
             assert self._check_model_state_dict()
 
         def on_train_start(self):

--- a/tests/tests_pytorch/models/test_restore.py
+++ b/tests/tests_pytorch/models/test_restore.py
@@ -626,8 +626,10 @@ def test_dp_resume(tmpdir):
             super().__init__()
             self.on_train_start_called = False
 
-        def on_validation_start(self):
+        def on_train_start(self):
             assert self.trainer.current_epoch == real_global_epoch and self.trainer.current_epoch > 0
+
+        def on_validation_start(self):
             dataloader = dm.val_dataloader()
             tpipes.run_model_prediction(self.trainer.lightning_module, dataloader=dataloader)
 


### PR DESCRIPTION
## What does this PR do?

Changes the behavior of loading the global_step. 

**Current:** 
Global step gets reloaded regardless of whether you call `Trainer.fit(ckpt_path=...)` or `Trainer.validate(ckpt_path=...), ...`

**Now:**
Global step will only restore its value when calling `Trainer.fit(ckpt_path=...)`. Changed test reflects this behavior. 

This is a breaking change, but aligns the behavior as expected for consistency with the rest of our reloading logic.

Discovered in #15500 

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃


cc @borda @justusschock @carmocca @rohitgr7