### PR TITLE
Validate that state-key is unique when using multiple callbacks of the same type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ module = [
     "lightning_app.components.serve.streamlit",
     "lightning_app.components.serve.types.image",
     "lightning_app.components.serve.types.type",
+    "lightning_app.components.serve.python_server",
     "lightning_app.components.training",
     "lightning_app.core.api",
     "lightning_app.core.app",

--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -35,6 +35,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - The `ModelCheckpoint.save_on_train_epoch_end` attribute is now computed dynamically every epoch, accounting for changes to the validation dataloaders ([#15300](https://github.com/Lightning-AI/lightning/pull/15300))
 
+- The Trainer now raises an error if it is given multiple stateful callbacks of the same time with colliding state keys ([#](https://github.com/Lightning-AI/lightning/pull/))
+
+
 ### Fixed
 
 - Enhanced `reduce_boolean_decision` to accommodate `any`-analogous semantics expected by the `EarlyStopping` callback ([#15253](https://github.com/Lightning-AI/lightning/pull/15253))

--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -35,7 +35,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - The `ModelCheckpoint.save_on_train_epoch_end` attribute is now computed dynamically every epoch, accounting for changes to the validation dataloaders ([#15300](https://github.com/Lightning-AI/lightning/pull/15300))
 
-- The Trainer now raises an error if it is given multiple stateful callbacks of the same time with colliding state keys ([#](https://github.com/Lightning-AI/lightning/pull/))
+- The Trainer now raises an error if it is given multiple stateful callbacks of the same time with colliding state keys ([#15634](https://github.com/Lightning-AI/lightning/pull/15634))
 
 
 ### Fixed

--- a/src/pytorch_lightning/trainer/connectors/callback_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/callback_connector.py
@@ -18,6 +18,8 @@ from collections import defaultdict
 from datetime import timedelta
 from typing import Dict, List, Optional, Sequence, Union
 
+from lightning_utilities.core.overrides import is_overridden
+
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks import (
     Callback,
@@ -295,7 +297,7 @@ def _configure_external_callbacks() -> List[Callback]:
 
 
 def _validate_callbacks_list(callbacks: List[Callback]) -> None:
-    stateful_callbacks = [c for c in callbacks if c.state_dict()]
+    stateful_callbacks = [cb for cb in callbacks if is_overridden("state_dict", instance=cb, parent=Callback)]
     seen_callbacks = defaultdict(list)
     for callback in stateful_callbacks:
         if callback.state_key in seen_callbacks:

--- a/src/pytorch_lightning/trainer/connectors/callback_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/callback_connector.py
@@ -17,7 +17,6 @@ import os
 from datetime import timedelta
 from typing import Dict, List, Optional, Sequence, Union
 
-
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks import (
     Callback,

--- a/src/pytorch_lightning/trainer/connectors/callback_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/callback_connector.py
@@ -17,7 +17,6 @@ import os
 from datetime import timedelta
 from typing import Dict, List, Optional, Sequence, Union
 
-from lightning_utilities.core.overrides import is_overridden
 
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks import (
@@ -36,6 +35,7 @@ from pytorch_lightning.callbacks.rich_model_summary import RichModelSummary
 from pytorch_lightning.callbacks.timer import Timer
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.imports import _PYTHON_GREATER_EQUAL_3_8_0, _PYTHON_GREATER_EQUAL_3_10_0
+from pytorch_lightning.utilities.model_helpers import is_overridden
 from pytorch_lightning.utilities.rank_zero import rank_zero_info
 
 _log = logging.getLogger(__name__)
@@ -296,7 +296,7 @@ def _configure_external_callbacks() -> List[Callback]:
 
 
 def _validate_callbacks_list(callbacks: List[Callback]) -> None:
-    stateful_callbacks = [cb for cb in callbacks if is_overridden("state_dict", instance=cb, parent=Callback)]
+    stateful_callbacks = [cb for cb in callbacks if is_overridden("state_dict", instance=cb)]
     seen_callbacks = set()
     for callback in stateful_callbacks:
         if callback.state_key in seen_callbacks:

--- a/src/pytorch_lightning/trainer/connectors/callback_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/callback_connector.py
@@ -14,7 +14,6 @@
 
 import logging
 import os
-from collections import defaultdict
 from datetime import timedelta
 from typing import Dict, List, Optional, Sequence, Union
 
@@ -298,7 +297,7 @@ def _configure_external_callbacks() -> List[Callback]:
 
 def _validate_callbacks_list(callbacks: List[Callback]) -> None:
     stateful_callbacks = [cb for cb in callbacks if is_overridden("state_dict", instance=cb, parent=Callback)]
-    seen_callbacks = defaultdict(list)
+    seen_callbacks = set()
     for callback in stateful_callbacks:
         if callback.state_key in seen_callbacks:
             raise RuntimeError(
@@ -308,4 +307,4 @@ def _validate_callbacks_list(callbacks: List[Callback]) -> None:
                 " the callback state to be checkpointable."
                 " HINT: The `callback.state_key` must be unique among all callbacks in the Trainer."
             )
-        seen_callbacks[callback.state_key].append(callback)
+        seen_callbacks.add(callback.state_key)

--- a/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
+++ b/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
@@ -981,8 +981,8 @@ def test_checkpoint_repeated_strategy_extended(tmpdir):
 def test_configure_model_checkpoint(tmpdir):
     """Test all valid and invalid ways a checkpoint callback can be passed to the Trainer."""
     kwargs = dict(default_root_dir=tmpdir)
-    callback1 = ModelCheckpoint()
-    callback2 = ModelCheckpoint()
+    callback1 = ModelCheckpoint(monitor="foo")
+    callback2 = ModelCheckpoint(monitor="bar")
 
     # no callbacks
     trainer = Trainer(enable_checkpointing=False, callbacks=[], **kwargs)

--- a/tests/tests_pytorch/trainer/connectors/test_callback_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_callback_connector.py
@@ -16,6 +16,7 @@ import logging
 from unittest import mock
 from unittest.mock import Mock
 
+import pytest
 import torch
 
 from pytorch_lightning import Callback, LightningModule, Trainer
@@ -36,8 +37,8 @@ from pytorch_lightning.utilities.imports import _PYTHON_GREATER_EQUAL_3_8_0, _PY
 
 def test_checkpoint_callbacks_are_last(tmpdir):
     """Test that checkpoint callbacks always get moved to the end of the list, with preserved order."""
-    checkpoint1 = ModelCheckpoint(tmpdir)
-    checkpoint2 = ModelCheckpoint(tmpdir)
+    checkpoint1 = ModelCheckpoint(tmpdir, monitor="foo")
+    checkpoint2 = ModelCheckpoint(tmpdir, monitor="bar")
     model_summary = ModelSummary()
     early_stopping = EarlyStopping(monitor="foo")
     lr_monitor = LearningRateMonitor()
@@ -179,7 +180,8 @@ def test_attach_model_callbacks():
         cb_connector._attach_model_callbacks()
         return trainer
 
-    early_stopping = EarlyStopping(monitor="foo")
+    early_stopping1 = EarlyStopping(monitor="red")
+    early_stopping2 = EarlyStopping(monitor="blue")
     progress_bar = TQDMProgressBar()
     lr_monitor = LearningRateMonitor()
     grad_accumulation = GradientAccumulationScheduler({1: 1})
@@ -189,40 +191,40 @@ def test_attach_model_callbacks():
     assert trainer.callbacks == [trainer.accumulation_scheduler]
 
     # callbacks of different types
-    trainer = _attach_callbacks(trainer_callbacks=[early_stopping], model_callbacks=[progress_bar])
-    assert trainer.callbacks == [early_stopping, trainer.accumulation_scheduler, progress_bar]
+    trainer = _attach_callbacks(trainer_callbacks=[early_stopping1], model_callbacks=[progress_bar])
+    assert trainer.callbacks == [early_stopping1, trainer.accumulation_scheduler, progress_bar]
 
     # same callback type twice, different instance
     trainer = _attach_callbacks(
-        trainer_callbacks=[progress_bar, EarlyStopping(monitor="foo")],
-        model_callbacks=[early_stopping],
+        trainer_callbacks=[progress_bar, EarlyStopping(monitor="red")],
+        model_callbacks=[early_stopping1],
     )
-    assert trainer.callbacks == [progress_bar, trainer.accumulation_scheduler, early_stopping]
+    assert trainer.callbacks == [progress_bar, trainer.accumulation_scheduler, early_stopping1]
 
     # multiple callbacks of the same type in trainer
     trainer = _attach_callbacks(
         trainer_callbacks=[
             LearningRateMonitor(),
-            EarlyStopping(monitor="foo"),
+            EarlyStopping(monitor="yellow"),
             LearningRateMonitor(),
-            EarlyStopping(monitor="foo"),
+            EarlyStopping(monitor="black"),
         ],
-        model_callbacks=[early_stopping, lr_monitor],
+        model_callbacks=[early_stopping1, lr_monitor],
     )
-    assert trainer.callbacks == [trainer.accumulation_scheduler, early_stopping, lr_monitor]
+    assert trainer.callbacks == [trainer.accumulation_scheduler, early_stopping1, lr_monitor]
 
     # multiple callbacks of the same type, in both trainer and model
     trainer = _attach_callbacks(
         trainer_callbacks=[
             LearningRateMonitor(),
             progress_bar,
-            EarlyStopping(monitor="foo"),
+            EarlyStopping(monitor="yellow"),
             LearningRateMonitor(),
-            EarlyStopping(monitor="foo"),
+            EarlyStopping(monitor="black"),
         ],
-        model_callbacks=[early_stopping, lr_monitor, grad_accumulation, early_stopping],
+        model_callbacks=[early_stopping1, lr_monitor, grad_accumulation, early_stopping2],
     )
-    assert trainer.callbacks == [progress_bar, early_stopping, lr_monitor, grad_accumulation, early_stopping]
+    assert trainer.callbacks == [progress_bar, early_stopping1, lr_monitor, grad_accumulation, early_stopping2]
 
 
 def test_attach_model_callbacks_override_info(caplog):
@@ -296,3 +298,13 @@ def _make_entry_point_query_mock(callback_factory):
         import_path = "pkg_resources.iter_entry_points"
     with mock.patch(import_path, query_mock):
         yield
+
+
+def test_validate_unique_callback_state_key():
+    """Test that we raise an error if the state keys collide leading to missing state in the checkpoint."""
+    callback1 = Mock(spec=Callback)
+    callback1.state_key = "same_key"
+    callback2 = Mock(spec=Callback)
+    callback2.state_key = "same_key"
+    with pytest.raises(RuntimeError, match="Found more than one stateful callback of type `Mock`"):
+        Trainer(callbacks=[callback1, callback2])

--- a/tests/tests_pytorch/trainer/test_trainer.py
+++ b/tests/tests_pytorch/trainer/test_trainer.py
@@ -924,9 +924,9 @@ def test_best_ckpt_evaluate_raises_warning_with_multiple_ckpt_callbacks():
     """Test that a warning is raised if best ckpt callback is used for evaluation configured with multiple
     checkpoints."""
 
-    ckpt_callback1 = ModelCheckpoint()
+    ckpt_callback1 = ModelCheckpoint(monitor="foo")
     ckpt_callback1.best_model_path = "foo_best_model.ckpt"
-    ckpt_callback2 = ModelCheckpoint()
+    ckpt_callback2 = ModelCheckpoint(monitor="bar")
     ckpt_callback2.best_model_path = "bar_best_model.ckpt"
     trainer = Trainer(callbacks=[ckpt_callback1, ckpt_callback2])
     trainer.state.fn = TrainerFn.TESTING


### PR DESCRIPTION
## What does this PR do?

If you give two different callback instances with the same state key to the Trainer, they overwrite each other when saving a checkpoint. Only one of two states will actually be in the checkpoint. Hence, the trainer would fail to resume all states correctly (silently). 

This PR validates this at the time of the trainer instantiation. 

This change is required to continue with an improved version of #15606 to make checkpoint migration better.

### Does your PR introduce any breaking changes? If yes, please list them.

If someone was affected by this but weren't noticing it, when they upgrade Lighting they will get a friendly error now. Apart from that change, there are no intended breaking behaviors.

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃



cc @borda @awaelchli