### PR TITLE
Fix catimage import

### DIFF
--- a/src/lightning_app/components/serve/python_server.py
+++ b/src/lightning_app/components/serve/python_server.py
@@ -1,6 +1,5 @@
 import abc
 import base64
-import os
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -28,8 +27,7 @@ class Image(BaseModel):
 
     @staticmethod
     def _get_sample_data() -> Dict[Any, Any]:
-        name = "lightning" + "_" + "app"
-        imagepath = Path(__file__.replace(f"lightning{os.sep}app", name)).absolute().parent / "catimage.png"
+        imagepath = Path(__file__).parent / "catimage.png"
         with open(imagepath, "rb") as image_file:
             encoded_string = base64.b64encode(image_file.read())
         return {"image": encoded_string.decode("UTF-8")}


### PR DESCRIPTION
## What does this PR do?

Fixes the `PythonServer` component sample image reading. 

When running the following example code locally with `--setup` flag, the app fails with the following message:

```python
# !pip install torchvision
import lightning as L
from lightning.app.components.serve import PythonServer, Image, Number
import base64, io, torchvision, torch
from PIL import Image as PILImage


class PyTorchServer(PythonServer):
    def setup(self):
        self._model = torchvision.models.resnet18(pretrained=True)
        self._device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
        self._model.to(self._device)

    def predict(self, request):
        image = base64.b64decode(request.image.encode("utf-8"))
        image = PILImage.open(io.BytesIO(image))
        transforms = torchvision.transforms.Compose([
            torchvision.transforms.Resize(224),
            torchvision.transforms.ToTensor(),
            torchvision.transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
        ])
        image = transforms(image)
        image = image.to(self._device)
        prediction = self._model(image.unsqueeze(0))
        return {"prediction": prediction.argmax().item()}


component = PyTorchServer(
   input_type=Image, output_type=Number, cloud_compute=L.CloudCompute('gpu')
)
app = L.LightningApp(component)
```


```
Traceback (most recent call last):
  File "/home/rick/miniconda3/envs/stag-3/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/home/rick/miniconda3/envs/stag-3/lib/python3.9/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/rick/miniconda3/envs/stag-3/lib/python3.9/site-packages/lightning/app/utilities/proxies.py", line 418, in __call__
    raise e
  File "/home/rick/miniconda3/envs/stag-3/lib/python3.9/site-packages/lightning/app/utilities/proxies.py", line 401, in __call__
    self.run_once()
  File "/home/rick/miniconda3/envs/stag-3/lib/python3.9/site-packages/lightning/app/utilities/proxies.py", line 549, in run_once
    self.work.on_exception(e)
  File "/home/rick/miniconda3/envs/stag-3/lib/python3.9/site-packages/lightning/app/core/work.py", line 564, in on_exception
    raise exception
  File "/home/rick/miniconda3/envs/stag-3/lib/python3.9/site-packages/lightning/app/utilities/proxies.py", line 514, in run_once
    ret = self.run_executor_cls(self.work, work_run, self.delta_queue)(*args, **kwargs)
  File "/home/rick/miniconda3/envs/stag-3/lib/python3.9/site-packages/lightning/app/utilities/proxies.py", line 350, in __call__
    return self.work_run(*args, **kwargs)
  File "/home/rick/miniconda3/envs/stag-3/lib/python3.9/site-packages/lightning/app/components/serve/python_server.py", line 216, in run
    self._attach_frontend(fastapi_app)
  File "/home/rick/miniconda3/envs/stag-3/lib/python3.9/site-packages/lightning/app/components/serve/python_server.py", line 174, in _attach_frontend
    request = self._get_sample_dict_from_datatype(self.configure_input_type())
  File "/home/rick/miniconda3/envs/stag-3/lib/python3.9/site-packages/lightning/app/components/serve/python_server.py", line 137, in _get_sample_dict_from_datatype
    return datatype._get_sample_data()
  File "/home/rick/miniconda3/envs/stag-3/lib/python3.9/site-packages/lightning/app/components/serve/python_server.py", line 33, in _get_sample_data
    with open(imagepath, "rb") as image_file:
FileNotFoundError: [Errno 2] No such file or directory: '/home/rick/miniconda3/envs/stag-3/lib/python3.9/site-packages/lightning_app/components/serve/catimage.png'
INFO: Your Lightning App is being stopped. This won't take long.
INFO: Your Lightning App has been stopped successfully!
```

This PR just uses regular relative file path finding to find the image

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fixes #\<issue_number>

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @borda