### PR TITLE
Tear down the DataFetcher in evaluation loops to ensure that the DataLoader iterators are destroyed

### DIFF
--- a/src/pytorch_lightning/loops/dataloader/evaluation_loop.py
+++ b/src/pytorch_lightning/loops/dataloader/evaluation_loop.py
@@ -176,6 +176,10 @@ class EvaluationLoop(DataLoaderLoop):
         # if `done` returned True before any iterations were done, this won't have been called in `on_advance_end`
         self.trainer._logger_connector.epoch_end_reached()
 
+        if self._data_fetcher is not None:
+            self._data_fetcher.teardown()
+            self._data_fetcher = None
+
         # hook
         self._evaluation_epoch_end(self._outputs)
         self._outputs = []  # free memory

--- a/src/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
+++ b/src/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
@@ -58,7 +58,9 @@ class EvaluationEpochLoop(Loop):
     def reset(self) -> None:
         """Resets the loop's internal state."""
         self._dl_max_batches = 0
-        self._data_fetcher = None
+        if self._data_fetcher is not None:
+            self._data_fetcher.teardown()
+            self._data_fetcher = None
         self._outputs = []
 
         if not self.restarting:
@@ -166,7 +168,9 @@ class EvaluationEpochLoop(Loop):
     def on_run_end(self) -> EPOCH_OUTPUT:
         """Returns the outputs of the whole run."""
         outputs, self._outputs = self._outputs, []  # free memory
-        self._data_fetcher = None
+        if self._data_fetcher is not None:
+            self._data_fetcher.teardown()
+            self._data_fetcher = None
         return outputs
 
     def teardown(self) -> None:

--- a/tests/tests_pytorch/loops/test_evaluation_loop_iterator_cleanup.py
+++ b/tests/tests_pytorch/loops/test_evaluation_loop_iterator_cleanup.py
@@ -1,0 +1,90 @@
+# Copyright The PyTorch Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import multiprocessing
+import time
+from typing import List, Tuple
+
+import torch
+from torch.nn import Linear
+from torch.utils.data import DataLoader, IterDataPipe
+
+from pytorch_lightning import Trainer, LightningDataModule
+from pytorch_lightning.core.module import LightningModule
+
+
+class FinallyCallCountingIterDataPipe(IterDataPipe):
+    def __init__(self, assert_counts: List[Tuple[int, "FinallyCallCountingIterDataPipe"]] = []):
+        self.assert_counts = assert_counts
+        self._len = 128
+        self.lock = multiprocessing.Lock()
+        self.finally_called_n_times = multiprocessing.Manager().Value("i", 0)
+
+    def __iter__(self):
+        time.sleep(0.5)  # A deadline for the previous iterators to be cleaned up. Could be replaced with
+        # some clever synchronization logic, but then the test would hang on failure.
+        for expected_count, dp in self.assert_counts:
+            with dp.lock:
+                # >= is needed here to pass the check on the second epoch
+                assert dp.finally_called_n_times.value >= expected_count
+        try:
+            for i in range(self._len):
+                yield i
+        finally:
+            with self.lock:
+                self.finally_called_n_times.value += 1
+
+    def __len__(self):
+        return self._len
+
+
+def test_evaluation_loop_disposes_of_iterator():
+    val_data_pipe = FinallyCallCountingIterDataPipe()
+    # When the train loop starts, we expect the iterator used by the sanity check to already be cleaned up
+    train_data_pipe = FinallyCallCountingIterDataPipe([(4, val_data_pipe)])
+
+    class TestModel(LightningModule):
+        def __init__(self):
+            super().__init__()
+            self.layer = Linear(1, 1)
+
+        def forward(self, *args, **kwargs):
+            return self.layer(torch.zeros((1,)))
+
+        def training_step(self, batch, batch_idx):
+            return self.forward(batch)
+
+        def validation_step(self, batch, batch_idx, dataloader_idx=0):
+            return self.forward(batch)
+
+        def configure_optimizers(self):
+            return torch.optim.SGD(self.layer.parameters(), lr=0.1)
+
+    class TestDataModule(LightningDataModule):
+        def train_dataloader(self):
+            return DataLoader(train_data_pipe, batch_size=4, num_workers=4)
+
+        def val_dataloader(self):
+            return DataLoader(val_data_pipe, batch_size=4, num_workers=4)
+
+    model = TestModel()
+    trainer = Trainer(max_epochs=2)
+    data_module = TestDataModule()
+    trainer.fit(model, datamodule=data_module)
+    time.sleep(0.5)  # A deadline for the previous iterators to be cleaned up. Could be replaced with
+    # some clever synchronization logic, but then the test would hang on failure.
+
+    # 2 epochs, 4 processes => 8 disposed iterators
+    assert train_data_pipe.finally_called_n_times.value == 8
+    # 2 epochs, 4 processes + 1 sanity check => 12 disposed iterators
+    assert val_data_pipe.finally_called_n_times.value == 12

--- a/tests/tests_pytorch/loops/test_evaluation_loop_iterator_cleanup.py
+++ b/tests/tests_pytorch/loops/test_evaluation_loop_iterator_cleanup.py
@@ -19,7 +19,7 @@ import torch
 from torch.nn import Linear
 from torch.utils.data import DataLoader, IterDataPipe
 
-from pytorch_lightning import Trainer, LightningDataModule
+from pytorch_lightning import LightningDataModule, Trainer
 from pytorch_lightning.core.module import LightningModule
 
 
@@ -38,8 +38,7 @@ class FinallyCallCountingIterDataPipe(IterDataPipe):
                 # >= is needed here to pass the check on the second epoch
                 assert dp.finally_called_n_times.value >= expected_count
         try:
-            for i in range(self._len):
-                yield i
+            yield from range(self._len)
         finally:
             with self.lock:
                 self.finally_called_n_times.value += 1


### PR DESCRIPTION
## What does this PR do?

Call `DataFetcher.teardown` when getting rid of it in the evaluation loops.

Fixes #15667

### Does your PR introduce any breaking changes? If yes, please list them.

* Not to my knowledge.

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [*] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [*] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [*] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
