### PR TITLE
[App] Resolve multi-node cloud bug

### DIFF
--- a/examples/app_multi_node/train_lite.py
+++ b/examples/app_multi_node/train_lite.py
@@ -9,7 +9,7 @@ class LitePyTorchDistributed(L.LightningWork):
     @staticmethod
     def run():
         # 1. Create LightningLite.
-        lite = LightningLite(strategy="ddp", precision="bf16")
+        lite = LightningLite(strategy="ddp", precision=16)
 
         # 2. Prepare distributed model and optimizer.
         model = torch.nn.Linear(32, 2)


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

It seems V100 doesn't support bfloat16.


```python
[root.ws.1] 2022-11-09T23:15:02.481Z   File "/home/zeus/.local/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1190, in _call_impl
[root.ws.1] 2022-11-09T23:15:02.481Z     return forward_call(*input, **kwargs)
[root.ws.1] 2022-11-09T23:15:02.481Z   File "/content/venv/lib/python3.8/site-packages/lightning/lite/wrappers.py", line 102, in forward
[root.ws.1] 2022-11-09T23:15:02.481Z     with self._precision.forward_context():
[root.ws.1] 2022-11-09T23:15:02.481Z   File "/usr/lib/python3.8/contextlib.py", line 113, in __enter__
[root.ws.1] 2022-11-09T23:15:02.481Z     return next(self.gen)
[root.ws.1] 2022-11-09T23:15:02.481Z   File "/content/venv/lib/python3.8/site-packages/lightning/lite/plugins/precision/native_amp.py", line 62, in forward_context
[root.ws.1] 2022-11-09T23:15:02.481Z     with self._autocast_context_manager():
[root.ws.1] 2022-11-09T23:15:02.481Z   File "/content/venv/lib/python3.8/site-packages/lightning/lite/plugins/precision/native_amp.py", line 103, in _autocast_context_manager
[root.ws.1] 2022-11-09T23:15:02.481Z     return new_autocast(self.device, dtype=torch.bfloat16 if self.precision == "bf16" else torch.half)
[root.ws.1] 2022-11-09T23:15:02.481Z   File "/home/zeus/.local/lib/python3.8/site-packages/torch/amp/autocast_mode.py", line 225, in __init__
[root.ws.1] 2022-11-09T23:15:02.481Z     raise RuntimeError('Current CUDA Device does not support bfloat16. Please switch dtype to float16.')
[root.ws.1] 2022-11-09T23:15:02.481Z RuntimeError: Current CUDA Device does not support bfloat16. Please switch dtype to float16.
```

Fixes #\<issue_number>

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @borda