### PR TITLE
Avoid using the same port number for autoscaler works

### DIFF
--- a/examples/app_server_with_auto_scaler/app.py
+++ b/examples/app_server_with_auto_scaler/app.py
@@ -22,8 +22,6 @@ class BatchResponse(BaseModel):
 
 class PyTorchServer(L.app.components.PythonServer):
     def __init__(self, *args, **kwargs):
-        print(args)
-        print(kwargs)
         super().__init__(
             input_type=BatchRequestModel,
             output_type=BatchResponse,

--- a/examples/app_server_with_auto_scaler/app.py
+++ b/examples/app_server_with_auto_scaler/app.py
@@ -36,9 +36,6 @@ class PyTorchServer(L.app.components.PythonServer):
         self._model = torchvision.models.resnet18(pretrained=True).to(self._device)
 
     def predict(self, requests: BatchRequestModel):
-        import time
-
-        time.sleep(60)
         transforms = torchvision.transforms.Compose(
             [
                 torchvision.transforms.Resize(224),
@@ -63,16 +60,14 @@ class MyAutoScaler(L.app.components.AutoScaler):
         """The default scaling logic that users can override."""
         # scale out if the number of pending requests exceeds max batch size.
         max_requests_per_work = self.max_batch_size
-        pending_requests_per_running_or_pending_work = metrics["pending_requests"] / (
-            replicas + metrics["pending_works"]
-        )
-        if pending_requests_per_running_or_pending_work >= max_requests_per_work:
+        pending_requests_per_work = metrics["pending_requests"] / (replicas + metrics["pending_works"])
+        if pending_requests_per_work >= max_requests_per_work:
             return replicas + 1
 
         # scale in if the number of pending requests is below 25% of max_requests_per_work
         min_requests_per_work = max_requests_per_work * 0.25
-        pending_requests_per_running_work = metrics["pending_requests"] / replicas
-        if pending_requests_per_running_work < min_requests_per_work:
+        pending_requests_per_work = metrics["pending_requests"] / replicas
+        if pending_requests_per_work < min_requests_per_work:
             return replicas - 1
 
         return replicas
@@ -80,17 +75,17 @@ class MyAutoScaler(L.app.components.AutoScaler):
 
 app = L.LightningApp(
     MyAutoScaler(
-        # server class and args
+        # work class and args
         PyTorchServer,
-        cloud_compute=L.CloudCompute("default"),
+        cloud_compute=L.CloudCompute("gpu"),
         # autoscaler specific args
         min_replicas=1,
         max_replicas=4,
-        autoscale_interval=1,
+        autoscale_interval=10,
         endpoint="predict",
         input_type=RequestModel,
         output_type=Any,
         timeout_batching=1,
-        max_batch_size=1,
+        max_batch_size=8,
     )
 )

--- a/src/lightning_app/CHANGELOG.md
+++ b/src/lightning_app/CHANGELOG.md
@@ -41,6 +41,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Apps without UIs no longer activate the "Open App" button when running in the cloud ([#15875](https://github.com/Lightning-AI/lightning/pull/15875))
 
+- Changed the default port of `PythonServer` from `7777` to a free port at runtime ([#15966](https://github.com/Lightning-AI/lightning/pull/15966))
+
 
 ### Deprecated
 

--- a/src/lightning_app/CHANGELOG.md
+++ b/src/lightning_app/CHANGELOG.md
@@ -75,6 +75,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed detection of a Lightning App running in debug mode ([#15951](https://github.com/Lightning-AI/lightning/pull/15951))
 
+- Fixed `AutoScaler` failing due to port collision across works ([#15966](https://github.com/Lightning-AI/lightning/pull/15966))
+
 
 ## [1.8.3] - 2022-11-22
 

--- a/src/lightning_app/components/auto_scaler.py
+++ b/src/lightning_app/components/auto_scaler.py
@@ -22,6 +22,7 @@ from starlette.status import HTTP_401_UNAUTHORIZED
 from lightning_app.core.flow import LightningFlow
 from lightning_app.core.work import LightningWork
 from lightning_app.utilities.app_helpers import Logger
+from lightning_app.utilities.network import find_free_network_port
 from lightning_app.utilities.packaging.cloud_compute import CloudCompute
 
 logger = Logger(__name__)
@@ -445,8 +446,14 @@ class AutoScaler(LightningFlow):
 
     def create_work(self) -> LightningWork:
         """Replicates a LightningWork instance with args and kwargs provided via ``__init__``."""
-        # TODO: Remove `start_with_flow=False` for faster initialization on the cloud
-        return self._work_cls(*self._work_args, **self._work_kwargs, start_with_flow=False)
+        self._work_kwargs.update(
+            dict(
+                port=find_free_network_port(),
+                # TODO: Remove `start_with_flow=False` for faster initialization on the cloud
+                start_with_flow=False,
+            )
+        )
+        return self._work_cls(*self._work_args, **self._work_kwargs)
 
     def add_work(self, work) -> str:
         """Adds a new LightningWork instance.

--- a/src/lightning_app/components/auto_scaler.py
+++ b/src/lightning_app/components/auto_scaler.py
@@ -22,7 +22,6 @@ from starlette.status import HTTP_401_UNAUTHORIZED
 from lightning_app.core.flow import LightningFlow
 from lightning_app.core.work import LightningWork
 from lightning_app.utilities.app_helpers import Logger
-from lightning_app.utilities.network import find_free_network_port
 from lightning_app.utilities.packaging.cloud_compute import CloudCompute
 
 logger = Logger(__name__)
@@ -446,13 +445,8 @@ class AutoScaler(LightningFlow):
 
     def create_work(self) -> LightningWork:
         """Replicates a LightningWork instance with args and kwargs provided via ``__init__``."""
-        self._work_kwargs.update(
-            dict(
-                port=find_free_network_port(),
-                # TODO: Remove `start_with_flow=False` for faster initialization on the cloud
-                start_with_flow=False,
-            )
-        )
+        # TODO: Remove `start_with_flow=False` for faster initialization on the cloud
+        self._work_kwargs.update(dict(start_with_flow=False))
         return self._work_cls(*self._work_args, **self._work_kwargs)
 
     def add_work(self, work) -> str:

--- a/src/lightning_app/components/serve/python_server.py
+++ b/src/lightning_app/components/serve/python_server.py
@@ -75,8 +75,6 @@ class PythonServer(LightningWork, abc.ABC):
     @requires(["torch", "lightning_api_access"])
     def __init__(  # type: ignore
         self,
-        host: str = "127.0.0.1",
-        port: int = 7777,
         input_type: type = _DefaultInputData,
         output_type: type = _DefaultOutputData,
         **kwargs,
@@ -84,8 +82,6 @@ class PythonServer(LightningWork, abc.ABC):
         """The PythonServer Class enables to easily get your machine learning server up and running.
 
         Arguments:
-            host: Address to be used for running the server.
-            port: Port to be used to running the server.
             input_type: Optional `input_type` to be provided. This needs to be a pydantic BaseModel class.
                 The default data type is good enough for the basic usecases and it expects the data
                 to be a json object that has one key called `payload`
@@ -129,7 +125,7 @@ class PythonServer(LightningWork, abc.ABC):
             ...
             >>> app = LightningApp(SimpleServer())
         """
-        super().__init__(parallel=True, host=host, port=port, **kwargs)
+        super().__init__(parallel=True, **kwargs)
         if not issubclass(input_type, BaseModel):
             raise TypeError("input_type must be a pydantic BaseModel class")
         if not issubclass(output_type, BaseModel):


### PR DESCRIPTION
## What does this PR do?
- Fixes the autoscaler example.
- Removes the restriction of manually setting a new port number to use with autoscaler. (Missed in the previous autoscaler PR #15769.)

### Does your PR introduce any breaking changes? If yes, please list them.
None

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @borda