### PR TITLE
Ignore `num_nodes` when running MultiNode components locally

### DIFF
--- a/src/lightning_app/CHANGELOG.md
+++ b/src/lightning_app/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - `lightning add ssh-key` CLI command has been transitioned to `lightning create ssh-key` with the same calling signature ([#15761](https://github.com/Lightning-AI/lightning/pull/15761))
 - `lightning remove ssh-key` CLI command has been transitioned to `lightning delete ssh-key` with the same calling signature ([#15761](https://github.com/Lightning-AI/lightning/pull/15761))
+- The `MultiNode` components now warn the user when running with `num_nodes > 1` locally ([#15806](https://github.com/Lightning-AI/lightning/pull/15806))
 
 
 ### Deprecated

--- a/src/lightning_app/components/multi_node/base.py
+++ b/src/lightning_app/components/multi_node/base.py
@@ -58,8 +58,8 @@ class MultiNode(LightningFlow):
         if num_nodes > 1 and not is_running_in_cloud():
             num_nodes = 1
             warnings.warn(
-                f"You set {type(self).__name__}(num_nodes={num_nodes}, ...)` but this app is running locally. "
-                " We assume you are debugging and will ignore the `num_nodes` argument. "
+                f"You set {type(self).__name__}(num_nodes={num_nodes}, ...)` but this app is running locally."
+                " We assume you are debugging and will ignore the `num_nodes` argument."
                 " To run on multiple nodes in the cloud, launch your app with `--cloud`."
             )
         self.ws = structures.List(

--- a/src/lightning_app/components/multi_node/base.py
+++ b/src/lightning_app/components/multi_node/base.py
@@ -1,8 +1,11 @@
 from typing import Any, Type
 
+from lightning_utilities.core.rank_zero import rank_zero_warn
+
 from lightning_app import structures
 from lightning_app.core.flow import LightningFlow
 from lightning_app.core.work import LightningWork
+from lightning_app.utilities.cloud import is_running_in_cloud
 from lightning_app.utilities.packaging.cloud_compute import CloudCompute
 
 
@@ -45,12 +48,21 @@ class MultiNode(LightningFlow):
 
         Arguments:
             work_cls: The work to be executed
-            num_nodes: Number of nodes.
-            cloud_compute: The cloud compute object used in the cloud.
+            num_nodes: Number of nodes. Gets ignored when running locally. Launch the app with --cloud to run on
+                multiple cloud machines.
+            cloud_compute: The cloud compute object used in the cloud. The value provided here gets ignored when
+                running locally.
             work_args: Arguments to be provided to the work on instantiation.
             work_kwargs: Keywords arguments to be provided to the work on instantiation.
         """
         super().__init__()
+        if num_nodes > 1 and not is_running_in_cloud():
+            num_nodes = 1
+            rank_zero_warn(
+                f"You set `num_nodes={num_nodes}` but this app is running locally. We assume you are debugging will"
+                " ignore the `num_nodes` argument. To run on multiple nodes in the cloud, launch your app with"
+                " `--cloud`."
+            )
         self.ws = structures.List(
             *[
                 work_cls(

--- a/src/lightning_app/components/multi_node/base.py
+++ b/src/lightning_app/components/multi_node/base.py
@@ -1,6 +1,5 @@
+import warnings
 from typing import Any, Type
-
-from lightning_utilities.core.rank_zero import rank_zero_warn
 
 from lightning_app import structures
 from lightning_app.core.flow import LightningFlow
@@ -58,10 +57,10 @@ class MultiNode(LightningFlow):
         super().__init__()
         if num_nodes > 1 and not is_running_in_cloud():
             num_nodes = 1
-            rank_zero_warn(
-                f"You set `num_nodes={num_nodes}` but this app is running locally. We assume you are debugging will"
-                " ignore the `num_nodes` argument. To run on multiple nodes in the cloud, launch your app with"
-                " `--cloud`."
+            warnings.warn(
+                f"You set {type(self).__name__}(num_nodes={num_nodes}, ...)` but this app is running locally. "
+                " We assume you are debugging and will ignore the `num_nodes` argument. "
+                " To run on multiple nodes in the cloud, launch your app with `--cloud`."
             )
         self.ws = structures.List(
             *[

--- a/tests/tests_app/components/multi_node/test_base.py
+++ b/tests/tests_app/components/multi_node/test_base.py
@@ -1,0 +1,19 @@
+from re import escape
+
+import pytest
+
+from lightning_app import LightningWork, CloudCompute
+from lightning_app.components import MultiNode
+from tests_app.helpers.utils import no_warning_call
+
+
+def test_multi_node_warn_running_locally():
+    class Work(LightningWork):
+        def run(self):
+            pass
+
+    with pytest.warns(UserWarning, match=escape("You set MultiNode(num_nodes=1, ...)` but ")):
+        MultiNode(Work, num_nodes=2, cloud_compute=CloudCompute("gpu"))
+
+    with no_warning_call(UserWarning, match=escape("You set MultiNode(num_nodes=1, ...)` but ")):
+        MultiNode(Work, num_nodes=1, cloud_compute=CloudCompute("gpu"))

--- a/tests/tests_app/helpers/utils.py
+++ b/tests/tests_app/helpers/utils.py
@@ -1,3 +1,4 @@
+import re
 from contextlib import contextmanager
 from typing import Optional, Type
 

--- a/tests/tests_app/helpers/utils.py
+++ b/tests/tests_app/helpers/utils.py
@@ -1,0 +1,29 @@
+from contextlib import contextmanager
+from typing import Optional, Type
+
+import pytest
+
+
+@contextmanager
+def no_warning_call(expected_warning: Type[Warning] = UserWarning, match: Optional[str] = None):
+    # TODO: Replace with `lightning_utilities.test.warning.no_warning_call`
+    # https://github.com/Lightning-AI/utilities/issues/57
+
+    with pytest.warns(None) as record:
+        yield
+
+    if match is None:
+        try:
+            w = record.pop(expected_warning)
+        except AssertionError:
+            # no warning raised
+            return
+    else:
+        for w in record.list:
+            if w.category is expected_warning and re.compile(match).search(w.message.args[0]):
+                break
+        else:
+            return
+
+    msg = "A warning" if expected_warning is None else f"`{expected_warning.__name__}`"
+    raise AssertionError(f"{msg} was raised: {w}")

--- a/tests/tests_examples_app/public/test_multi_node.py
+++ b/tests/tests_examples_app/public/test_multi_node.py
@@ -11,7 +11,7 @@ class LightningTestMultiNodeApp(LightningTestApp):
     def on_before_run_once(self):
         res = super().on_before_run_once()
         if self.works and all(w.has_stopped for w in self.works):
-            assert len([w for w in self.works]) == 2
+            assert len([w for w in self.works]) == 1
             return True
         return res
 
@@ -34,7 +34,7 @@ class LightningTestMultiNodeWorksApp(LightningTestApp):
     def on_before_run_once(self):
         res = super().on_before_run_once()
         if self.works and all(w.has_stopped for w in self.works):
-            assert len([w for w in self.works]) == 2
+            assert len([w for w in self.works]) == 1
             return True
         return res
 

--- a/tests/tests_examples_app/public/test_multi_node.py
+++ b/tests/tests_examples_app/public/test_multi_node.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from unittest import mock
 
 import pytest
 from tests_examples_app.public import _PATH_EXAMPLES
@@ -11,13 +12,14 @@ class LightningTestMultiNodeApp(LightningTestApp):
     def on_before_run_once(self):
         res = super().on_before_run_once()
         if self.works and all(w.has_stopped for w in self.works):
-            assert len([w for w in self.works]) == 1
+            assert len([w for w in self.works]) == 2
             return True
         return res
 
 
 @pytest.mark.skip(reason="flaky")
-def test_multi_node_example(monkeypatch):
+@mock.patch("lightning_app.components.multi_node.base.is_running_in_cloud", return_value=True)
+def test_multi_node_example(_, monkeypatch):
     monkeypatch.chdir(os.path.join(_PATH_EXAMPLES, "app_multi_node"))
     command_line = [
         "app.py",
@@ -34,7 +36,7 @@ class LightningTestMultiNodeWorksApp(LightningTestApp):
     def on_before_run_once(self):
         res = super().on_before_run_once()
         if self.works and all(w.has_stopped for w in self.works):
-            assert len([w for w in self.works]) == 1
+            assert len([w for w in self.works]) == 2
             return True
         return res
 
@@ -50,7 +52,8 @@ class LightningTestMultiNodeWorksApp(LightningTestApp):
     ],
 )
 @pytest.mark.skipif(sys.platform == "win32", reason="flaky")
-def test_multi_node_examples(app_name, monkeypatch):
+@mock.patch("lightning_app.components.multi_node.base.is_running_in_cloud", return_value=True)
+def test_multi_node_examples(_, app_name, monkeypatch):
     monkeypatch.chdir(os.path.join(_PATH_EXAMPLES, "app_multi_node"))
     command_line = [
         app_name,


### PR DESCRIPTION
## What does this PR do?

Running an app with multi-node components locally is problematic, as processes will collide on the GPUs (you shouldn't `torch.set_device(x)` with the same value for x from multiple processes). The use case is typically when you debug. 

This PR adds a warning and sets the value of num_nodes=1 when running locally. 



## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃


cc @borda