### PR TITLE
[CLI] fix ssh listing stopped components

### DIFF
--- a/src/lightning_app/CHANGELOG.md
+++ b/src/lightning_app/CHANGELOG.md
@@ -36,8 +36,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fixed debugging with VSCode IDE ([#15747](https://github.com/Lightning-AI/lightning/pull/15747))
-
-
+- Fixed SSH CLI command listing stopped components ([#15810](https://github.com/Lightning-AI/lightning/pull/15810))
 - Fixed the work not stopped when successful when passed directly to the LightningApp ([#15801](https://github.com/Lightning-AI/lightning/pull/15801))
 
 

--- a/src/lightning_app/cli/cmd_apps.py
+++ b/src/lightning_app/cli/cmd_apps.py
@@ -54,9 +54,13 @@ class _AppManager:
             apps = apps + resp.lightningapps
         return apps
 
-    def list_components(self, app_id: str) -> List[Externalv1Lightningwork]:
+    def list_components(self, app_id: str, phase_in: List[str] = []) -> List[Externalv1Lightningwork]:
         project = _get_project(self.api_client)
-        resp = self.api_client.lightningwork_service_list_lightningwork(project_id=project.project_id, app_id=app_id)
+        resp = self.api_client.lightningwork_service_list_lightningwork(
+            project_id=project.project_id,
+            app_id=app_id,
+            phase_in=phase_in,
+        )
         return resp.lightningworks
 
     def list(self, cluster_id: str = None, limit: int = 100) -> None:

--- a/src/lightning_app/cli/lightning_cli.py
+++ b/src/lightning_app/cli/lightning_cli.py
@@ -8,7 +8,7 @@ import arrow
 import click
 import inquirer
 import rich
-from lightning_cloud.openapi import Externalv1LightningappInstance, V1LightningappInstanceState
+from lightning_cloud.openapi import Externalv1LightningappInstance, V1LightningappInstanceState, V1LightningworkState
 from lightning_cloud.openapi.rest import ApiException
 from lightning_utilities.core.imports import RequirementCache
 from requests.exceptions import ConnectionError
@@ -420,7 +420,7 @@ def ssh(app_name: str = None, component_name: str = None) -> None:
     except ApiException:
         raise click.ClickException("failed fetching app instance")
 
-    components = app_manager.list_components(app_id=app_id)
+    components = app_manager.list_components(app_id=app_id, phase_in=[V1LightningworkState.RUNNING])
     available_component_names = [work.name for work in components] + ["flow"]
     if component_name is None:
         available_components = [

--- a/tests/tests_app/cli/test_cmd_apps.py
+++ b/tests/tests_app/cli/test_cmd_apps.py
@@ -7,7 +7,9 @@ from lightning_cloud.openapi import (
     V1LightningappInstanceSpec,
     V1LightningappInstanceState,
     V1LightningappInstanceStatus,
+    V1LightningworkState,
     V1ListLightningappInstancesResponse,
+    V1ListLightningworkResponse,
     V1ListMembershipsResponse,
     V1Membership,
 )
@@ -95,6 +97,36 @@ def test_list_all_apps(list_memberships: mock.MagicMock, list_instances: mock.Ma
 
     list_memberships.assert_called_once()
     list_instances.assert_called_once_with(project_id="default-project", limit=100, phase_in=[])
+
+
+@mock.patch("lightning_cloud.login.Auth.authenticate", MagicMock())
+@mock.patch("lightning_app.utilities.network.LightningClient.lightningwork_service_list_lightningwork")
+@mock.patch("lightning_app.utilities.network.LightningClient.projects_service_list_memberships")
+def test_list_components(list_memberships: mock.MagicMock, list_components: mock.MagicMock):
+    list_memberships.return_value = V1ListMembershipsResponse(memberships=[V1Membership(project_id="default-project")])
+    list_components.return_value = V1ListLightningworkResponse(lightningworks=[])
+
+    cluster_manager = _AppManager()
+    cluster_manager.list_components(app_id="cheese")
+
+    list_memberships.assert_called_once()
+    list_components.assert_called_once_with(project_id="default-project", app_id="cheese", phase_in=[])
+
+
+@mock.patch("lightning_cloud.login.Auth.authenticate", MagicMock())
+@mock.patch("lightning_app.utilities.network.LightningClient.lightningwork_service_list_lightningwork")
+@mock.patch("lightning_app.utilities.network.LightningClient.projects_service_list_memberships")
+def test_list_components_with_phase(list_memberships: mock.MagicMock, list_components: mock.MagicMock):
+    list_memberships.return_value = V1ListMembershipsResponse(memberships=[V1Membership(project_id="default-project")])
+    list_components.return_value = V1ListLightningworkResponse(lightningworks=[])
+
+    cluster_manager = _AppManager()
+    cluster_manager.list_components(app_id="cheese", phase_in=[V1LightningworkState.RUNNING])
+
+    list_memberships.assert_called_once()
+    list_components.assert_called_once_with(
+        project_id="default-project", app_id="cheese", phase_in=[V1LightningworkState.RUNNING]
+    )
 
 
 @mock.patch("lightning_cloud.login.Auth.authenticate", MagicMock())


### PR DESCRIPTION
## What does this PR do?

Today, `lightning ssh` shows stopped components as well. This is confusing as users can't access those stopped instances.
This PR fixes this behaviour to only list running work.

Fixes #\<issue_number>

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
