### PR TITLE
Fix which groups requires docs builds

### DIFF
--- a/.github/checkgroup.yml
+++ b/.github/checkgroup.yml
@@ -48,8 +48,6 @@ subprojects:
       #- "pl-cpu (ubuntu-20.04, lightning, 3.7, 1.9, oldest)"
       - "pl-cpu (windows-2022, lightning, 3.10, 1.12)"
       #- "pl-cpu (windows-2022, lightning, 3.7, 1.9, oldest)"
-      - "make-doctest (pytorch)"
-      - "make-html (pytorch)"
       - "pytorch-lightning (GPUs)"
       - "pytorch-lightning (HPUs)"
       - "pytorch-lightning (IPUs)"
@@ -121,6 +119,7 @@ subprojects:
 
   - id: "pytorch_lightning: Docs"
     paths:
+      - "src/pytorch_lightning/**"
       - "docs/source-pytorch/**"
       - ".github/workflows/docs-*.yml"
       - "requirements/docs.txt"
@@ -203,8 +202,6 @@ subprojects:
       #- "pl-cpu (ubuntu-20.04, lightning, 3.7, 1.9, oldest)"
       - "pl-cpu (windows-2022, lightning, 3.10, 1.12)"
       #- "pl-cpu (windows-2022, lightning, 3.7, 1.9, oldest)"
-      - "make-doctest (pytorch)"
-      - "make-html (pytorch)"
       - "pytorch-lightning (GPUs)"
       - "pytorch-lightning (HPUs)"
       - "pytorch-lightning (IPUs)"
@@ -257,8 +254,6 @@ subprojects:
       - ".actions/**"
     checks:
       - "App.cloud-e2e"
-      - "make-doctest (app)"
-      - "make-html (app)"
       - "app-pytest (macOS-11, app, 3.8, latest)"
       - "app-pytest (macOS-11, app, 3.8, oldest)"
       - "app-pytest (macOS-11, lightning, 3.9, latest)"
@@ -324,6 +319,7 @@ subprojects:
 
   - id: "lightning_app: Docs"
     paths:
+      - "src/lightning_app/**"
       - "docs/source-app/**"
       - ".github/workflows/docs-*.yml"
       - "requirements/docs.txt"


### PR DESCRIPTION
## What does this PR do?

https://github.com/Lightning-AI/lightning/pull/15317 only modifies tests, but checkgroup expects that the docs job runs. But it shouldn't since it modifies only the tests

The same change is applied to apps

### Does your PR introduce any breaking changes? If yes, please list them.

None