### PR TITLE
[App] Fixing Sigterm Handler causing thread lock which caused KeyboardInterrupt to hang

### DIFF
--- a/src/lightning_app/CHANGELOG.md
+++ b/src/lightning_app/CHANGELOG.md
@@ -42,6 +42,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed the `enable_spawn` method of the `WorkRunExecutor` ([#15812](https://github.com/Lightning-AI/lightning/pull/15812)
 
+- Fixed Sigterm Handler causing thread lock which caused KeyboardInterrupt to hang ([#15881](https://github.com/Lightning-AI/lightning/pull/15881))
+
 
 ## [1.8.3] - 2022-11-22
 

--- a/src/lightning_app/runners/multiprocess.py
+++ b/src/lightning_app/runners/multiprocess.py
@@ -27,6 +27,7 @@ class MultiProcessRuntime(Runtime):
     """
 
     backend: Union[str, Backend] = "multiprocessing"
+    _has_triggered_termination: bool = False
 
     def dispatch(self, *args: Any, on_before_run: Optional[Callable] = None, **kwargs: Any):
         """Method to dispatch and run the LightningApp."""
@@ -111,9 +112,11 @@ class MultiProcessRuntime(Runtime):
             self.app._run()
         except KeyboardInterrupt:
             self.terminate()
+            self._has_triggered_termination = True
             raise
         finally:
-            self.terminate()
+            if not self._has_triggered_termination:
+                self.terminate()
 
     def terminate(self):
         if APP_SERVER_IN_CLOUD:


### PR DESCRIPTION
## What does this PR do?

Multiprocessing runtime was configured to call `terminate` on the work process twice

```python
        except KeyboardInterrupt:
            self.terminate()
            raise
        finally:
            self.terminate()
```

The second `terminate` would cancel the first sigterm handler call but cancellation of a handler wouldn't release the thread lock causing the second sigterm handler to be on a deadlock

Note: We still have issues with uvloop overriding the signal handlers. But that's a different issue

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fixes #\<issue_number>

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @borda