### PR TITLE
Let metadata `score` be serializable by wand

### DIFF
--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -54,6 +54,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed an issue with the `BaseFinetuning` callback not setting the `track_running_stats` attribute for batch normaliztion layers ([#15063](https://github.com/Lightning-AI/lightning/pull/15063))
 
+- Fixed an issue with `WandbLogger(log_model=True|'all)` raising an error and not being able to serialize tensors in the metadata ([#15544](https://github.com/Lightning-AI/lightning/pull/15544))
+
 
 ## [1.8.0] - 2022-11-01
 

--- a/src/pytorch_lightning/loggers/wandb.py
+++ b/src/pytorch_lightning/loggers/wandb.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Union
 
 import torch.nn as nn
+from torch import Tensor
 from lightning_utilities.core.imports import RequirementCache
 
 from pytorch_lightning.callbacks import Checkpoint

--- a/src/pytorch_lightning/loggers/wandb.py
+++ b/src/pytorch_lightning/loggers/wandb.py
@@ -21,8 +21,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Union
 
 import torch.nn as nn
-from torch import Tensor
 from lightning_utilities.core.imports import RequirementCache
+from torch import Tensor
 
 from pytorch_lightning.callbacks import Checkpoint
 from pytorch_lightning.loggers.logger import Logger, rank_zero_experiment

--- a/src/pytorch_lightning/loggers/wandb.py
+++ b/src/pytorch_lightning/loggers/wandb.py
@@ -572,7 +572,7 @@ class WandbLogger(Logger):
         for t, p, s, tag in checkpoints:
             metadata = (
                 {
-                    "score": s,
+                    "score": s.item() if isinstance(s, Tensor) else s,
                     "original_filename": Path(p).name,
                     checkpoint_callback.__class__.__name__: {
                         k: getattr(checkpoint_callback, k)

--- a/tests/tests_pytorch/loggers/test_wandb.py
+++ b/tests/tests_pytorch/loggers/test_wandb.py
@@ -281,7 +281,7 @@ def test_wandb_log_model_with_score(wandb, monkeypatch, tmpdir):
 
     calls = wandb.Artifact.call_args_list
     assert len(calls) == 1
-    score = calls[0].kwargs["metadata"]["score"]
+    score = calls[0][1]["metadata"]["score"]
     # model checkpoint monitors scalar tensors, but wandb can't serializable them - expect Python scalars in metadata
     assert isinstance(score, int) and score == 3
 

--- a/tests/tests_pytorch/loggers/test_wandb.py
+++ b/tests/tests_pytorch/loggers/test_wandb.py
@@ -19,6 +19,7 @@ import pytest
 
 import pytorch_lightning
 from pytorch_lightning import Trainer
+from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.demos.boring_classes import BoringModel
 from pytorch_lightning.loggers import WandbLogger
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
@@ -249,6 +250,39 @@ def test_wandb_log_model(wandb, monkeypatch, tmpdir):
             },
         },
     )
+
+
+@mock.patch("pytorch_lightning.loggers.wandb.Run", new=mock.Mock)
+@mock.patch("pytorch_lightning.loggers.wandb.wandb")
+def test_wandb_log_model_with_score(wandb, monkeypatch, tmpdir):
+    """Test to prevent regression on #15543, ensuring the score is logged as a Python number, not a scalar tensor."""
+    monkeypatch.setattr(pytorch_lightning.loggers.wandb, "_WANDB_GREATER_EQUAL_0_10_22", True)
+
+    wandb.run = None
+    model = BoringModel()
+
+    wandb.init().log_artifact.reset_mock()
+    wandb.init.reset_mock()
+    wandb.Artifact.reset_mock()
+    logger = WandbLogger(log_model=True)
+    logger.experiment.id = "1"
+    logger.experiment.name = "run_name"
+    checkpoint_callback = ModelCheckpoint(monitor="step")
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        logger=logger,
+        callbacks=[checkpoint_callback],
+        max_epochs=1,
+        limit_train_batches=3,
+        limit_val_batches=1,
+    )
+    trainer.fit(model)
+
+    calls = wandb.Artifact.call_args_list
+    assert len(calls) == 1
+    score = calls[0].kwargs["metadata"]["score"]
+    # model checkpoint monitors scalar tensors, but wandb can't serializable them - expect Python scalars in metadata
+    assert isinstance(score, int) and score == 3
 
 
 @mock.patch("pytorch_lightning.loggers.wandb.Run", new=mock.Mock)

--- a/tests/tests_pytorch/loggers/test_wandb.py
+++ b/tests/tests_pytorch/loggers/test_wandb.py
@@ -255,7 +255,8 @@ def test_wandb_log_model(wandb, monkeypatch, tmpdir):
 @mock.patch("pytorch_lightning.loggers.wandb.Run", new=mock.Mock)
 @mock.patch("pytorch_lightning.loggers.wandb.wandb")
 def test_wandb_log_model_with_score(wandb, monkeypatch, tmpdir):
-    """Test to prevent regression on #15543, ensuring the score is logged as a Python number, not a scalar tensor."""
+    """Test to prevent regression on #15543, ensuring the score is logged as a Python number, not a scalar
+    tensor."""
     monkeypatch.setattr(pytorch_lightning.loggers.wandb, "_WANDB_GREATER_EQUAL_0_10_22", True)
 
     wandb.run = None


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fixes #15543

### Does your PR introduce any breaking changes? If yes, please list them.

No.

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified


Make sure you had fun coding 🙃

=> always!