### PR TITLE
Fix ImportErrors on Multinode if package not present

### DIFF
--- a/src/lightning_app/CHANGELOG.md
+++ b/src/lightning_app/CHANGELOG.md
@@ -66,6 +66,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed PythonServer generating noise on M1 ([#15949](https://github.com/Lightning-AI/lightning/pull/15949))
 
+- Fixed `ImportError` on Multinode if package not present ([#15963](https://github.com/Lightning-AI/lightning/pull/15963))
+
 
 ## [1.8.3] - 2022-11-22
 

--- a/src/lightning_app/components/multi_node/lite.py
+++ b/src/lightning_app/components/multi_node/lite.py
@@ -37,11 +37,14 @@ class _LiteRunExecutor(_PyTorchSpawnRunExecutor):
         mps_accelerators = []
 
         for pkg_name in ("lightning.lite", "lightning_" + "lite"):
-            pkg = importlib.import_module(pkg_name)
-            lites.append(pkg.LightningLite)
-            strategies.append(pkg.strategies.DDPSpawnShardedStrategy)
-            strategies.append(pkg.strategies.DDPSpawnStrategy)
-            mps_accelerators.append(pkg.accelerators.MPSAccelerator)
+            try:
+                pkg = importlib.import_module(pkg_name)
+                lites.append(pkg.LightningLite)
+                strategies.append(pkg.strategies.DDPSpawnShardedStrategy)
+                strategies.append(pkg.strategies.DDPSpawnStrategy)
+                mps_accelerators.append(pkg.accelerators.MPSAccelerator)
+            except (ImportError, ModuleNotFoundError):
+                continue
 
         # Used to configure PyTorch progress group
         os.environ["MASTER_ADDR"] = main_address

--- a/src/lightning_app/components/multi_node/trainer.py
+++ b/src/lightning_app/components/multi_node/trainer.py
@@ -37,11 +37,14 @@ class _LightningTrainerRunExecutor(_PyTorchSpawnRunExecutor):
         mps_accelerators = []
 
         for pkg_name in ("lightning.pytorch", "pytorch_" + "lightning"):
-            pkg = importlib.import_module(pkg_name)
-            trainers.append(pkg.Trainer)
-            strategies.append(pkg.strategies.DDPSpawnShardedStrategy)
-            strategies.append(pkg.strategies.DDPSpawnStrategy)
-            mps_accelerators.append(pkg.accelerators.MPSAccelerator)
+            try:
+                pkg = importlib.import_module(pkg_name)
+                trainers.append(pkg.Trainer)
+                strategies.append(pkg.strategies.DDPSpawnShardedStrategy)
+                strategies.append(pkg.strategies.DDPSpawnStrategy)
+                mps_accelerators.append(pkg.accelerators.MPSAccelerator)
+            except (ImportError, ModuleNotFoundError):
+                continue
 
         # Used to configure PyTorch progress group
         os.environ["MASTER_ADDR"] = main_address


### PR DESCRIPTION
## What does this PR do?

This fixes the case where either the `lightning.pytorch`/`pytorch_lightning or the `lightning.lite` or the `lightning_lite` are not available. This doesn't show in CI, since the packages are still in pythonpath even if not installed.

cc @borda