### PR TITLE
Integrate CheckGroup v5.3

### DIFF
--- a/.github/workflows/probot-check-group.yml
+++ b/.github/workflows/probot-check-group.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event.pull_request.draft == false
     timeout-minutes: 61  # in case something is wrong with the internal timeout
     steps:
-      - uses: Lightning-AI/probot@v5.2
+      - uses: Lightning-AI/probot@v5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## What does this PR do?

Noticed a bug where checkgroup would not pull the latest run of a workflow, if it had been run multiple times. Fixed in https://github.com/Lightning-AI/probot/pull/8

### Does your PR introduce any breaking changes? If yes, please list them.

None

cc @carmocca @akihironitta @borda