### PR TITLE
Speed up subprocess launch

### DIFF
--- a/src/lightning_lite/strategies/launchers/subprocess_script.py
+++ b/src/lightning_lite/strategies/launchers/subprocess_script.py
@@ -14,10 +14,8 @@
 import os
 import subprocess
 import sys
-from time import sleep
 from typing import Any, Callable, Sequence
 
-import numpy as np
 from lightning_utilities.core.imports import RequirementCache
 
 from lightning_lite.plugins.environments.cluster_environment import ClusterEnvironment
@@ -125,11 +123,6 @@ class _SubprocessScriptLauncher(_Launcher):
             else:
                 command = _basic_subprocess_cmd()
             subprocess.Popen(command, env=env_copy)
-
-            # starting all processes at once can cause issues
-            # with dataloaders delay between 1-10 seconds
-            delay = np.random.uniform(1, 5, 1)[0]
-            sleep(delay)
 
     def _check_can_spawn_children(self) -> None:
         if self.cluster_environment.local_rank() != 0:

--- a/src/pytorch_lightning/strategies/launchers/subprocess_script.py
+++ b/src/pytorch_lightning/strategies/launchers/subprocess_script.py
@@ -13,10 +13,8 @@
 # limitations under the License.
 import os
 import subprocess
-from time import sleep
 from typing import Any, Callable, Optional
 
-import numpy as np
 from lightning_utilities.core.imports import RequirementCache
 
 import pytorch_lightning as pl
@@ -122,11 +120,6 @@ class _SubprocessScriptLauncher(_Launcher):
                 command = _basic_subprocess_cmd()
 
             subprocess.Popen(command, env=env_copy)
-
-            # starting all processes at once can cause issues
-            # with dataloaders delay between 1-10 seconds
-            delay = np.random.uniform(1, 5, 1)[0]
-            sleep(delay)
 
     def _check_can_spawn_children(self) -> None:
         if self.cluster_environment.local_rank() != 0:

--- a/tests/tests_lite/strategies/launchers/test_subprocess_script.py
+++ b/tests/tests_lite/strategies/launchers/test_subprocess_script.py
@@ -47,9 +47,8 @@ def test_subprocess_script_launcher_external_processes(popen_mock):
     popen_mock.assert_not_called()
 
 
-@mock.patch("lightning_lite.strategies.launchers.subprocess_script.sleep")
 @mock.patch("lightning_lite.strategies.launchers.subprocess_script.subprocess.Popen")
-def test_subprocess_script_launcher_launch_processes(popen_mock, _):
+def test_subprocess_script_launcher_launch_processes(popen_mock):
     cluster_env = Mock()
     cluster_env.creates_processes_externally = False
     cluster_env.local_rank.return_value = 0


### PR DESCRIPTION
## What does this PR do?

I couldn't find evidence that launching DDP all processes at the same time can cause issues. Introducing randomized delays only introduces non-determinism. We can safely remove the code and let the processes start immediately. 

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃


cc @borda @justusschock @awaelchli @akihironitta