### PR TITLE
Fix typo in package publish action

### DIFF
--- a/.github/actions/pkg-publish/action.yml
+++ b/.github/actions/pkg-publish/action.yml
@@ -30,7 +30,7 @@ runs:
     if: inputs.pypi-test-token != ''
     with:
       user: __token__
-      password: ${{ input.pypi-test-token }}
+      password: ${{ inputs.pypi-test-token }}
       repository_url: https://test.pypi.org/legacy/
       packages_dir: pypi/
       verbose: true


### PR DESCRIPTION
Fix a typo in the github release workflow

cc @borda