### PR TITLE
Added check in WandbLogger checkpointing to convert Tensor to float for metadata

### DIFF
--- a/src/pytorch_lightning/loggers/wandb.py
+++ b/src/pytorch_lightning/loggers/wandb.py
@@ -20,6 +20,7 @@ from argparse import Namespace
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Union
 
+import torch
 import torch.nn as nn
 from lightning_utilities.core.imports import RequirementCache
 from torch import Tensor
@@ -580,6 +581,10 @@ class WandbLogger(Logger):
 
         # log iteratively all new checkpoints
         for t, p, s, tag in checkpoints:
+            if isinstance(p, torch.Tensor):
+                p = p.item()
+            if isinstance(t, torch.Tensor):
+                t = t.item()
             metadata = (
                 {
                     "score": s.item() if isinstance(s, Tensor) else s,


### PR DESCRIPTION


## What does this PR do?

This PR fixes a bug in which the score returned to the WandbLogger while checkpointing is a Tensor but the W&B artifact metadata must have a float value.

A check has been added that in case the score is a tensor, it is converted to float.

Fixes #15624 

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
