### PR TITLE
[App] Temporarily disable ready

### DIFF
--- a/src/lightning_app/core/app.py
+++ b/src/lightning_app/core/app.py
@@ -488,7 +488,13 @@ class LightningApp:
         done = False
 
         # TODO: Re-enable the `ready` property once issues are resolved
-        self.ready = True  # self.root.ready
+        if not self.root.ready:
+            warnings.warn(
+                "One of your Flows returned `.ready` as `False`. "
+                "This feature is not yet enabled so this will be ignored.",
+                UserWarning,
+            )
+        self.ready = True
 
         self._start_with_flow_works()
 

--- a/src/lightning_app/core/app.py
+++ b/src/lightning_app/core/app.py
@@ -486,7 +486,9 @@ class LightningApp:
         """
         self._original_state = deepcopy(self.state)
         done = False
-        self.ready = self.root.ready
+
+        # TODO: Re-enable the `ready` property once issues are resolved
+        self.ready = True  # self.root.ready
 
         self._start_with_flow_works()
 

--- a/src/lightning_app/core/flow.py
+++ b/src/lightning_app/core/flow.py
@@ -232,7 +232,10 @@ class LightningFlow:
 
     @property
     def ready(self) -> bool:
-        """Override to customize when your App should be ready."""
+        """Not currently enabled.
+
+        Override to customize when your App should be ready.
+        """
         flows = self.flows
         return all(flow.ready for flow in flows.values()) if flows else True
 


### PR DESCRIPTION
## What does this PR do?

As the `ready` property delays the app health endpoint, it can cause issues with the platform. Disabling it for now while we work on a fix.

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
