### PR TITLE
Make LightningModule torch.jit.script-able again

### DIFF
--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -88,6 +88,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed issue with unsupported torch.inference_mode() on hpu backends ([#15918](https://github.com/Lightning-AI/lightning/pull/15918))
 
 
+- Fixed `torch.jit.script`-ing a LightningModule causing an unintended error message about deprecated `use_amp` property ([#15947](https://github.com/Lightning-AI/lightning/pull/15947))
+
+
 ## [1.8.3] - 2022-11-22
 
 ### Changed

--- a/src/pytorch_lightning/_graveyard/core.py
+++ b/src/pytorch_lightning/_graveyard/core.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from typing import Any
 
-from pytorch_lightning import LightningDataModule, LightningModule
+from pytorch_lightning import LightningDataModule
 
 
 def _on_save_checkpoint(_: LightningDataModule, __: Any) -> None:
@@ -31,28 +31,6 @@ def _on_load_checkpoint(_: LightningDataModule, __: Any) -> None:
         " Use `load_state_dict` instead."
     )
 
-
-def _use_amp(_: LightningModule) -> None:
-    # Remove in v2.0.0 and the skip in `__jit_unused_properties__`
-    if not LightningModule._jit_is_scripting:
-        # cannot use `AttributeError` as it messes up with `nn.Module.__getattr__`
-        raise RuntimeError(
-            "`LightningModule.use_amp` was deprecated in v1.6 and is no longer accessible as of v1.8."
-            " Please use `Trainer.amp_backend`.",
-        )
-
-
-def _use_amp_setter(_: LightningModule, __: bool) -> None:
-    # Remove in v2.0.0
-    # cannot use `AttributeError` as it messes up with `nn.Module.__getattr__`
-    raise RuntimeError(
-        "`LightningModule.use_amp` was deprecated in v1.6 and is no longer accessible as of v1.8."
-        " Please use `Trainer.amp_backend`.",
-    )
-
-
-# Properties
-LightningModule.use_amp = property(fget=_use_amp, fset=_use_amp_setter)
 
 # Methods
 LightningDataModule.on_save_checkpoint = _on_save_checkpoint

--- a/src/pytorch_lightning/core/module.py
+++ b/src/pytorch_lightning/core/module.py
@@ -88,7 +88,6 @@ class LightningModule(
             "automatic_optimization",
             "truncated_bptt_steps",
             "trainer",
-            "use_amp",  # from graveyard
         ]
         + _DeviceDtypeModuleMixin.__jit_unused_properties__
         + HyperparametersMixin.__jit_unused_properties__

--- a/tests/tests_pytorch/core/test_lightning_module.py
+++ b/tests/tests_pytorch/core/test_lightning_module.py
@@ -426,6 +426,7 @@ def test_proper_refcount():
 
 
 def test_lightning_module_scriptable():
+    """Test that the LightningModule is `torch.jit.script`-able. Regression test for #15917."""
     model = BoringModel()
     trainer = Trainer()
     model.trainer = trainer

--- a/tests/tests_pytorch/core/test_lightning_module.py
+++ b/tests/tests_pytorch/core/test_lightning_module.py
@@ -425,6 +425,13 @@ def test_proper_refcount():
     assert sys.getrefcount(torch_module) == sys.getrefcount(lightning_module)
 
 
+def test_lightning_module_scriptable():
+    model = BoringModel()
+    trainer = Trainer()
+    model.trainer = trainer
+    torch.jit.script(model)
+
+
 def test_trainer_reference_recursively():
     ensemble = LightningModule()
     inner = LightningModule()

--- a/tests/tests_pytorch/graveyard/test_core.py
+++ b/tests/tests_pytorch/graveyard/test_core.py
@@ -53,18 +53,3 @@ def test_v2_0_0_unsupported_datamodule_on_save_load_checkpoint():
         match="`LightningDataModule.on_load_checkpoint`.*no longer supported as of v1.8.",
     ):
         trainer.fit(model, OnLoadDataModule())
-
-
-def test_v2_0_0_lightning_module_unsupported_use_amp():
-    model = BoringModel()
-    with pytest.raises(
-        RuntimeError,
-        match="`LightningModule.use_amp`.*no longer accessible as of v1.8.",
-    ):
-        model.use_amp
-
-    with pytest.raises(
-        RuntimeError,
-        match="`LightningModule.use_amp`.*no longer accessible as of v1.8.",
-    ):
-        model.use_amp = False


### PR DESCRIPTION
## What does this PR do?

Fixes #15917

torch.jit.script has issues with properties. Related to #10092 and it is an unsolved problem in torch, see https://github.com/pytorch/pytorch/issues/67146. It is unclear whether this can ever be addressed, as pytorch 2.0 will bring a different compiler that is substantially more powerful than torch.jit.script for program capture.

We were triggering this issue by patching a property onto the LightningModule from the graveyard: https://github.com/Lightning-AI/lightning/pull/12315

cc @borda @carmocca @justusschock @awaelchli @lantiga 

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃

cc @carmocca @justusschock @awaelchli @borda