### PR TITLE
Add rank_zero functions to the graveyard

### DIFF
--- a/src/pytorch_lightning/_graveyard/__init__.py
+++ b/src/pytorch_lightning/_graveyard/__init__.py
@@ -17,4 +17,5 @@ import pytorch_lightning._graveyard.core
 import pytorch_lightning._graveyard.legacy_import_unpickler
 import pytorch_lightning._graveyard.loggers
 import pytorch_lightning._graveyard.trainer
-import pytorch_lightning._graveyard.training_type  # noqa: F401
+import pytorch_lightning._graveyard.training_type
+import pytorch_lightning._graveyard.utilities  # noqa: F401

--- a/src/pytorch_lightning/_graveyard/utilities.py
+++ b/src/pytorch_lightning/_graveyard/utilities.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+import pytorch_lightning as pl
+
+
+def _rank_zero_debug(*_: Any, **__: Any) -> None:
+    # TODO: Remove in v2.0.0
+    raise RuntimeError(
+        "`pytorch_lightning.utilities.distributed.rank_zero_debug` was deprecated in v1.6 and is no longer accessible"
+        " as of v1.8. Use the equivalent function from the `pytorch_lightning.utilities.rank_zero` module instead."
+    )
+
+
+def _rank_zero_info(*_: Any, **__: Any) -> None:
+    # TODO: Remove in v2.0.0
+    raise RuntimeError(
+        "pytorch_lightning.utilities.distributed.rank_zero_info` was deprecated in v1.6 and is no longer accessible"
+        " as of v1.8. Use the equivalent function from the `pytorch_lightning.utilities.rank_zero` module instead."
+    )
+
+
+pl.utilities.distributed.rank_zero_debug = _rank_zero_debug
+pl.utilities.distributed.rank_zero_info = _rank_zero_info

--- a/src/pytorch_lightning/_graveyard/utilities.py
+++ b/src/pytorch_lightning/_graveyard/utilities.py
@@ -14,7 +14,7 @@ def _rank_zero_debug(*_: Any, **__: Any) -> None:
 def _rank_zero_info(*_: Any, **__: Any) -> None:
     # TODO: Remove in v2.0.0
     raise RuntimeError(
-        "pytorch_lightning.utilities.distributed.rank_zero_info` was deprecated in v1.6 and is no longer accessible"
+        "`pytorch_lightning.utilities.distributed.rank_zero_info` was deprecated in v1.6 and is no longer accessible"
         " as of v1.8. Use the equivalent function from the `pytorch_lightning.utilities.rank_zero` module instead."
     )
 

--- a/tests/tests_pytorch/graveyard/test_utilities.py
+++ b/tests/tests_pytorch/graveyard/test_utilities.py
@@ -1,0 +1,15 @@
+import pytest
+
+
+def test_v2_0_0_rank_zero_from_distributed():
+    from pytorch_lightning.utilities.distributed import rank_zero_debug, rank_zero_info
+
+    with pytest.raises(
+        RuntimeError, match="rank_zero_debug` was deprecated in v1.6 and is no longer accessible as of v1.8."
+    ):
+        rank_zero_debug("foo")
+
+    with pytest.raises(
+        RuntimeError, match="rank_zero_info` was deprecated in v1.6 and is no longer accessible as of v1.8."
+    ):
+        rank_zero_info("bar")


### PR DESCRIPTION
## What does this PR do?

Adds these deprecations https://github.com/Lightning-AI/lightning/blob/dbb5ca8d436a917fc9c2bdd6e9c00e4fd6187735/src/pytorch_lightning/utilities/distributed.py#L407-L422 to the graveyard

Closes #15536
Closes #15509

### Does your PR introduce any breaking changes? If yes, please list them.

None