### PR TITLE
Bundle requirements in meta package

### DIFF
--- a/.actions/assistant.py
+++ b/.actions/assistant.py
@@ -113,6 +113,13 @@ def create_mirror_package(source_dir: str, package_mapping: Dict[str, str]) -> N
             target_dir=os.path.join(source_dir, "lightning", new),
         )
 
+    # Copy requirements
+    requirements_source = os.path.join(os.path.dirname(source_dir), "requirements")
+    requirements_target = os.path.join(source_dir, "lightning", "requirements")
+    if os.path.exists(requirements_target):
+        shutil.rmtree(requirements_target)
+    shutil.copytree(requirements_source, requirements_target)
+
 
 class AssistantCLI:
     @staticmethod

--- a/src/lightning/__init__.py
+++ b/src/lightning/__init__.py
@@ -46,6 +46,8 @@ import lightning.app  # isort: skip # noqa: E402
 
 lightning.app._PROJECT_ROOT = os.path.dirname(lightning.app._PROJECT_ROOT)
 
+_REQUIREMENTS_ROOT = os.path.join(os.path.dirname(__file__), "requirements")
+
 # Enable breakpoint within forked processes.
 __builtins__["breakpoint"] = pdb.set_trace
 

--- a/src/lightning/__setup__.py
+++ b/src/lightning/__setup__.py
@@ -32,6 +32,7 @@ def _adjust_manifest(**kwargs: Any) -> None:
         lines = [ln.rstrip() for ln in fp.readlines()]
     lines += [
         "recursive-include src/lightning *.md",
+        "recursive-include src/lightning/requirements *.txt",
         "recursive-include requirements *.txt",
         "recursive-include src/lightning/app/ui *",
         "recursive-include src/lightning/cli/*-template *",  # Add templates as build-in

--- a/src/lightning_app/__setup__.py
+++ b/src/lightning_app/__setup__.py
@@ -75,16 +75,6 @@ def _setup_args(**__: Any) -> Dict[str, Any]:
     # TODO: remove this once lightning-ui package is ready as a dependency
     _setup_tools._download_frontend(_PACKAGE_ROOT)
 
-    _install_requires = _setup_tools.load_requirements(
-        _PATH_REQUIREMENTS, unfreeze="major" if _FREEZE_REQUIREMENTS else "all"
-    )
-
-    _extras_require = _prepare_extras()
-
-    # If running in the cloud, require the cloud extras
-    if "LIGHTNING_APP_STATE_URL" in os.environ:
-        _install_requires = _install_requires + _extras_require["cloud"]
-
     return dict(
         name="lightning-app",
         version=_version.version,
@@ -108,8 +98,10 @@ def _setup_args(**__: Any) -> Dict[str, Any]:
             ],
         },
         setup_requires=["wheel"],
-        install_requires=_install_requires,
-        extras_require=_extras_require,
+        install_requires=_setup_tools.load_requirements(
+            _PATH_REQUIREMENTS, unfreeze="major" if _FREEZE_REQUIREMENTS else "all"
+        ),
+        extras_require=_prepare_extras(),
         project_urls={
             "Bug Tracker": "https://github.com/Lightning-AI/lightning/issues",
             "Documentation": "https://lightning.ai/lightning-docs",

--- a/src/lightning_app/__setup__.py
+++ b/src/lightning_app/__setup__.py
@@ -75,6 +75,16 @@ def _setup_args(**__: Any) -> Dict[str, Any]:
     # TODO: remove this once lightning-ui package is ready as a dependency
     _setup_tools._download_frontend(_PACKAGE_ROOT)
 
+    _install_requires = _setup_tools.load_requirements(
+        _PATH_REQUIREMENTS, unfreeze="major" if _FREEZE_REQUIREMENTS else "all"
+    )
+
+    _extras_require = _prepare_extras()
+
+    # If running in the cloud, require the cloud extras
+    if "LIGHTNING_APP_STATE_URL" in os.environ:
+        _install_requires = _install_requires + _extras_require["cloud"]
+
     return dict(
         name="lightning-app",
         version=_version.version,
@@ -98,10 +108,8 @@ def _setup_args(**__: Any) -> Dict[str, Any]:
             ],
         },
         setup_requires=["wheel"],
-        install_requires=_setup_tools.load_requirements(
-            _PATH_REQUIREMENTS, unfreeze="major" if _FREEZE_REQUIREMENTS else "all"
-        ),
-        extras_require=_prepare_extras(),
+        install_requires=_install_requires,
+        extras_require=_extras_require,
         project_urls={
             "Bug Tracker": "https://github.com/Lightning-AI/lightning/issues",
             "Documentation": "https://lightning.ai/lightning-docs",


### PR DESCRIPTION
## What does this PR do?

We need a way to install cloud extras __after__ lightning has been installed.
After discussion with @Borda, this PR bundles the requirements files into the meta-package so that they can later be referenced and installed without re-installing the package.

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @borda