### PR TITLE
Deprecate nvidia/apex

### DIFF
--- a/docs/source-pytorch/accelerators/gpu_intermediate.rst
+++ b/docs/source-pytorch/accelerators/gpu_intermediate.rst
@@ -469,9 +469,6 @@ Validation and test step have the same option when using DP.
 Distributed and 16-bit precision
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Due to an issue with Apex and DataParallel (PyTorch and NVIDIA issue), Lightning does
-not allow 16-bit and DP training. We tried to get this to work, but it's an issue on their end.
-
 Below are the possible configurations we support.
 
 +-------+---------+-----+-----+--------+-----------------------------------------------------------------------+
@@ -487,7 +484,7 @@ Below are the possible configurations we support.
 +-------+---------+-----+-----+--------+-----------------------------------------------------------------------+
 |       | Y       |     | Y   | Y      | `Trainer(accelerator="gpu", devices=k, strategy='ddp', precision=16)` |
 +-------+---------+-----+-----+--------+-----------------------------------------------------------------------+
-
+# FIXME(carlos): check native amp and DP
 
 Implement Your Own Distributed (DDP) training
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source-pytorch/accelerators/gpu_intermediate.rst
+++ b/docs/source-pytorch/accelerators/gpu_intermediate.rst
@@ -472,19 +472,23 @@ Distributed and 16-bit precision
 Below are the possible configurations we support.
 
 +-------+---------+-----+-----+--------+-----------------------------------------------------------------------+
-| 1 GPU | 1+ GPUs | DP  | DDP | 16-bit | command                                                               |
+| 1 GPU | 1+ GPUs | DDP  | DP | 16-bit | command                                                               |
 +=======+=========+=====+=====+========+=======================================================================+
 | Y     |         |     |     |        | `Trainer(accelerator="gpu", devices=1)`                               |
 +-------+---------+-----+-----+--------+-----------------------------------------------------------------------+
 | Y     |         |     |     | Y      | `Trainer(accelerator="gpu", devices=1, precision=16)`                 |
 +-------+---------+-----+-----+--------+-----------------------------------------------------------------------+
-|       | Y       | Y   |     |        | `Trainer(accelerator="gpu", devices=k, strategy='dp')`                |
+|       | Y       | Y   |     |        | `Trainer(accelerator="gpu", devices=k, strategy='ddp')`               |
 +-------+---------+-----+-----+--------+-----------------------------------------------------------------------+
-|       | Y       |     | Y   |        | `Trainer(accelerator="gpu", devices=k, strategy='ddp')`               |
+|       | Y       | Y   |     | Y      | `Trainer(accelerator="gpu", devices=k, strategy='ddp', precision=16)` |
 +-------+---------+-----+-----+--------+-----------------------------------------------------------------------+
-|       | Y       |     | Y   | Y      | `Trainer(accelerator="gpu", devices=k, strategy='ddp', precision=16)` |
+|       | Y       |     | Y   |        | `Trainer(accelerator="gpu", devices=k, strategy='dp')`                |
 +-------+---------+-----+-----+--------+-----------------------------------------------------------------------+
-# FIXME(carlos): check native amp and DP
+|       | Y       |     | Y   | Y      | `Trainer(accelerator="gpu", devices=k, strategy='dp', precision=16)`  |
++-------+---------+-----+-----+--------+-----------------------------------------------------------------------+
+
+DDP and DP can also be used with 1 GPU, but there's no reason to do so other than debugging distributed-related issues.
+
 
 Implement Your Own Distributed (DDP) training
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source-pytorch/api_references.rst
+++ b/docs/source-pytorch/api_references.rst
@@ -184,7 +184,6 @@ precision
     :nosignatures:
     :template: classtemplate.rst
 
-    ApexMixedPrecisionPlugin
     ColossalAIPrecisionPlugin
     DeepSpeedPrecisionPlugin
     DoublePrecisionPlugin
@@ -192,7 +191,7 @@ precision
     FullyShardedNativeNativeMixedPrecisionPlugin
     HPUPrecisionPlugin
     IPUPrecisionPlugin
-    NativeMixedPrecisionPlugin
+    MixedPrecisionPlugin
     PrecisionPlugin
     ShardedNativeMixedPrecisionPlugin
     TPUBf16PrecisionPlugin

--- a/docs/source-pytorch/common/checkpointing_basic.rst
+++ b/docs/source-pytorch/common/checkpointing_basic.rst
@@ -186,5 +186,5 @@ If you don't just want to load weights, but instead restore the full training, d
    model = LitModel()
    trainer = Trainer()
 
-   # automatically restores model, epoch, step, LR schedulers, apex, etc...
+   # automatically restores model, epoch, step, LR schedulers, etc...
    trainer.fit(model, ckpt_path="some/path/to/my_checkpoint.ckpt")

--- a/docs/source-pytorch/common/optimization.rst
+++ b/docs/source-pytorch/common/optimization.rst
@@ -151,7 +151,6 @@ For example, here step optimizer A every batch and optimizer B every 2 batches.
         optimizer_idx,
         optimizer_closure,
         on_tpu=False,
-        using_native_amp=False,
         using_lbfgs=False,
     ):
         # update generator every step
@@ -183,7 +182,6 @@ Here we add a manual learning rate warm-up without an lr scheduler.
         optimizer_idx,
         optimizer_closure,
         on_tpu=False,
-        using_native_amp=False,
         using_lbfgs=False,
     ):
         # update params
@@ -215,7 +213,6 @@ to perform a step, Lightning won't be able to support accelerators, precision an
         optimizer_idx,
         optimizer_closure,
         on_tpu=False,
-        using_native_amp=False,
         using_lbfgs=False,
     ):
         optimizer.step(closure=optimizer_closure)
@@ -232,7 +229,6 @@ to perform a step, Lightning won't be able to support accelerators, precision an
         optimizer_idx,
         optimizer_closure,
         on_tpu=False,
-        using_native_amp=False,
         using_lbfgs=False,
     ):
         optimizer = optimizer.optimizer

--- a/docs/source-pytorch/common/precision_intermediate.rst
+++ b/docs/source-pytorch/common/precision_intermediate.rst
@@ -58,6 +58,7 @@ FP16 Mixed Precision
 ********************
 
 In most cases, mixed precision uses FP16. Supported `PyTorch operations <https://pytorch.org/docs/stable/amp.html#op-specific-behavior>`__ automatically run in FP16, saving memory and improving throughput on the supported accelerators.
+Since computation happens in FP16, there is a chance of numerical instability during training. This is handled internally by a dynamic grad scaler which skips invalid steps and adjusts the scaler to ensure subsequent steps fall within a finite range. For more information `see the autocast docs <https://pytorch.org/docs/stable/amp.html#gradient-scaling>`__.
 
 
 .. note::
@@ -68,46 +69,6 @@ In most cases, mixed precision uses FP16. Supported `PyTorch operations <https:/
     :skipif: not torch.cuda.is_available()
 
     Trainer(accelerator="gpu", devices=1, precision=16)
-
-
-PyTorch Native
---------------
-
-PyTorch 1.6 release introduced mixed precision functionality into their core as the AMP package, `torch.cuda.amp <https://pytorch.org/docs/stable/amp.html>`__. It is more flexible and intuitive compared to `NVIDIA APEX <https://github.com/NVIDIA/apex>`__.
-Since computation happens in FP16, there is a chance of numerical instability during training. This is handled internally by a dynamic grad scaler which skips invalid steps and adjusts the scaler to ensure subsequent steps fall within a finite range. For more information `see the autocast docs <https://pytorch.org/docs/stable/amp.html#gradient-scaling>`__.
-Lightning uses native amp by default with ``precision=16|"bf16"``. You can also set it using:
-
-.. testcode::
-
-    Trainer(precision=16, amp_backend="native")
-
-
-NVIDIA APEX
------------
-
-.. warning::
-
-    We strongly recommend using the above native mixed precision rather than NVIDIA APEX unless you require more refined control.
-
-`NVIDIA APEX <https://github.com/NVIDIA/apex>`__ offers additional flexibility in setting mixed precision. This can be useful when trying out different precision configurations, such as keeping most of your weights in FP16 and running computation in FP16.
-
-.. testcode::
-    :skipif: not _APEX_AVAILABLE or not torch.cuda.is_available()
-
-    Trainer(accelerator="gpu", devices=1, amp_backend="apex", precision=16)
-
-Set the `NVIDIA optimization level <https://nvidia.github.io/apex/amp.html#opt-levels>`__ via the precision plugin.
-
-.. testcode::
-    :skipif: not _APEX_AVAILABLE or not torch.cuda.is_available()
-
-    from pytorch_lightning.plugins import ApexMixedPrecisionPlugin
-
-
-    apex_plugin = ApexMixedPrecisionPlugin(amp_level="O3")
-    Trainer(accelerator="gpu", devices=1, precision=16, plugins=[apex_plugin])
-
-----
 
 ************************
 BFloat16 Mixed Precision

--- a/docs/source-pytorch/common/trainer.rst
+++ b/docs/source-pytorch/common/trainer.rst
@@ -289,27 +289,6 @@ Example::
     # no accumulation for epochs 1-4. accumulate 3 for epochs 5-10. accumulate 20 after that
     trainer = Trainer(accumulate_grad_batches={5: 3, 10: 20})
 
-amp_backend
-^^^^^^^^^^^
-
-.. raw:: html
-
-    <video width="50%" max-width="400px" controls
-    poster="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/pl_docs/trainer_flags/thumb/amp_backend.jpg"
-    src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/pl_docs/trainer_flags/amp_backend.mp4"></video>
-
-|
-
-Use PyTorch AMP ('native'), or NVIDIA apex ('apex').
-
-.. testcode::
-
-    # using PyTorch built-in AMP, default used by the Trainer
-    trainer = Trainer(amp_backend="native")
-
-    # using NVIDIA Apex
-    trainer = Trainer(amp_backend="apex")
-
 auto_scale_batch_size
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -1155,27 +1134,6 @@ Half precision, or mixed precision, is the combined use of 32 and 16 bit floatin
 
 
 .. note:: When running on TPUs, torch.bfloat16 will be used but tensor printing will still show torch.float32.
-
-.. admonition::  If you are interested in using Apex 16-bit training:
-   :class: dropdown
-
-    NVIDIA Apex and DDP have instability problems. We recommend using the native AMP for 16-bit precision with multiple GPUs.
-    To use Apex 16-bit training:
-
-    1. `Install apex. <https://github.com/NVIDIA/apex#quick-start>`__
-
-    2. Set the ``precision`` trainer flag to 16. You can customize the `Apex optimization level <https://nvidia.github.io/apex/amp.html#opt-levels>`_ by setting the ``amp_level`` flag
-       in the precision plugin.
-
-    .. testcode::
-        :skipif: not _APEX_AVAILABLE or not torch.cuda.is_available()
-
-        from pytorch_lightning.plugins import ApexMixedPrecisionPlugin
-
-
-        apex_plugin = ApexMixedPrecisionPlugin(amp_level="O2")
-        # turn on 16-bit
-        trainer = Trainer(accelerator="gpu", devices=1, precision=16, plugins=[apex_plugin])
 
 profiler
 ^^^^^^^^

--- a/docs/source-pytorch/conf.py
+++ b/docs/source-pytorch/conf.py
@@ -398,7 +398,6 @@ from pytorch_lightning import LightningDataModule, LightningModule, Trainer, see
 from pytorch_lightning.callbacks import Callback
 from pytorch_lightning.cli import _JSONARGPARSE_SIGNATURES_AVAILABLE as _JSONARGPARSE_AVAILABLE
 from pytorch_lightning.utilities import (
-    _APEX_AVAILABLE,
     _TORCHVISION_AVAILABLE,
 )
 from pytorch_lightning.loggers.neptune import _NEPTUNE_AVAILABLE

--- a/docs/source-pytorch/extensions/plugins.rst
+++ b/docs/source-pytorch/extensions/plugins.rst
@@ -52,7 +52,6 @@ The full list of built-in precision plugins is listed below.
     :nosignatures:
     :template: classtemplate.rst
 
-    ApexMixedPrecisionPlugin
     ColossalAIPrecisionPlugin
     DeepSpeedPrecisionPlugin
     DoublePrecisionPlugin
@@ -60,7 +59,7 @@ The full list of built-in precision plugins is listed below.
     FullyShardedNativeNativeMixedPrecisionPlugin
     HPUPrecisionPlugin
     IPUPrecisionPlugin
-    NativeMixedPrecisionPlugin
+    MixedPrecisionPlugin
     PrecisionPlugin
     ShardedNativeMixedPrecisionPlugin
     TPUBf16PrecisionPlugin

--- a/docs/source-pytorch/model/manual_optimization.rst
+++ b/docs/source-pytorch/model/manual_optimization.rst
@@ -319,4 +319,4 @@ Here is an example using a closure function.
         opt.step(closure=closure)
 
 .. warning::
-   The :class:`~torch.optim.LBFGS` optimizer is not supported for apex AMP, native AMP, IPUs, or DeepSpeed.
+   The :class:`~torch.optim.LBFGS` optimizer is not supported for AMP, IPUs, or DeepSpeed.

--- a/src/lightning_lite/connector.py
+++ b/src/lightning_lite/connector.py
@@ -26,7 +26,7 @@ from lightning_lite.accelerators.tpu import TPUAccelerator
 from lightning_lite.plugins import (
     CheckpointIO,
     DeepSpeedPrecision,
-    NativeMixedPrecision,
+    MixedPrecision,
     Precision,
     TPUBf16Precision,
     TPUPrecision,
@@ -476,7 +476,7 @@ class _Connector:
 
             if isinstance(self.strategy, FSDPStrategy):
                 return FSDPPrecision(precision=self._precision_input, device=device)
-            return NativeMixedPrecision(precision=self._precision_input, device=device)
+            return MixedPrecision(precision=self._precision_input, device=device)
 
         raise RuntimeError("No precision set")
 

--- a/src/lightning_lite/connector.py
+++ b/src/lightning_lite/connector.py
@@ -452,7 +452,7 @@ class _Connector:
                     )
                 return TPUBf16Precision()
         if isinstance(self.strategy, DeepSpeedStrategy):
-            return DeepSpeedPrecision(self._precision_input, amp_type="native", amp_level=None)  # type: ignore
+            return DeepSpeedPrecision(self._precision_input)  # type: ignore
 
         if self._precision_input == 32:
             return Precision()

--- a/src/lightning_lite/plugins/__init__.py
+++ b/src/lightning_lite/plugins/__init__.py
@@ -18,7 +18,7 @@ from lightning_lite.plugins.io.xla import XLACheckpointIO
 from lightning_lite.plugins.precision.deepspeed import DeepSpeedPrecision
 from lightning_lite.plugins.precision.double import DoublePrecision
 from lightning_lite.plugins.precision.fsdp import FSDPPrecision
-from lightning_lite.plugins.precision.native_amp import NativeMixedPrecision
+from lightning_lite.plugins.precision.native_amp import MixedPrecision
 from lightning_lite.plugins.precision.precision import Precision
 from lightning_lite.plugins.precision.tpu import TPUPrecision
 from lightning_lite.plugins.precision.tpu_bf16 import TPUBf16Precision
@@ -31,7 +31,7 @@ __all__ = [
     "Precision",
     "DeepSpeedPrecision",
     "DoublePrecision",
-    "NativeMixedPrecision",
+    "MixedPrecision",
     "TPUPrecision",
     "TPUBf16Precision",
     "FSDPPrecision",

--- a/src/lightning_lite/plugins/precision/__init__.py
+++ b/src/lightning_lite/plugins/precision/__init__.py
@@ -14,7 +14,7 @@
 from lightning_lite.plugins.precision.deepspeed import DeepSpeedPrecision
 from lightning_lite.plugins.precision.double import DoublePrecision
 from lightning_lite.plugins.precision.fsdp import FSDPPrecision
-from lightning_lite.plugins.precision.native_amp import NativeMixedPrecision
+from lightning_lite.plugins.precision.native_amp import MixedPrecision
 from lightning_lite.plugins.precision.precision import Precision
 from lightning_lite.plugins.precision.tpu import TPUPrecision
 from lightning_lite.plugins.precision.tpu_bf16 import TPUBf16Precision
@@ -22,7 +22,7 @@ from lightning_lite.plugins.precision.tpu_bf16 import TPUBf16Precision
 __all__ = [
     "DeepSpeedPrecision",
     "DoublePrecision",
-    "NativeMixedPrecision",
+    "MixedPrecision",
     "Precision",
     "TPUPrecision",
     "TPUBf16Precision",

--- a/src/lightning_lite/plugins/precision/fsdp.py
+++ b/src/lightning_lite/plugins/precision/fsdp.py
@@ -16,16 +16,16 @@ from typing import Optional, TYPE_CHECKING
 import torch
 from typing_extensions import Literal
 
-from lightning_lite.plugins.precision.native_amp import NativeMixedPrecision
+from lightning_lite.plugins.precision.native_amp import MixedPrecision
 from lightning_lite.utilities.enums import PrecisionType
 from lightning_lite.utilities.imports import _TORCH_GREATER_EQUAL_1_12
 
 if TYPE_CHECKING:
-    from torch.distributed.fsdp.fully_sharded_data_parallel import MixedPrecision
+    from torch.distributed.fsdp.fully_sharded_data_parallel import MixedPrecision as TorchMixedPrecision
     from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler
 
 
-class FSDPPrecision(NativeMixedPrecision):
+class FSDPPrecision(MixedPrecision):
     """AMP for Fully Sharded Data Parallel training."""
 
     def __init__(
@@ -43,8 +43,8 @@ class FSDPPrecision(NativeMixedPrecision):
         )
 
     @property
-    def mixed_precision_config(self) -> "MixedPrecision":
-        from torch.distributed.fsdp.fully_sharded_data_parallel import MixedPrecision
+    def mixed_precision_config(self) -> "TorchMixedPrecision":
+        from torch.distributed.fsdp.fully_sharded_data_parallel import MixedPrecision as TorchMixedPrecision
 
         if self.precision == PrecisionType.HALF:
             dtype = torch.float16
@@ -52,7 +52,7 @@ class FSDPPrecision(NativeMixedPrecision):
             dtype = torch.bfloat16
         else:
             raise ValueError(f"Was unable to infer precision type, received {self.precision!r}.")
-        return MixedPrecision(
+        return TorchMixedPrecision(
             param_dtype=dtype,
             reduce_dtype=dtype,
             buffer_dtype=dtype,

--- a/src/lightning_lite/plugins/precision/native_amp.py
+++ b/src/lightning_lite/plugins/precision/native_amp.py
@@ -26,8 +26,8 @@ from lightning_lite.plugins.precision.utils import _convert_fp_tensor
 from lightning_lite.utilities.types import Optimizable
 
 
-class NativeMixedPrecision(Precision):
-    """Plugin for Native Mixed Precision (AMP) training with ``torch.autocast``.
+class MixedPrecision(Precision):
+    """Plugin for Automatic Mixed Precision (AMP) training with ``torch.autocast``.
 
     Args:
         precision: Whether to use ``torch.float16`` (``16``) or ``torch.bfloat16`` (``'bf16'``).

--- a/src/lightning_lite/strategies/deepspeed.py
+++ b/src/lightning_lite/strategies/deepspeed.py
@@ -32,7 +32,7 @@ from lightning_lite.plugins.precision import Precision
 from lightning_lite.strategies.ddp import DDPStrategy
 from lightning_lite.strategies.strategy import _Sharded
 from lightning_lite.utilities.distributed import log
-from lightning_lite.utilities.enums import AMPType, PrecisionType
+from lightning_lite.utilities.enums import PrecisionType
 from lightning_lite.utilities.rank_zero import rank_zero_info
 from lightning_lite.utilities.seed import reset_seed
 from lightning_lite.utilities.types import _PATH
@@ -501,7 +501,7 @@ class DeepSpeedStrategy(DDPStrategy, _Sharded):
     def _format_precision_config(self) -> None:
         assert isinstance(self.config, dict)
         if self.precision.precision == PrecisionType.HALF:
-            if "fp16" not in self.config and self.precision.amp_type == AMPType.NATIVE:
+            if "fp16" not in self.config:
                 # FP16 is a DeepSpeed standalone AMP implementation
                 rank_zero_info("Enabling DeepSpeed FP16.")
                 self.config["fp16"] = {
@@ -512,9 +512,6 @@ class DeepSpeedStrategy(DDPStrategy, _Sharded):
                     "hysteresis": self.hysteresis,
                     "min_loss_scale": self.min_loss_scale,
                 }
-            elif "amp" not in self.config and self.precision.amp_type == AMPType.APEX:
-                rank_zero_info("Enabling DeepSpeed APEX Implementation.")
-                self.config["amp"] = {"enabled": True, "opt_level": self.precision.amp_level}
         elif "bf16" not in self.config and self.precision.precision == PrecisionType.BFLOAT:
             rank_zero_info("Enabling DeepSpeed BF16.")
             self.config["bf16"] = {"enabled": True}

--- a/src/lightning_lite/utilities/__init__.py
+++ b/src/lightning_lite/utilities/__init__.py
@@ -14,7 +14,7 @@
 """General utilities."""
 
 from lightning_lite.utilities.apply_func import move_data_to_device  # noqa: F401
-from lightning_lite.utilities.enums import _AcceleratorType, _StrategyType, AMPType, LightningEnum  # noqa: F401
+from lightning_lite.utilities.enums import _AcceleratorType, _StrategyType, LightningEnum  # noqa: F401
 from lightning_lite.utilities.rank_zero import (  # noqa: F401
     rank_zero_deprecation,
     rank_zero_info,

--- a/src/lightning_lite/utilities/enums.py
+++ b/src/lightning_lite/utilities/enums.py
@@ -29,6 +29,7 @@ else:
     LightningEnum = StrEnum
 
 
+# FIXME(carlos): Deprecate this on PL
 class AMPType(LightningEnum):
     """Type of Automatic Mixed Precission used for training."""
 

--- a/src/lightning_lite/utilities/enums.py
+++ b/src/lightning_lite/utilities/enums.py
@@ -29,14 +29,6 @@ else:
     LightningEnum = StrEnum
 
 
-# FIXME(carlos): Deprecate this on PL
-class AMPType(LightningEnum):
-    """Type of Automatic Mixed Precission used for training."""
-
-    APEX = "apex"
-    NATIVE = "native"
-
-
 class PrecisionType(LightningEnum):
     """Type of precision used."""
 

--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -74,12 +74,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - `nvidia/apex` deprecation ([#16039](https://github.com/PyTorchLightning/pytorch-lightning/pull/16039))
   * Deprecated `pytorch_lightning.plugins.NativeMixedPrecisionPlugin` in favor of `pytorch_lightning.plugins.MixedPrecisionPlugin`
-  * Deprecated the `LightningModule.optimizer_step(using_native_amp=...)` argument.
-  * Deprecated the `Trainer(amp_backend=...)` argument.
-  * Deprecated the `Trainer(amp_level=...)` argument.
-  * Deprecated the `pytorch_lightning.plugins.ApexMixedPrecisionPlugin` class.
-  * Deprecates the `pytorch_lightning.utilities.enum.sAMPType` enum.
-  * Deprecates the `DeepSpeedPrecisionPlugin(amp_type=..., amp_level=...)` arguments.
+  * Deprecated the `LightningModule.optimizer_step(using_native_amp=...)` argument
+  * Deprecated the `Trainer(amp_backend=...)` argument
+  * Deprecated the `Trainer.amp_backend` property
+  * Deprecated the `Trainer(amp_level=...)` argument
+  * Deprecated the `pytorch_lightning.plugins.ApexMixedPrecisionPlugin` class
+  * Deprecates the `pytorch_lightning.utilities.enum.sAMPType` enum
+  * Deprecates the `DeepSpeedPrecisionPlugin(amp_type=..., amp_level=...)` arguments
 
 
 ### Removed

--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -72,6 +72,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Deprecated `pytorch_lightning.profiler` in favor of `pytorch_lightning.profilers` ([#16059](https://github.com/PyTorchLightning/pytorch-lightning/pull/16059))
 
 
+- `nvidia/apex` deprecation ([#16039](https://github.com/PyTorchLightning/pytorch-lightning/pull/16039))
+  * Deprecated `pytorch_lightning.plugins.NativeMixedPrecisionPlugin` in favor of `pytorch_lightning.plugins.MixedPrecisionPlugin`
+  * Deprecated the `LightningModule.optimizer_step(using_native_amp=...)` argument.
+  * Deprecated the `Trainer(amp_backend=...)` argument.
+  * Deprecated the `Trainer(amp_level=...)` argument.
+  * Deprecated the `pytorch_lightning.plugins.ApexMixedPrecisionPlugin` class.
+  * Deprecates the `pytorch_lightning.utilities.enum.sAMPType` enum.
+  * Deprecates the `DeepSpeedPrecisionPlugin(amp_type=..., amp_level=...)` arguments.
+
+
 ### Removed
 
 - Removed deprecated `pytorch_lightning.utilities.memory.get_gpu_memory_map` in favor of `pytorch_lightning.accelerators.cuda.get_nvidia_gpu_stats` ([#15617](https://github.com/Lightning-AI/lightning/pull/15617))

--- a/src/pytorch_lightning/core/module.py
+++ b/src/pytorch_lightning/core/module.py
@@ -1599,8 +1599,6 @@ class LightningModule(
         optimizer_idx: int = 0,
         optimizer_closure: Optional[Callable[[], Any]] = None,
         on_tpu: bool = False,
-        # FIXME(carlos): deprecate this
-        using_native_amp: bool = False,
         using_lbfgs: bool = False,
     ) -> None:
         r"""
@@ -1619,19 +1617,18 @@ class LightningModule(
             optimizer_closure: The optimizer closure. This closure must be executed as it includes the
                 calls to ``training_step()``, ``optimizer.zero_grad()``, and ``backward()``.
             on_tpu: ``True`` if TPU backward is required
-            using_native_amp: ``True`` if using native amp
             using_lbfgs: True if the matching optimizer is :class:`torch.optim.LBFGS`
 
         Examples::
 
             # DEFAULT
             def optimizer_step(self, epoch, batch_idx, optimizer, optimizer_idx,
-                               optimizer_closure, on_tpu, using_native_amp, using_lbfgs):
+                               optimizer_closure, on_tpu, using_lbfgs):
                 optimizer.step(closure=optimizer_closure)
 
             # Alternating schedule for optimizer steps (i.e.: GANs)
             def optimizer_step(self, epoch, batch_idx, optimizer, optimizer_idx,
-                               optimizer_closure, on_tpu, using_native_amp, using_lbfgs):
+                               optimizer_closure, on_tpu, using_lbfgs):
                 # update generator opt every step
                 if optimizer_idx == 0:
                     optimizer.step(closure=optimizer_closure)
@@ -1661,7 +1658,6 @@ class LightningModule(
                 optimizer_idx,
                 optimizer_closure,
                 on_tpu,
-                using_native_amp,
                 using_lbfgs,
             ):
                 # update params

--- a/src/pytorch_lightning/core/module.py
+++ b/src/pytorch_lightning/core/module.py
@@ -1599,6 +1599,7 @@ class LightningModule(
         optimizer_idx: int = 0,
         optimizer_closure: Optional[Callable[[], Any]] = None,
         on_tpu: bool = False,
+        # FIXME(carlos): deprecate this
         using_native_amp: bool = False,
         using_lbfgs: bool = False,
     ) -> None:

--- a/src/pytorch_lightning/lite/lite.py
+++ b/src/pytorch_lightning/lite/lite.py
@@ -38,7 +38,7 @@ from lightning_lite.strategies import XLAStrategy
 from pytorch_lightning.accelerators import Accelerator as PLAccelerator
 from pytorch_lightning.plugins import DeepSpeedPrecisionPlugin as PLDeepSpeedPrecisionPlugin
 from pytorch_lightning.plugins import DoublePrecisionPlugin as PLDoublePrecisionPlugin
-from pytorch_lightning.plugins import NativeMixedPrecisionPlugin as PLNativeMixedPrecisionPlugin
+from pytorch_lightning.plugins import MixedPrecisionPlugin as PLMixedPrecisionPlugin
 from pytorch_lightning.plugins import PrecisionPlugin as PLPrecisionPlugin
 from pytorch_lightning.plugins import TPUBf16PrecisionPlugin as PLTPUBf16PrecisionPlugin
 from pytorch_lightning.plugins import TPUPrecisionPlugin as PLTPUPrecisionPlugin
@@ -284,7 +284,7 @@ def _to_lite_precision(plugin: Optional[PLPrecisionPlugin]) -> LitePrecision:
     if type(plugin) is PLPrecisionPlugin:
         return LitePrecision()
 
-    if type(plugin) is PLNativeMixedPrecisionPlugin:
+    if type(plugin) is PLMixedPrecisionPlugin:
         return LiteMixedPrecision(
             precision=plugin.precision, device=plugin.device, scaler=plugin.scaler  # type: ignore[arg-type]
         )

--- a/src/pytorch_lightning/lite/lite.py
+++ b/src/pytorch_lightning/lite/lite.py
@@ -23,7 +23,7 @@ from lightning_lite.lite import LightningLite as _NewLightningLite
 from lightning_lite.plugins import CheckpointIO, ClusterEnvironment
 from lightning_lite.plugins import DeepSpeedPrecision as LiteDeepSpeedPrecision
 from lightning_lite.plugins import DoublePrecision as LiteDoublePrecision
-from lightning_lite.plugins import NativeMixedPrecision as LiteNativeMixedPrecision
+from lightning_lite.plugins import MixedPrecision as LiteMixedPrecision
 from lightning_lite.plugins import Precision as LitePrecision
 from lightning_lite.plugins import TPUBf16Precision as LiteTPUBf16Precision
 from lightning_lite.plugins import TPUPrecision as LiteTPUPrecision
@@ -285,7 +285,7 @@ def _to_lite_precision(plugin: Optional[PLPrecisionPlugin]) -> LitePrecision:
         return LitePrecision()
 
     if type(plugin) is PLNativeMixedPrecisionPlugin:
-        return LiteNativeMixedPrecision(
+        return LiteMixedPrecision(
             precision=plugin.precision, device=plugin.device, scaler=plugin.scaler  # type: ignore[arg-type]
         )
 

--- a/src/pytorch_lightning/lite/lite.py
+++ b/src/pytorch_lightning/lite/lite.py
@@ -293,9 +293,7 @@ def _to_lite_precision(plugin: Optional[PLPrecisionPlugin]) -> LitePrecision:
         return LiteDoublePrecision()
 
     if type(plugin) is PLDeepSpeedPrecisionPlugin:
-        return LiteDeepSpeedPrecision(
-            precision=plugin.precision, amp_type=plugin.amp_type, amp_level=plugin.amp_level  # type: ignore[arg-type]
-        )
+        return LiteDeepSpeedPrecision(precision=plugin.precision)  # type: ignore[arg-type]
 
     if type(plugin) is PLTPUPrecisionPlugin:
         return LiteTPUPrecision()

--- a/src/pytorch_lightning/loops/optimization/optimizer_loop.py
+++ b/src/pytorch_lightning/loops/optimization/optimizer_loop.py
@@ -31,7 +31,6 @@ from pytorch_lightning.loops.utilities import (
     _extract_hiddens,
 )
 from pytorch_lightning.trainer.progress import OptimizationProgress
-from pytorch_lightning.utilities import AMPType
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.types import STEP_OUTPUT
 
@@ -341,7 +340,7 @@ class OptimizerLoop(Loop[_OUTPUTS_TYPE]):
         is_lbfgs = isinstance(optimizer, torch.optim.LBFGS)
 
         # wraps into LightningOptimizer only for running step
-        if self.trainer.amp_backend == AMPType.APEX:
+        if self.trainer.amp_backend == "apex":
             # apex overrides .step function and need to be wrapped on each step
             optimizer = LightningOptimizer._to_lightning_optimizer(optimizer, self.trainer.strategy, opt_idx)
         else:
@@ -362,7 +361,7 @@ class OptimizerLoop(Loop[_OUTPUTS_TYPE]):
             opt_idx,
             train_step_and_backward_closure,
             on_tpu=isinstance(self.trainer.accelerator, TPUAccelerator),
-            using_native_amp=(self.trainer.amp_backend == AMPType.NATIVE),
+            using_native_amp=(self.trainer.amp_backend == "native"),
             using_lbfgs=is_lbfgs,
         )
 

--- a/src/pytorch_lightning/loops/optimization/optimizer_loop.py
+++ b/src/pytorch_lightning/loops/optimization/optimizer_loop.py
@@ -30,6 +30,7 @@ from pytorch_lightning.loops.utilities import (
     _build_training_step_kwargs,
     _extract_hiddens,
 )
+from pytorch_lightning.plugins import ApexMixedPrecisionPlugin
 from pytorch_lightning.trainer.progress import OptimizationProgress
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.rank_zero import rank_zero_deprecation
@@ -342,7 +343,7 @@ class OptimizerLoop(Loop[_OUTPUTS_TYPE]):
         is_lbfgs = isinstance(optimizer, torch.optim.LBFGS)
 
         # wraps into LightningOptimizer only for running step
-        if self.trainer.amp_backend == "apex":
+        if isinstance(self.trainer.precision_plugin, ApexMixedPrecisionPlugin):
             # apex overrides .step function and need to be wrapped on each step
             optimizer = LightningOptimizer._to_lightning_optimizer(optimizer, self.trainer.strategy, opt_idx)
         else:

--- a/src/pytorch_lightning/loops/optimization/optimizer_loop.py
+++ b/src/pytorch_lightning/loops/optimization/optimizer_loop.py
@@ -362,7 +362,7 @@ class OptimizerLoop(Loop[_OUTPUTS_TYPE]):
                 "The NVIDIA/apex AMP implementation has been deprecated upstream. Consequently, its integration inside"
                 " PyTorch Lightning has been deprecated in v1.9.0 and will be removed in v1.10.0."
                 f" The `{type(pl_module).__name__}.optimizer_step()` hook is overridden, including the"
-                " `using_native_amp` argument. Removing this argument will avoid this message, you can expect it to "
+                " `using_native_amp` argument. Removing this argument will avoid this message, you can expect it to"
                 " return True."
             )
             kwargs["using_native_amp"] = self.trainer.amp_backend == "native"

--- a/src/pytorch_lightning/loops/optimization/optimizer_loop.py
+++ b/src/pytorch_lightning/loops/optimization/optimizer_loop.py
@@ -31,6 +31,7 @@ from pytorch_lightning.loops.utilities import (
     _extract_hiddens,
 )
 from pytorch_lightning.plugins import ApexMixedPrecisionPlugin
+from pytorch_lightning.plugins.precision.native_amp import MixedPrecisionPlugin
 from pytorch_lightning.trainer.progress import OptimizationProgress
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.rank_zero import rank_zero_deprecation
@@ -366,7 +367,7 @@ class OptimizerLoop(Loop[_OUTPUTS_TYPE]):
                 " `using_native_amp` argument. Removing this argument will avoid this message, you can expect it to"
                 " return True."
             )
-            kwargs["using_native_amp"] = self.trainer.amp_backend == "native"
+            kwargs["using_native_amp"] = isinstance(self.trainer.precision_plugin, MixedPrecisionPlugin)
         self.trainer._call_lightning_module_hook(
             "optimizer_step",
             self.trainer.current_epoch,

--- a/src/pytorch_lightning/loops/optimization/optimizer_loop.py
+++ b/src/pytorch_lightning/loops/optimization/optimizer_loop.py
@@ -374,7 +374,7 @@ class OptimizerLoop(Loop[_OUTPUTS_TYPE]):
             opt_idx,
             train_step_and_backward_closure,
             on_tpu=isinstance(self.trainer.accelerator, TPUAccelerator),
-            **kwargs,
+            **kwargs,  # type: ignore[arg-type]
             using_lbfgs=is_lbfgs,
         )
 

--- a/src/pytorch_lightning/plugins/__init__.py
+++ b/src/pytorch_lightning/plugins/__init__.py
@@ -12,7 +12,7 @@ from pytorch_lightning.plugins.precision.fsdp_native_native_amp import FullyShar
 from pytorch_lightning.plugins.precision.fully_sharded_native_amp import FullyShardedNativeMixedPrecisionPlugin
 from pytorch_lightning.plugins.precision.hpu import HPUPrecisionPlugin
 from pytorch_lightning.plugins.precision.ipu import IPUPrecisionPlugin
-from pytorch_lightning.plugins.precision.native_amp import NativeMixedPrecisionPlugin
+from pytorch_lightning.plugins.precision.native_amp import MixedPrecisionPlugin, NativeMixedPrecisionPlugin
 from pytorch_lightning.plugins.precision.precision_plugin import PrecisionPlugin
 from pytorch_lightning.plugins.precision.sharded_native_amp import ShardedNativeMixedPrecisionPlugin
 from pytorch_lightning.plugins.precision.tpu import TPUPrecisionPlugin
@@ -34,6 +34,7 @@ __all__ = [
     "IPUPrecisionPlugin",
     "HPUPrecisionPlugin",
     "NativeMixedPrecisionPlugin",
+    "MixedPrecisionPlugin",
     "PrecisionPlugin",
     "ShardedNativeMixedPrecisionPlugin",
     "FullyShardedNativeMixedPrecisionPlugin",

--- a/src/pytorch_lightning/plugins/precision/__init__.py
+++ b/src/pytorch_lightning/plugins/precision/__init__.py
@@ -19,7 +19,7 @@ from pytorch_lightning.plugins.precision.fsdp_native_native_amp import FullyShar
 from pytorch_lightning.plugins.precision.fully_sharded_native_amp import FullyShardedNativeMixedPrecisionPlugin
 from pytorch_lightning.plugins.precision.hpu import HPUPrecisionPlugin
 from pytorch_lightning.plugins.precision.ipu import IPUPrecisionPlugin
-from pytorch_lightning.plugins.precision.native_amp import NativeMixedPrecisionPlugin
+from pytorch_lightning.plugins.precision.native_amp import MixedPrecisionPlugin, NativeMixedPrecisionPlugin
 from pytorch_lightning.plugins.precision.precision_plugin import PrecisionPlugin
 from pytorch_lightning.plugins.precision.sharded_native_amp import ShardedNativeMixedPrecisionPlugin
 from pytorch_lightning.plugins.precision.tpu import TPUPrecisionPlugin
@@ -35,6 +35,7 @@ __all__ = [
     "HPUPrecisionPlugin",
     "IPUPrecisionPlugin",
     "NativeMixedPrecisionPlugin",
+    "MixedPrecisionPlugin",
     "PrecisionPlugin",
     "ShardedNativeMixedPrecisionPlugin",
     "TPUPrecisionPlugin",

--- a/src/pytorch_lightning/plugins/precision/apex_amp.py
+++ b/src/pytorch_lightning/plugins/precision/apex_amp.py
@@ -32,10 +32,10 @@ _APEX_AVAILABLE = RequirementCache("apex")
 @functools.lru_cache(maxsize=1)
 def _import_amp_without_deprecation() -> ModuleType:
     # hide the warning upstream in favor of our deprecation
-    with warnings.filterwarnings(action="ignore", message="apex.amp is deprecated", category=FutureWarning):
-        from apex import amp
+    warnings.filterwarnings(action="ignore", message="apex.amp is deprecated", category=FutureWarning)
+    from apex import amp
 
-        return amp
+    return amp
 
 
 # TODO: remove in v1.10.0

--- a/src/pytorch_lightning/plugins/precision/apex_amp.py
+++ b/src/pytorch_lightning/plugins/precision/apex_amp.py
@@ -23,7 +23,6 @@ from torch.optim import LBFGS, Optimizer
 import pytorch_lightning as pl
 from lightning_lite.utilities.types import _PARAMETERS, Optimizable
 from pytorch_lightning.plugins.precision.precision_plugin import PrecisionPlugin
-from pytorch_lightning.utilities import AMPType
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.rank_zero import rank_zero_deprecation
 
@@ -43,7 +42,7 @@ def _import_amp_without_deprecation() -> ModuleType:
 class ApexMixedPrecisionPlugin(PrecisionPlugin):
     """Mixed Precision Plugin based on Nvidia/Apex (https://github.com/NVIDIA/apex)"""
 
-    backend = AMPType.APEX
+    backend = "apex"
 
     def __init__(self, amp_level: str = "O2") -> None:
         # deprecate before the availability check so users don't install without knowning that it's deprecated

--- a/src/pytorch_lightning/plugins/precision/apex_amp.py
+++ b/src/pytorch_lightning/plugins/precision/apex_amp.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import functools
 import warnings
 from types import ModuleType
 from typing import Any, Callable, Dict, Optional
@@ -29,7 +28,6 @@ from pytorch_lightning.utilities.rank_zero import rank_zero_deprecation
 _APEX_AVAILABLE = RequirementCache("apex")
 
 
-@functools.lru_cache(maxsize=1)
 def _import_amp_without_deprecation() -> ModuleType:
     # hide the warning upstream in favor of our deprecation
     warnings.filterwarnings(action="ignore", message="apex.amp is deprecated", category=FutureWarning)

--- a/src/pytorch_lightning/plugins/precision/deepspeed.py
+++ b/src/pytorch_lightning/plugins/precision/deepspeed.py
@@ -66,8 +66,8 @@ class DeepSpeedPrecisionPlugin(PrecisionPlugin):
                     f"`{type(self).__name__}(amp_level={amp_level!r})` is only relevant when using NVIDIA/apex"
                 )
             rank_zero_deprecation(
-                f"Passing `{type(self).__name__}(amp_type=...)` been deprecated in v1.9.0 and will be removed in"
-                " v1.10.0. This argument is no longer necessary."
+                f"Passing `{type(self).__name__}(amp_type={amp_type!r})` been deprecated in v1.9.0 and will be removed"
+                f" in v1.10.0. This argument is no longer necessary."
             )
 
         supported_precision = (PrecisionType.HALF, PrecisionType.FLOAT, PrecisionType.BFLOAT)

--- a/src/pytorch_lightning/plugins/precision/deepspeed.py
+++ b/src/pytorch_lightning/plugins/precision/deepspeed.py
@@ -21,11 +21,12 @@ from torch.optim import LBFGS, Optimizer
 import pytorch_lightning as pl
 from lightning_lite.utilities.enums import AMPType, PrecisionType
 from lightning_lite.utilities.types import Steppable
+from pytorch_lightning.plugins.precision.apex_amp import _APEX_AVAILABLE
 from pytorch_lightning.plugins.precision.precision_plugin import PrecisionPlugin
 from pytorch_lightning.utilities import GradClipAlgorithmType
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
-from pytorch_lightning.utilities.imports import _APEX_AVAILABLE
 from pytorch_lightning.utilities.model_helpers import is_overridden
+from pytorch_lightning.utilities.rank_zero import rank_zero_deprecation
 
 _DEEPSPEED_AVAILABLE = RequirementCache("deepspeed")
 if TYPE_CHECKING and _DEEPSPEED_AVAILABLE:
@@ -39,20 +40,19 @@ class DeepSpeedPrecisionPlugin(PrecisionPlugin):
 
     Args:
         precision: Double precision (64), full precision (32), half precision (16) or bfloat16 precision (bf16).
-        amp_type: The mixed precision backend to use ("native" or "apex").
-        amp_level: The optimization level to use (O1, O2, etc...). By default it will be set to "O2"
-            if ``amp_type`` is set to "apex".
-
     Raises:
-        MisconfigurationException:
-            If using ``bfloat16`` precision and ``deepspeed<v0.6``.
-
         ValueError:
             If unsupported ``precision`` is provided.
     """
 
-    def __init__(self, precision: Union[str, int], amp_type: str, amp_level: Optional[str] = None) -> None:
+    def __init__(self, precision: Union[str, int], amp_type: str = "native", amp_level: Optional[str] = None) -> None:
         if amp_type == AMPType.APEX:
+            # TODO: remove in v1.10.0
+            rank_zero_deprecation(
+                "The NVIDIA/apex AMP implementation has been deprecated upstream. Consequently, its integration inside"
+                " PyTorch Lightning has been deprecated in v1.9.0. Support for using it through the DeepSpeed"
+                " implementation will be removed in v1.10.0."
+            )
             if not _APEX_AVAILABLE:
                 raise MisconfigurationException(
                     "You have asked for Apex AMP but `apex` is not installed."
@@ -60,6 +60,15 @@ class DeepSpeedPrecisionPlugin(PrecisionPlugin):
                 )
 
             amp_level = amp_level or "O2"
+        else:
+            if amp_level is not None:
+                raise ValueError(
+                    f"`{type(self).__name__}(amp_level={amp_level!r})` is only relevant when using NVIDIA/apex"
+                )
+            rank_zero_deprecation(
+                f"Passing `{type(self).__name__}(amp_type=...)` been deprecated in v1.9.0 and will be removed in"
+                " v1.10.0. This argument is no longer necessary."
+            )
 
         supported_precision = (PrecisionType.HALF, PrecisionType.FLOAT, PrecisionType.BFLOAT)
         if precision not in supported_precision:

--- a/src/pytorch_lightning/plugins/precision/deepspeed.py
+++ b/src/pytorch_lightning/plugins/precision/deepspeed.py
@@ -19,7 +19,7 @@ from torch import Tensor
 from torch.optim import LBFGS, Optimizer
 
 import pytorch_lightning as pl
-from lightning_lite.utilities.enums import AMPType, PrecisionType
+from lightning_lite.utilities.enums import PrecisionType
 from lightning_lite.utilities.types import Steppable
 from pytorch_lightning.plugins.precision.apex_amp import _APEX_AVAILABLE
 from pytorch_lightning.plugins.precision.precision_plugin import PrecisionPlugin
@@ -46,7 +46,7 @@ class DeepSpeedPrecisionPlugin(PrecisionPlugin):
     """
 
     def __init__(self, precision: Union[str, int], amp_type: str = "native", amp_level: Optional[str] = None) -> None:
-        if amp_type == AMPType.APEX:
+        if amp_type == "apex":
             # TODO: remove in v1.10.0
             rank_zero_deprecation(
                 "The NVIDIA/apex AMP implementation has been deprecated upstream. Consequently, its integration inside"

--- a/src/pytorch_lightning/plugins/precision/deepspeed.py
+++ b/src/pytorch_lightning/plugins/precision/deepspeed.py
@@ -45,7 +45,9 @@ class DeepSpeedPrecisionPlugin(PrecisionPlugin):
             If unsupported ``precision`` is provided.
     """
 
-    def __init__(self, precision: Union[str, int], amp_type: str = "native", amp_level: Optional[str] = None) -> None:
+    def __init__(
+        self, precision: Union[str, int], amp_type: Optional[str] = None, amp_level: Optional[str] = None
+    ) -> None:
         if amp_type == "apex":
             # TODO: remove in v1.10.0
             rank_zero_deprecation(
@@ -60,11 +62,13 @@ class DeepSpeedPrecisionPlugin(PrecisionPlugin):
                 )
 
             amp_level = amp_level or "O2"
+        elif amp_level is not None:
+            raise ValueError(
+                f"`{type(self).__name__}(amp_level={amp_level!r})` is only relevant when using NVIDIA/apex"
+            )
+        if amp_type is None:
+            amp_type = "native"
         else:
-            if amp_level is not None:
-                raise ValueError(
-                    f"`{type(self).__name__}(amp_level={amp_level!r})` is only relevant when using NVIDIA/apex"
-                )
             rank_zero_deprecation(
                 f"Passing `{type(self).__name__}(amp_type={amp_type!r})` been deprecated in v1.9.0 and will be removed"
                 f" in v1.10.0. This argument is no longer necessary."

--- a/src/pytorch_lightning/plugins/precision/fsdp_native_native_amp.py
+++ b/src/pytorch_lightning/plugins/precision/fsdp_native_native_amp.py
@@ -17,7 +17,7 @@ import torch
 
 from lightning_lite.utilities.enums import PrecisionType
 from lightning_lite.utilities.imports import _TORCH_GREATER_EQUAL_1_12
-from pytorch_lightning.plugins.precision.native_amp import NativeMixedPrecisionPlugin
+from pytorch_lightning.plugins.precision.native_amp import MixedPrecisionPlugin
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 
 if _TORCH_GREATER_EQUAL_1_12 and torch.distributed.is_available():
@@ -28,7 +28,7 @@ else:
     ShardedGradScaler = None  # type: ignore[misc,assignment]
 
 
-class FullyShardedNativeNativeMixedPrecisionPlugin(NativeMixedPrecisionPlugin):
+class FullyShardedNativeNativeMixedPrecisionPlugin(MixedPrecisionPlugin):
     """Native AMP for Fully Sharded Native Training."""
 
     def __init__(self, precision: Union[str, int], device: str, scaler: Optional[ShardedGradScaler] = None) -> None:

--- a/src/pytorch_lightning/plugins/precision/native_amp.py
+++ b/src/pytorch_lightning/plugins/precision/native_amp.py
@@ -26,6 +26,7 @@ from pytorch_lightning.utilities import AMPType, GradClipAlgorithmType
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 
 
+# FIXME(carlos): deprecate Native
 class NativeMixedPrecisionPlugin(PrecisionPlugin):
     """Plugin for Native Mixed Precision (AMP) training with ``torch.autocast``.
 

--- a/src/pytorch_lightning/plugins/precision/native_amp.py
+++ b/src/pytorch_lightning/plugins/precision/native_amp.py
@@ -129,7 +129,7 @@ class NativeMixedPrecisionPlugin(MixedPrecisionPlugin):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         rank_zero_deprecation(
-            f"The `{type(self).__name__}` class has been renamed in v1.9.0 and will be removed in"
+            "The `NativeMixedPrecisionPlugin` class has been renamed in v1.9.0 and will be removed in"
             " v1.10.0. Please use `pytorch_lightning.plugins.MixedPrecisionPlugin` instead."
         )
         super().__init__(*args, **kwargs)

--- a/src/pytorch_lightning/plugins/precision/sharded_native_amp.py
+++ b/src/pytorch_lightning/plugins/precision/sharded_native_amp.py
@@ -14,7 +14,7 @@
 from typing import Optional, Union
 
 from lightning_lite.strategies.fairscale import _FAIRSCALE_AVAILABLE
-from pytorch_lightning.plugins.precision.native_amp import NativeMixedPrecisionPlugin
+from pytorch_lightning.plugins.precision.native_amp import MixedPrecisionPlugin
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 
 if _FAIRSCALE_AVAILABLE:
@@ -24,7 +24,7 @@ else:
     OSS = ShardedGradScaler = object
 
 
-class ShardedNativeMixedPrecisionPlugin(NativeMixedPrecisionPlugin):
+class ShardedNativeMixedPrecisionPlugin(MixedPrecisionPlugin):
     """Native AMP for Sharded Training."""
 
     def __init__(self, precision: Union[str, int], device: str, scaler: Optional[ShardedGradScaler] = None) -> None:

--- a/src/pytorch_lightning/strategies/deepspeed.py
+++ b/src/pytorch_lightning/strategies/deepspeed.py
@@ -31,7 +31,7 @@ from torch.optim import Optimizer
 
 import pytorch_lightning as pl
 from lightning_lite.plugins import ClusterEnvironment
-from lightning_lite.utilities.enums import AMPType, PrecisionType
+from lightning_lite.utilities.enums import PrecisionType
 from lightning_lite.utilities.optimizer import _optimizers_to_device
 from lightning_lite.utilities.seed import reset_seed
 from lightning_lite.utilities.types import _PATH, LRScheduler, ReduceLROnPlateau
@@ -654,7 +654,7 @@ class DeepSpeedStrategy(DDPStrategy):
     def _format_precision_config(self) -> None:
         assert isinstance(self.config, dict)
         if self.precision_plugin.precision == PrecisionType.HALF:
-            if "fp16" not in self.config and self.precision_plugin.amp_type == AMPType.NATIVE:
+            if "fp16" not in self.config and self.precision_plugin.amp_type == "native":
                 # FP16 is a DeepSpeed standalone AMP implementation
                 rank_zero_info("Enabling DeepSpeed FP16.")
                 self.config["fp16"] = {
@@ -665,7 +665,7 @@ class DeepSpeedStrategy(DDPStrategy):
                     "hysteresis": self.hysteresis,
                     "min_loss_scale": self.min_loss_scale,
                 }
-            elif "amp" not in self.config and self.precision_plugin.amp_type == AMPType.APEX:
+            elif "amp" not in self.config and self.precision_plugin.amp_type == "apex":
                 rank_zero_info("Enabling DeepSpeed APEX Implementation.")
                 self.config["amp"] = {"enabled": True, "opt_level": self.precision_plugin.amp_level}
         elif "bf16" not in self.config and self.precision_plugin.precision == PrecisionType.BFLOAT:

--- a/src/pytorch_lightning/trainer/configuration_validator.py
+++ b/src/pytorch_lightning/trainer/configuration_validator.py
@@ -42,11 +42,11 @@ def verify_loop_configurations(trainer: "pl.Trainer") -> None:
         __verify_manual_optimization_support(trainer, model)
         __check_training_step_requires_dataloader_iter(model)
     elif trainer.state.fn == TrainerFn.VALIDATING:
-        __verify_eval_loop_configuration(trainer, model, "val")
+        __verify_eval_loop_configuration(model, "val")
     elif trainer.state.fn == TrainerFn.TESTING:
-        __verify_eval_loop_configuration(trainer, model, "test")
+        __verify_eval_loop_configuration(model, "test")
     elif trainer.state.fn == TrainerFn.PREDICTING:
-        __verify_eval_loop_configuration(trainer, model, "predict")
+        __verify_eval_loop_configuration(model, "predict")
 
     __verify_batch_transfer_support(trainer)
     # TODO: Delete this check in v2.0
@@ -82,12 +82,12 @@ def __verify_train_val_loop_configuration(trainer: "pl.Trainer", model: "pl.Ligh
             " `training_step()`, `train_dataloader()` and `configure_optimizers()` to be defined."
         )
 
-    trainer.overridden_optimizer_step = is_overridden("optimizer_step", model)
-    trainer.overridden_optimizer_zero_grad = is_overridden("optimizer_zero_grad", model)
+    overridden_optimizer_step = is_overridden("optimizer_step", model)
+    overridden_optimizer_zero_grad = is_overridden("optimizer_zero_grad", model)
     automatic_optimization = model.automatic_optimization
     going_to_accumulate_grad_batches = trainer.accumulation_scheduler.going_to_accumulate_grad_batches()
 
-    has_overridden_optimization_functions = trainer.overridden_optimizer_step or trainer.overridden_optimizer_zero_grad
+    has_overridden_optimization_functions = overridden_optimizer_step or overridden_optimizer_zero_grad
     if has_overridden_optimization_functions and going_to_accumulate_grad_batches and automatic_optimization:
         rank_zero_warn(
             "When using `Trainer(accumulate_grad_batches != 1)` and overriding"
@@ -111,7 +111,7 @@ def __verify_train_val_loop_configuration(trainer: "pl.Trainer", model: "pl.Ligh
         )
 
 
-def __verify_eval_loop_configuration(trainer: "pl.Trainer", model: "pl.LightningModule", stage: str) -> None:
+def __verify_eval_loop_configuration(model: "pl.LightningModule", stage: str) -> None:
     step_name = "validation_step" if stage == "val" else f"{stage}_step"
     trainer_method = "validate" if stage == "val" else stage
 

--- a/src/pytorch_lightning/trainer/connectors/accelerator_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/accelerator_connector.py
@@ -48,7 +48,7 @@ from pytorch_lightning.plugins import (
     FullyShardedNativeMixedPrecisionPlugin,
     HPUPrecisionPlugin,
     IPUPrecisionPlugin,
-    NativeMixedPrecisionPlugin,
+    MixedPrecisionPlugin,
     PLUGIN_INPUT,
     PrecisionPlugin,
     ShardedNativeMixedPrecisionPlugin,
@@ -717,7 +717,7 @@ class AcceleratorConnector:
 
         if self._precision_flag in (16, "bf16"):
             rank_zero_info(
-                f"Using 16bit {self._amp_type_flag.value} Automatic Mixed Precision (AMP)"  # type: ignore
+                f"Using 16bit {self._amp_type_flag} Automatic Mixed Precision (AMP)"  # type: ignore
                 if self._precision_flag == 16
                 else "Using bfloat16 Automatic Mixed Precision (AMP)"
             )
@@ -731,7 +731,7 @@ class AcceleratorConnector:
                     return FullyShardedNativeNativeMixedPrecisionPlugin(self._precision_flag, device)
                 if isinstance(self.strategy, DDPFullyShardedStrategy):
                     return FullyShardedNativeMixedPrecisionPlugin(self._precision_flag, device)
-                return NativeMixedPrecisionPlugin(self._precision_flag, device)
+                return MixedPrecisionPlugin(self._precision_flag, device)
 
             if self._amp_type_flag == "apex":
                 self._amp_level_flag = self._amp_level_flag or "O2"
@@ -771,7 +771,7 @@ class AcceleratorConnector:
             )
         if self._precision_flag == "bf16" and self._amp_type_flag != "native":
             raise MisconfigurationException(
-                f"You passed `Trainer(amp_type={self._amp_type_flag.value!r}, precision='bf16')` but "  # type: ignore
+                f"You passed `Trainer(amp_type={self._amp_type_flag!r}, precision='bf16')` but "  # type: ignore
                 "it's not supported. Try using `amp_type='native'` instead."
             )
         if self._precision_flag in (16, "bf16") and self._amp_type_flag == "apex":

--- a/src/pytorch_lightning/trainer/connectors/accelerator_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/accelerator_connector.py
@@ -79,7 +79,6 @@ from pytorch_lightning.strategies import (
 )
 from pytorch_lightning.strategies.ddp_spawn import _DDP_FORK_ALIASES
 from pytorch_lightning.tuner.auto_gpu_select import pick_multiple_gpus
-from pytorch_lightning.utilities.enums import AMPType
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.imports import _HOROVOD_AVAILABLE, _IPU_AVAILABLE
 from pytorch_lightning.utilities.rank_zero import rank_zero_deprecation, rank_zero_info, rank_zero_warn
@@ -384,7 +383,7 @@ class AcceleratorConnector:
             )
         else:
             amp_type = "native"
-        self._amp_type_flag = AMPType.from_str(amp_type).value
+        self._amp_type_flag = amp_type.lower()
 
         if amp_level is not None:
             rank_zero_deprecation(

--- a/src/pytorch_lightning/trainer/connectors/accelerator_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/accelerator_connector.py
@@ -28,7 +28,7 @@ from lightning_lite.plugins.environments import (
     SLURMEnvironment,
     TorchElasticEnvironment,
 )
-from lightning_lite.utilities import _StrategyType, LightningEnum
+from lightning_lite.utilities import _StrategyType
 from lightning_lite.utilities.device_parser import _determine_root_gpu_device
 from lightning_lite.utilities.imports import _IS_INTERACTIVE, _TORCH_GREATER_EQUAL_1_11
 from pytorch_lightning.accelerators import AcceleratorRegistry
@@ -174,8 +174,8 @@ class AcceleratorConnector:
         self._parallel_devices: List[Union[int, torch.device, str]] = []
         self._layer_sync: Optional[LayerSync] = NativeSyncBatchNorm() if sync_batchnorm else None
         self.checkpoint_io: Optional[CheckpointIO] = None
-        self._amp_type_flag: Optional[LightningEnum] = None
-        self._amp_level_flag: Optional[str] = amp_level
+        self._amp_type_flag: Optional[str] = None  # TODO: Remove in v1.10.0
+        self._amp_level_flag: Optional[str] = amp_level  # TODO: Remove in v1.10.0
         self._auto_select_gpus: bool = auto_select_gpus
 
         self._check_config_and_set_final_flags(
@@ -382,8 +382,8 @@ class AcceleratorConnector:
                 f" this message, it will select PyTorch's implementation automatically."
             )
         else:
-            amp_type = "native"
-        self._amp_type_flag = amp_type.lower()
+            amp_type = None
+        self._amp_type_flag = amp_type
 
         if amp_level is not None:
             rank_zero_deprecation(
@@ -721,7 +721,7 @@ class AcceleratorConnector:
                 else "Using bfloat16 Automatic Mixed Precision (AMP)"
             )
 
-            if self._amp_type_flag == "native":
+            if self._amp_type_flag in (None, "native"):
                 device = "cpu" if self._accelerator_flag == "cpu" else "cuda"
 
                 if isinstance(self.strategy, (DDPShardedStrategy, DDPSpawnShardedStrategy)):

--- a/src/pytorch_lightning/trainer/connectors/accelerator_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/accelerator_connector.py
@@ -716,7 +716,7 @@ class AcceleratorConnector:
 
         if self._precision_flag in (16, "bf16"):
             rank_zero_info(
-                f"Using 16bit {self._amp_type_flag} Automatic Mixed Precision (AMP)"  # type: ignore
+                f"Using 16bit {self._amp_type_flag} Automatic Mixed Precision (AMP)"
                 if self._precision_flag == 16
                 else "Using bfloat16 Automatic Mixed Precision (AMP)"
             )
@@ -768,19 +768,17 @@ class AcceleratorConnector:
                 "You passed `Trainer(accelerator='cpu', precision=16, amp_type='apex')`"
                 " but apex AMP not supported on CPU."
             )
-        if self._precision_flag == "bf16" and self._amp_type_flag != "native":
-            raise MisconfigurationException(
-                f"You passed `Trainer(amp_type={self._amp_type_flag!r}, precision='bf16')` but "  # type: ignore
-                "it's not supported. Try using `amp_type='native'` instead."
-            )
         if self._precision_flag in (16, "bf16") and self._amp_type_flag == "apex":
+            if self._precision_flag == "bf16":
+                raise MisconfigurationException(
+                    "You passed `Trainer(amp_type='apex', precision='bf16')` but it's not supported."
+                    " Remove the `amp_type` argument."
+                )
             if isinstance(
                 self.strategy,
                 (DDPShardedStrategy, DDPSpawnShardedStrategy, DDPFullyShardedStrategy, DDPFullyShardedNativeStrategy),
             ):
-                raise MisconfigurationException(
-                    "Sharded plugins are not supported with apex, please switch to `amp_backend='native'`."
-                )
+                raise MisconfigurationException("Sharded plugins are not supported with apex.")
 
     def _lazy_init_strategy(self) -> None:
         """Lazily set missing attributes on the previously instantiated strategy."""

--- a/src/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -29,7 +29,7 @@ from lightning_lite.plugins.environments.slurm import SLURMEnvironment
 from lightning_lite.utilities.cloud_io import get_filesystem
 from lightning_lite.utilities.types import _PATH
 from pytorch_lightning.callbacks import ModelCheckpoint
-from pytorch_lightning.plugins.precision import ApexMixedPrecisionPlugin, NativeMixedPrecisionPlugin
+from pytorch_lightning.plugins.precision import ApexMixedPrecisionPlugin, MixedPrecisionPlugin
 from pytorch_lightning.trainer.states import TrainerFn
 from pytorch_lightning.utilities import _OMEGACONF_AVAILABLE
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
@@ -295,9 +295,7 @@ class CheckpointConnector:
         # old checkpoints compatibility
         if "amp_scaling_state" in self._loaded_checkpoint and isinstance(prec_plugin, ApexMixedPrecisionPlugin):
             prec_plugin.load_state_dict(self._loaded_checkpoint["amp_scaling_state"])
-        if "native_amp_scaling_state" in self._loaded_checkpoint and isinstance(
-            prec_plugin, NativeMixedPrecisionPlugin
-        ):
+        if "native_amp_scaling_state" in self._loaded_checkpoint and isinstance(prec_plugin, MixedPrecisionPlugin):
             prec_plugin.load_state_dict(self._loaded_checkpoint["native_amp_scaling_state"])
 
     def _restore_quantization_callbacks(self) -> None:

--- a/src/pytorch_lightning/trainer/trainer.py
+++ b/src/pytorch_lightning/trainer/trainer.py
@@ -164,8 +164,8 @@ class Trainer:
         detect_anomaly: bool = False,
         auto_scale_batch_size: Union[str, bool] = False,
         plugins: Optional[Union[PLUGIN_INPUT, List[PLUGIN_INPUT]]] = None,
-        amp_backend: str = "native",
-        amp_level: Optional[str] = None,
+        amp_backend: str = "native",  # TODO: Remove in 1.10
+        amp_level: Optional[str] = None,  # # TODO: Remove in 1.10
         move_metrics_to_cpu: bool = False,
         multiple_trainloader_mode: str = "max_size_cycle",
         inference_mode: bool = True,
@@ -183,6 +183,10 @@ class Trainer:
 
             amp_backend: The mixed precision backend to use ("native" or "apex").
                 Default: ``'native''``.
+
+                .. deprecated:: v1.9
+                    Setting ``amp_backend`` inside the ``Trainer`` is deprecated in v1.8.0 and will be removed
+                    in v1.10.0. This argument was only relevant for apex which is being removed.
 
             amp_level: The optimization level to use (O1, O2, etc...). By default it will be set to "O2"
                 if ``amp_backend`` is set to "apex".

--- a/src/pytorch_lightning/trainer/trainer.py
+++ b/src/pytorch_lightning/trainer/trainer.py
@@ -84,7 +84,7 @@ from pytorch_lightning.trainer.connectors.signal_connector import SignalConnecto
 from pytorch_lightning.trainer.states import RunningStage, TrainerFn, TrainerState, TrainerStatus
 from pytorch_lightning.trainer.supporters import CombinedLoader
 from pytorch_lightning.tuner.tuning import _TunerResult, Tuner
-from pytorch_lightning.utilities import AMPType, GradClipAlgorithmType, parsing
+from pytorch_lightning.utilities import GradClipAlgorithmType, parsing
 from pytorch_lightning.utilities.argparse import (
     _defaults_from_env_vars,
     add_argparse_args,
@@ -164,6 +164,7 @@ class Trainer:
         detect_anomaly: bool = False,
         auto_scale_batch_size: Union[str, bool] = False,
         plugins: Optional[Union[PLUGIN_INPUT, List[PLUGIN_INPUT]]] = None,
+        # FIXME: deprecate these
         amp_backend: str = "native",  # TODO: Remove in 1.10
         amp_level: Optional[str] = None,  # # TODO: Remove in 1.10
         move_metrics_to_cpu: bool = False,
@@ -1776,11 +1777,11 @@ class Trainer:
         self.strategy.optimizer_frequencies = new_freqs
 
     @property
-    def amp_backend(self) -> Optional[AMPType]:
+    def amp_backend(self) -> Optional[str]:
         if isinstance(self.precision_plugin, ApexMixedPrecisionPlugin):
-            return AMPType.APEX
+            return "apex"
         if isinstance(self.precision_plugin, NativeMixedPrecisionPlugin):
-            return AMPType.NATIVE
+            return "native"
         return None
 
     @property

--- a/src/pytorch_lightning/trainer/trainer.py
+++ b/src/pytorch_lightning/trainer/trainer.py
@@ -58,12 +58,7 @@ from pytorch_lightning.loops import PredictionLoop, TrainingEpochLoop
 from pytorch_lightning.loops.dataloader.evaluation_loop import EvaluationLoop
 from pytorch_lightning.loops.fit_loop import FitLoop
 from pytorch_lightning.loops.utilities import _parse_loop_limits, _reset_progress
-from pytorch_lightning.plugins import (
-    ApexMixedPrecisionPlugin,
-    NativeMixedPrecisionPlugin,
-    PLUGIN_INPUT,
-    PrecisionPlugin,
-)
+from pytorch_lightning.plugins import ApexMixedPrecisionPlugin, MixedPrecisionPlugin, PLUGIN_INPUT, PrecisionPlugin
 from pytorch_lightning.profilers import Profiler
 from pytorch_lightning.strategies import (
     DDPFullyShardedNativeStrategy,
@@ -164,8 +159,7 @@ class Trainer:
         detect_anomaly: bool = False,
         auto_scale_batch_size: Union[str, bool] = False,
         plugins: Optional[Union[PLUGIN_INPUT, List[PLUGIN_INPUT]]] = None,
-        # FIXME: deprecate these
-        amp_backend: str = "native",  # TODO: Remove in 1.10
+        amp_backend: Optional[str] = None,  # TODO: Remove in 1.10
         amp_level: Optional[str] = None,  # # TODO: Remove in 1.10
         move_metrics_to_cpu: bool = False,
         multiple_trainloader_mode: str = "max_size_cycle",
@@ -194,7 +188,7 @@ class Trainer:
 
                 .. deprecated:: v1.8
                     Setting ``amp_level`` inside the ``Trainer`` is deprecated in v1.8.0 and will be removed
-                    in v1.10.0. Please set it inside the specific precision plugin and pass it to the ``Trainer``.
+                    in v1.10.0.
 
             auto_lr_find: If set to True, will make trainer.tune() run a learning rate finder,
                 trying to optimize initial learning for faster convergence. trainer.tune() method will
@@ -1780,7 +1774,7 @@ class Trainer:
     def amp_backend(self) -> Optional[str]:
         if isinstance(self.precision_plugin, ApexMixedPrecisionPlugin):
             return "apex"
-        if isinstance(self.precision_plugin, NativeMixedPrecisionPlugin):
+        if isinstance(self.precision_plugin, MixedPrecisionPlugin):
             return "native"
         return None
 

--- a/src/pytorch_lightning/trainer/trainer.py
+++ b/src/pytorch_lightning/trainer/trainer.py
@@ -1772,6 +1772,12 @@ class Trainer:
 
     @property
     def amp_backend(self) -> Optional[str]:
+        rank_zero_deprecation(
+            "The NVIDIA/apex AMP implementation has been deprecated upstream. Consequently, its integration inside"
+            " PyTorch Lightning has been deprecated in v1.9.0 and will be removed in v1.10.0."
+            " Accessing `Trainer.amp_backend` will not be supported. You can assume it will be `'native'`",
+            stacklevel=6,
+        )
         if isinstance(self.precision_plugin, ApexMixedPrecisionPlugin):
             return "apex"
         if isinstance(self.precision_plugin, MixedPrecisionPlugin):

--- a/src/pytorch_lightning/trainer/trainer.py
+++ b/src/pytorch_lightning/trainer/trainer.py
@@ -159,8 +159,8 @@ class Trainer:
         detect_anomaly: bool = False,
         auto_scale_batch_size: Union[str, bool] = False,
         plugins: Optional[Union[PLUGIN_INPUT, List[PLUGIN_INPUT]]] = None,
-        amp_backend: Optional[str] = None,  # TODO: Remove in 1.10
-        amp_level: Optional[str] = None,  # # TODO: Remove in 1.10
+        amp_backend: Optional[str] = None,  # TODO: Remove in v1.10.0
+        amp_level: Optional[str] = None,  # TODO: Remove in v1.10.0
         move_metrics_to_cpu: bool = False,
         multiple_trainloader_mode: str = "max_size_cycle",
         inference_mode: bool = True,

--- a/src/pytorch_lightning/utilities/__init__.py
+++ b/src/pytorch_lightning/utilities/__init__.py
@@ -21,7 +21,6 @@ from pytorch_lightning.utilities.distributed import AllGatherGrad  # noqa: F401
 from pytorch_lightning.utilities.enums import GradClipAlgorithmType  # noqa: F401
 from pytorch_lightning.utilities.grads import grad_norm  # noqa: F401
 from pytorch_lightning.utilities.imports import (  # noqa: F401
-    _APEX_AVAILABLE,
     _HIVEMIND_AVAILABLE,
     _HOROVOD_AVAILABLE,
     _HPU_AVAILABLE,

--- a/src/pytorch_lightning/utilities/__init__.py
+++ b/src/pytorch_lightning/utilities/__init__.py
@@ -18,6 +18,7 @@ import numpy
 from lightning_lite.utilities import LightningEnum  # noqa: F401
 from lightning_lite.utilities import move_data_to_device  # noqa: F401
 from pytorch_lightning.utilities.distributed import AllGatherGrad  # noqa: F401
+from pytorch_lightning.utilities.enums import AMPType  # noqa: F401
 from pytorch_lightning.utilities.enums import GradClipAlgorithmType  # noqa: F401
 from pytorch_lightning.utilities.grads import grad_norm  # noqa: F401
 from pytorch_lightning.utilities.imports import (  # noqa: F401
@@ -38,7 +39,6 @@ from pytorch_lightning.utilities.rank_zero import (  # noqa: F401
     rank_zero_only,
     rank_zero_warn,
 )
-from pytorch_lightning.utiltiies.enums import AMPType  # noqa: F401
 
 FLOAT16_EPSILON = numpy.finfo(numpy.float16).eps
 FLOAT32_EPSILON = numpy.finfo(numpy.float32).eps

--- a/src/pytorch_lightning/utilities/__init__.py
+++ b/src/pytorch_lightning/utilities/__init__.py
@@ -15,8 +15,8 @@
 
 import numpy
 
+from lightning_lite.utilities import LightningEnum  # noqa: F401
 from lightning_lite.utilities import move_data_to_device  # noqa: F401
-from lightning_lite.utilities import AMPType, LightningEnum  # noqa: F401
 from pytorch_lightning.utilities.distributed import AllGatherGrad  # noqa: F401
 from pytorch_lightning.utilities.enums import GradClipAlgorithmType  # noqa: F401
 from pytorch_lightning.utilities.grads import grad_norm  # noqa: F401
@@ -38,6 +38,7 @@ from pytorch_lightning.utilities.rank_zero import (  # noqa: F401
     rank_zero_only,
     rank_zero_warn,
 )
+from pytorch_lightning.utiltiies.enums import AMPType  # noqa: F401
 
 FLOAT16_EPSILON = numpy.finfo(numpy.float16).eps
 FLOAT32_EPSILON = numpy.finfo(numpy.float32).eps

--- a/src/pytorch_lightning/utilities/enums.py
+++ b/src/pytorch_lightning/utilities/enums.py
@@ -15,9 +15,56 @@
 from __future__ import annotations
 
 import os
+from enum import Enum, EnumMeta
+from typing import Any
 
-from lightning_lite.utilities.enums import AMPType, LightningEnum, PrecisionType  # noqa: F401
+from lightning_lite.utilities.enums import LightningEnum, PrecisionType  # noqa: F401
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
+from pytorch_lightning.utilities.rank_zero import rank_zero_deprecation
+
+
+class _DeprecatedEnumMeta(EnumMeta):
+    """Enum that calls `deprecate()` whenever a member is accessed.
+
+    Adapted from: https://stackoverflow.com/a/62309159/208880
+    """
+
+    def __getattribute__(cls, name: str) -> Any:
+        obj = super().__getattribute__(name)
+        # ignore __dunder__ names -- prevents potential recursion errors
+        if not (name.startswith("__") and name.endswith("__")) and isinstance(obj, Enum):
+            obj.deprecate()
+        return obj
+
+    def __getitem__(cls, name: str) -> Any:
+        member: _DeprecatedEnumMeta = super().__getitem__(name)
+        member.deprecate()
+        return member
+
+    def __call__(cls, *args: Any, **kwargs: Any) -> Any:
+        obj = super().__call__(*args, **kwargs)
+        if isinstance(obj, Enum):
+            obj.deprecate()
+        return obj
+
+
+class _DeprecatedEnum(LightningEnum, metaclass=_DeprecatedEnumMeta):
+    """_DeprecatedEnum calls an enum's `deprecate()` method on member access."""
+
+    pass
+
+
+class AMPType(LightningEnum):
+    """Type of Automatic Mixed Precision used for training."""
+
+    APEX = "apex"
+    NATIVE = "native"
+
+    def deprecate(self) -> None:
+        rank_zero_deprecation(
+            f"`{type(self).__name__}` enum has been deprecated in v1.9.0 and will be removed in v1.10.0."
+            f" Use the string value `{self.value!r}` instead."
+        )
 
 
 class GradClipAlgorithmType(LightningEnum):

--- a/src/pytorch_lightning/utilities/enums.py
+++ b/src/pytorch_lightning/utilities/enums.py
@@ -48,13 +48,7 @@ class _DeprecatedEnumMeta(EnumMeta):
         return obj
 
 
-class _DeprecatedEnum(LightningEnum, metaclass=_DeprecatedEnumMeta):
-    """_DeprecatedEnum calls an enum's `deprecate()` method on member access."""
-
-    pass
-
-
-class AMPType(LightningEnum):
+class AMPType(LightningEnum, metaclass=_DeprecatedEnumMeta):
     """Type of Automatic Mixed Precision used for training."""
 
     APEX = "apex"
@@ -62,7 +56,7 @@ class AMPType(LightningEnum):
 
     def deprecate(self) -> None:
         rank_zero_deprecation(
-            f"`{type(self).__name__}` enum has been deprecated in v1.9.0 and will be removed in v1.10.0."
+            f"The `{type(self).__name__}` enum has been deprecated in v1.9.0 and will be removed in v1.10.0."
             f" Use the string value `{self.value!r}` instead."
         )
 

--- a/src/pytorch_lightning/utilities/imports.py
+++ b/src/pytorch_lightning/utilities/imports.py
@@ -24,7 +24,6 @@ _TORCH_LESSER_EQUAL_1_10_2 = compare_version("torch", operator.le, "1.10.2")
 # duplicated from lite because HPU is patching it below
 _TORCH_GREATER_EQUAL_1_13 = compare_version("torch", operator.ge, "1.13.0")
 
-_APEX_AVAILABLE = module_available("apex.amp")
 _DALI_AVAILABLE = module_available("nvidia.dali")
 _HABANA_FRAMEWORK_AVAILABLE = package_available("habana_frameworks")
 _HIVEMIND_AVAILABLE = package_available("hivemind")

--- a/tests/tests_lite/plugins/precision/test_deepspeed.py
+++ b/tests/tests_lite/plugins/precision/test_deepspeed.py
@@ -36,7 +36,8 @@ def test_deepspeed_precision_apex_not_installed(monkeypatch):
 
 @mock.patch("lightning_lite.plugins.precision.deepspeed._APEX_AVAILABLE", return_value=True)
 def test_deepspeed_precision_apex_default_level(_):
-    precision = DeepSpeedPrecision(precision=16, amp_type="apex")
+    with pytest.deprecated_call(match="apex AMP implementation has been deprecated"):
+        precision = DeepSpeedPrecision(precision=16, amp_type="apex")
     assert isinstance(precision, DeepSpeedPrecision)
     assert precision.amp_level == "O2"
 

--- a/tests/tests_lite/plugins/precision/test_deepspeed.py
+++ b/tests/tests_lite/plugins/precision/test_deepspeed.py
@@ -23,27 +23,11 @@ from lightning_lite.utilities.types import Steppable
 
 def test_invalid_precision_with_deepspeed_precision():
     with pytest.raises(ValueError, match="is not supported in DeepSpeed. `precision` must be one of"):
-        DeepSpeedPrecision(precision=64, amp_type="native")
-
-
-def test_deepspeed_precision_apex_not_installed(monkeypatch):
-    import lightning_lite.plugins.precision.deepspeed as deepspeed
-
-    monkeypatch.setattr(deepspeed, "_APEX_AVAILABLE", False)
-    with pytest.raises(ImportError, match="You have asked for Apex AMP but `apex` is not installed."):
-        DeepSpeedPrecision(precision=16, amp_type="apex")
-
-
-@mock.patch("lightning_lite.plugins.precision.deepspeed._APEX_AVAILABLE", return_value=True)
-def test_deepspeed_precision_apex_default_level(_):
-    with pytest.deprecated_call(match="apex AMP implementation has been deprecated"):
-        precision = DeepSpeedPrecision(precision=16, amp_type="apex")
-    assert isinstance(precision, DeepSpeedPrecision)
-    assert precision.amp_level == "O2"
+        DeepSpeedPrecision(precision=64)
 
 
 def test_deepspeed_precision_backward():
-    precision = DeepSpeedPrecision(precision=32, amp_type="native")
+    precision = DeepSpeedPrecision(precision=32)
     tensor = Mock()
     model = Mock()
     precision.backward(tensor, model, "positional-arg", keyword="arg")
@@ -61,7 +45,7 @@ def test_deepspeed_engine_is_steppable(engine):
 
 
 def test_deepspeed_precision_optimizer_step():
-    precision = DeepSpeedPrecision(precision=32, amp_type="native")
+    precision = DeepSpeedPrecision(precision=32)
     optimizer = model = Mock()
     precision.optimizer_step(optimizer, lr_kwargs=dict())
     model.step.assert_called_once_with(lr_kwargs=dict())

--- a/tests/tests_lite/plugins/precision/test_native_amp.py
+++ b/tests/tests_lite/plugins/precision/test_native_amp.py
@@ -16,25 +16,25 @@ from unittest.mock import Mock
 import pytest
 import torch
 
-from lightning_lite.plugins.precision.native_amp import NativeMixedPrecision
+from lightning_lite.plugins.precision.native_amp import MixedPrecision
 
 
 def test_native_amp_precision_default_scaler():
-    precision = NativeMixedPrecision(precision=16, device=Mock())
+    precision = MixedPrecision(precision=16, device=Mock())
     assert isinstance(precision.scaler, torch.cuda.amp.GradScaler)
 
 
 def test_native_amp_precision_scaler_with_bf16():
     with pytest.raises(ValueError, match="`precision='bf16'` does not use a scaler"):
-        NativeMixedPrecision(precision="bf16", device=Mock(), scaler=Mock())
+        MixedPrecision(precision="bf16", device=Mock(), scaler=Mock())
 
-    precision = NativeMixedPrecision(precision="bf16", device=Mock())
+    precision = MixedPrecision(precision="bf16", device=Mock())
     assert precision.scaler is None
 
 
 def test_native_amp_precision_forward_context():
     """Test to ensure that the context manager correctly is set to bfloat16 on CPU and CUDA."""
-    precision = NativeMixedPrecision(precision=16, device="cuda")
+    precision = MixedPrecision(precision=16, device="cuda")
     assert precision.device == "cuda"
     assert isinstance(precision.scaler, torch.cuda.amp.GradScaler)
     assert torch.get_default_dtype() == torch.float32
@@ -42,7 +42,7 @@ def test_native_amp_precision_forward_context():
         # check with str due to a bug upstream: https://github.com/pytorch/pytorch/issues/65786
         assert str(torch.get_autocast_gpu_dtype()) in ("torch.float16", "torch.half")
 
-    precision = NativeMixedPrecision(precision="bf16", device="cpu")
+    precision = MixedPrecision(precision="bf16", device="cpu")
     assert precision.device == "cpu"
     assert precision.scaler is None
     with precision.forward_context():
@@ -56,7 +56,7 @@ def test_native_amp_precision_forward_context():
 
 
 def test_native_amp_precision_backward():
-    precision = NativeMixedPrecision(precision="mixed", device="cuda")
+    precision = MixedPrecision(precision="mixed", device="cuda")
     precision.scaler = Mock()
     precision.scaler.scale = Mock(side_effect=(lambda x: x))
     tensor = Mock()
@@ -67,7 +67,7 @@ def test_native_amp_precision_backward():
 
 
 def test_native_amp_precision_optimizer_step_with_scaler():
-    precision = NativeMixedPrecision(precision="mixed", device="cuda")
+    precision = MixedPrecision(precision="mixed", device="cuda")
     precision.scaler = Mock()
     optimizer = Mock()
 
@@ -77,7 +77,7 @@ def test_native_amp_precision_optimizer_step_with_scaler():
 
 
 def test_native_amp_precision_optimizer_step_without_scaler():
-    precision = NativeMixedPrecision(precision="bf16", device="cuda")
+    precision = MixedPrecision(precision="bf16", device="cuda")
     assert precision.scaler is None
     optimizer = Mock()
 

--- a/tests/tests_lite/test_connector.py
+++ b/tests/tests_lite/test_connector.py
@@ -29,7 +29,7 @@ from lightning_lite.accelerators.cpu import CPUAccelerator
 from lightning_lite.accelerators.cuda import CUDAAccelerator
 from lightning_lite.accelerators.mps import MPSAccelerator
 from lightning_lite.connector import _Connector
-from lightning_lite.plugins import DoublePrecision, NativeMixedPrecision, Precision, TPUPrecision
+from lightning_lite.plugins import DoublePrecision, MixedPrecision, Precision, TPUPrecision
 from lightning_lite.plugins.environments import (
     KubeflowEnvironment,
     LightningEnvironment,
@@ -409,7 +409,7 @@ def test_strategy_choice_gpu_str(strategy, strategy_class):
     "strategy,expected_strategy", [("ddp_sharded", DDPShardedStrategy), ("ddp_sharded_spawn", DDPShardedStrategy)]
 )
 @pytest.mark.parametrize(
-    "precision,expected_precision", [(16, NativeMixedPrecision), (32, Precision), ("bf16", NativeMixedPrecision)]
+    "precision,expected_precision", [(16, MixedPrecision), (32, Precision), ("bf16", MixedPrecision)]
 )
 def test_strategy_choice_sharded(strategy, expected_strategy, precision, expected_precision):
     connector = _Connector(strategy=strategy, devices=1, precision=precision)
@@ -753,7 +753,7 @@ def test_precision_selection_16_on_cpu_warns():
         _Connector(precision=16)
 
 
-class MyNativeAMP(NativeMixedPrecision):
+class MyNativeAMP(MixedPrecision):
     pass
 
 
@@ -761,7 +761,7 @@ class MyNativeAMP(NativeMixedPrecision):
 @pytest.mark.parametrize("strategy,devices", [("ddp", 2), ("ddp_spawn", 2)])
 @pytest.mark.parametrize(
     "is_custom_plugin,plugin_cls",
-    [(False, NativeMixedPrecision), (True, MyNativeAMP)],
+    [(False, MixedPrecision), (True, MyNativeAMP)],
 )
 def test_precision_selection_amp_ddp(strategy, devices, is_custom_plugin, plugin_cls):
     plugin = None

--- a/tests/tests_pytorch/conftest.py
+++ b/tests/tests_pytorch/conftest.py
@@ -305,11 +305,6 @@ def pytest_collection_modifyitems(items: List[pytest.Function], config: pytest.C
     for item in items:
         item.add_marker(deprecation_error)
 
-    apex_deprecation = pytest.mark.filterwarnings("ignore:apex.amp is deprecated:FutureWarning")
-    for item in items:
-        if any(marker.name == "skipif" and marker.kwargs.get("amp_apex", False) for marker in item.own_markers):
-            item.add_marker(apex_deprecation)
-
 
 def pytest_addoption(parser):
     parser.addoption("--hpus", action="store", type=int, default=1, help="Number of hpus 1-8")

--- a/tests/tests_pytorch/core/test_lightning_module.py
+++ b/tests/tests_pytorch/core/test_lightning_module.py
@@ -152,7 +152,6 @@ def test_toggle_untoggle_2_optimizers_no_shared_parameters(tmpdir):
             optimizer_idx,
             closure,
             on_tpu=False,
-            using_native_amp=False,
             using_lbfgs=False,
         ):
             if optimizer_idx == 0:
@@ -216,7 +215,6 @@ def test_toggle_untoggle_3_optimizers_shared_parameters(tmpdir):
             optimizer_idx,
             closure,
             on_tpu=False,
-            using_native_amp=False,
             using_lbfgs=False,
         ):
             if optimizer_idx == 0:

--- a/tests/tests_pytorch/deprecated_api/test_remove_1-10.py
+++ b/tests/tests_pytorch/deprecated_api/test_remove_1-10.py
@@ -33,6 +33,7 @@ from pytorch_lightning.lite import LightningLite
 from pytorch_lightning.overrides import LightningDistributedModule, LightningParallelModule
 from pytorch_lightning.overrides.base import unwrap_lightning_module
 from pytorch_lightning.overrides.fairscale import LightningShardedDataParallel, unwrap_lightning_module_sharded
+from pytorch_lightning.plugins import ApexMixedPrecisionPlugin, DeepSpeedPrecisionPlugin, NativeMixedPrecisionPlugin
 from pytorch_lightning.plugins.environments import LightningEnvironment
 from pytorch_lightning.strategies.bagua import LightningBaguaModule
 from pytorch_lightning.strategies.utils import on_colab_kaggle
@@ -67,15 +68,11 @@ from pytorch_lightning.utilities.distributed import (
     sync_ddp_if_available,
     tpu_distributed,
 )
+from pytorch_lightning.utilities.enums import AMPType
 from pytorch_lightning.utilities.optimizer import optimizer_to_device, optimizers_to_device
 from pytorch_lightning.utilities.seed import pl_worker_init_function, reset_seed, seed_everything
 from pytorch_lightning.utilities.xla_device import inner_f, pl_multi_process, XLADeviceUtils
 from tests_pytorch.helpers.runif import RunIf
-
-
-def test_deprecated_amp_level():
-    with pytest.deprecated_call(match="Setting `amp_level` inside the `Trainer` is deprecated in v1.8.0"):
-        Trainer(amp_level="O3", amp_backend="apex")
 
 
 @pytest.mark.parametrize(
@@ -356,3 +353,48 @@ def test_profiler_classes_deprecated_warning(cls):
         f" Use .*profilers.{cls.__name__}` class instead."
     ):
         cls()
+
+
+def test_apex_deprecation_warnings():
+    class MyModel(BoringModel):
+        def optimizer_step(
+            self,
+            epoch,
+            batch_idx,
+            optimizer,
+            optimizer_idx=0,
+            optimizer_closure=None,
+            on_tpu=False,
+            using_native_amp=False,
+            **kwargs,
+        ):
+            return optimizer_closure()
+
+    model = MyModel()
+    trainer = Trainer(fast_dev_run=True)
+    with pytest.deprecated_call(match="including the `using_native_amp` argument"):
+        trainer.fit(model)
+
+    with pytest.deprecated_call(match="ApexMixedPrecisionPlugin` class will be removed in v1.10"):
+        ApexMixedPrecisionPlugin()
+
+    with pytest.deprecated_call(match="NativeMixedPrecisionPlugin` class has been renamed in v1.9"):
+        NativeMixedPrecisionPlugin(16, "cpu")
+
+    with pytest.deprecated_call(match="Support for.*DeepSpeed implementation will be removed in v1.10.0"):
+        DeepSpeedPrecisionPlugin(16, amp_type="apex")
+
+    with pytest.deprecated_call(match=r"amp_type='native'\)` been deprecated in v1.9"):
+        DeepSpeedPrecisionPlugin(16, amp_type="native")
+
+    with pytest.raises(ValueError, match=r"amp_level='O2'\)` is only relevant when using NVIDIA/apex"):
+        DeepSpeedPrecisionPlugin(16, amp_level="O2")
+
+    with pytest.deprecated_call(match=r"Trainer\(amp_backend='apex'\)` argument is deprecated"):
+        Trainer(amp_backend="apex")
+
+    with pytest.deprecated_call(match=r"Trainer\(amp_level='O2'\)` argument is deprecated"):
+        Trainer(amp_backend="apex", amp_level="O2")
+
+    with pytest.deprecated_call(match="AMPType` enum has been deprecated in v1.9"):
+        AMPType.APEX

--- a/tests/tests_pytorch/deprecated_api/test_remove_1-10.py
+++ b/tests/tests_pytorch/deprecated_api/test_remove_1-10.py
@@ -355,6 +355,7 @@ def test_profiler_classes_deprecated_warning(cls):
         cls()
 
 
+@RunIf(amp_apex=True)
 def test_apex_deprecation_warnings():
     class MyModel(BoringModel):
         def optimizer_step(

--- a/tests/tests_pytorch/deprecated_api/test_remove_1-10.py
+++ b/tests/tests_pytorch/deprecated_api/test_remove_1-10.py
@@ -398,3 +398,7 @@ def test_apex_deprecation_warnings():
 
     with pytest.deprecated_call(match="AMPType` enum has been deprecated in v1.9"):
         AMPType.APEX
+
+    trainer = Trainer()
+    with pytest.deprecated_call(match="amp_backend` will not be supported"):
+        trainer.amp_backend

--- a/tests/tests_pytorch/helpers/runif.py
+++ b/tests/tests_pytorch/helpers/runif.py
@@ -154,7 +154,7 @@ class RunIf:
             conditions.append(not _TORCH_QUANTIZE_AVAILABLE or _miss_default)
             reasons.append("PyTorch quantization")
 
-        # TODO: remove in v1.9.0
+        # TODO: remove in v1.10.0
         if amp_apex:
             conditions.append(not _APEX_AVAILABLE)
             reasons.append("NVIDIA Apex")

--- a/tests/tests_pytorch/helpers/runif.py
+++ b/tests/tests_pytorch/helpers/runif.py
@@ -25,11 +25,11 @@ from lightning_lite.strategies.fairscale import _FAIRSCALE_AVAILABLE
 from pytorch_lightning.accelerators.mps import MPSAccelerator
 from pytorch_lightning.accelerators.tpu import TPUAccelerator
 from pytorch_lightning.callbacks.progress.rich_progress import _RICH_AVAILABLE
+from pytorch_lightning.plugins.precision.apex_amp import _APEX_AVAILABLE
 from pytorch_lightning.strategies.bagua import _BAGUA_AVAILABLE
 from pytorch_lightning.strategies.colossalai import _COLOSSALAI_AVAILABLE
 from pytorch_lightning.strategies.deepspeed import _DEEPSPEED_AVAILABLE
 from pytorch_lightning.utilities.imports import (
-    _APEX_AVAILABLE,
     _HIVEMIND_AVAILABLE,
     _HOROVOD_AVAILABLE,
     _HPU_AVAILABLE,
@@ -154,6 +154,7 @@ class RunIf:
             conditions.append(not _TORCH_QUANTIZE_AVAILABLE or _miss_default)
             reasons.append("PyTorch quantization")
 
+        # TODO: remove in v1.9.0
         if amp_apex:
             conditions.append(not _APEX_AVAILABLE)
             reasons.append("NVIDIA Apex")

--- a/tests/tests_pytorch/models/test_amp.py
+++ b/tests/tests_pytorch/models/test_amp.py
@@ -194,9 +194,10 @@ def test_amp_with_apex(bwd_mock, tmpdir):
     model = CustomModel()
     model.training_epoch_end = None
 
-    trainer = Trainer(
-        default_root_dir=tmpdir, max_steps=5, precision=16, amp_backend="apex", accelerator="gpu", devices=1
-    )
+    with pytest.deprecated_call(match="apex AMP implementation has been deprecated"):
+        trainer = Trainer(
+            default_root_dir=tmpdir, max_steps=5, precision=16, amp_backend="apex", accelerator="gpu", devices=1
+        )
     assert str(trainer.amp_backend) == "AMPType.APEX"
     trainer.fit(model)
     # `max_steps` is fulfilled in the third batch first optimizer, but we don't check the loop
@@ -210,15 +211,16 @@ def test_amp_with_apex(bwd_mock, tmpdir):
 @RunIf(min_cuda_gpus=1, amp_apex=True)
 def test_amp_with_apex_reload(tmpdir):
     model = BoringModel()
-    trainer = Trainer(
-        default_root_dir=tmpdir,
-        max_steps=1,
-        limit_test_batches=1,
-        precision=16,
-        amp_backend="apex",
-        accelerator="gpu",
-        devices=1,
-    )
+    with pytest.deprecated_call(match="apex AMP implementation has been deprecated"):
+        trainer = Trainer(
+            default_root_dir=tmpdir,
+            max_steps=1,
+            limit_test_batches=1,
+            precision=16,
+            amp_backend="apex",
+            accelerator="gpu",
+            devices=1,
+        )
     trainer.fit(model)
     trainer.fit_loop.max_steps = 2
 

--- a/tests/tests_pytorch/models/test_amp.py
+++ b/tests/tests_pytorch/models/test_amp.py
@@ -166,11 +166,15 @@ def test_amp_without_apex(bwd_mock, tmpdir):
     """Check that even with apex amp type without requesting precision=16 the amp backend is void."""
     model = BoringModel()
 
-    trainer = Trainer(default_root_dir=tmpdir, amp_backend="native")
-    assert trainer.amp_backend is None
+    with pytest.deprecated_call(match="apex AMP implementation has been deprecated"):
+        trainer = Trainer(default_root_dir=tmpdir, amp_backend="native")
+    with pytest.deprecated_call(match="apex AMP implementation has been deprecated"):
+        assert trainer.amp_backend is None
 
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, amp_backend="apex")
-    assert trainer.amp_backend is None
+    with pytest.deprecated_call(match="apex AMP implementation has been deprecated"):
+        trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, amp_backend="apex")
+    with pytest.deprecated_call(match="apex AMP implementation has been deprecated"):
+        assert trainer.amp_backend is None
     trainer.fit(model)
     assert not bwd_mock.called
 
@@ -198,7 +202,8 @@ def test_amp_with_apex(bwd_mock, tmpdir):
         trainer = Trainer(
             default_root_dir=tmpdir, max_steps=5, precision=16, amp_backend="apex", accelerator="gpu", devices=1
         )
-    assert str(trainer.amp_backend) == "AMPType.APEX"
+    with pytest.deprecated_call(match="apex AMP implementation has been deprecated"):
+        assert str(trainer.amp_backend) == "apex"
     trainer.fit(model)
     # `max_steps` is fulfilled in the third batch first optimizer, but we don't check the loop
     # `done` condition until all optimizers have run, so the number of backwards is higher than `max_steps`

--- a/tests/tests_pytorch/models/test_ddp_fork_amp.py
+++ b/tests/tests_pytorch/models/test_ddp_fork_amp.py
@@ -15,7 +15,7 @@ import multiprocessing
 
 import torch
 
-from pytorch_lightning.plugins import NativeMixedPrecisionPlugin
+from pytorch_lightning.plugins import MixedPrecisionPlugin
 from tests_pytorch.helpers.runif import RunIf
 
 
@@ -24,7 +24,7 @@ from tests_pytorch.helpers.runif import RunIf
 def test_amp_gpus_ddp_fork():
     """Ensure the use of native AMP with `ddp_fork` (or associated alias strategies) does not generate CUDA
     initialization errors."""
-    _ = NativeMixedPrecisionPlugin(precision=16, device="cuda")
+    _ = MixedPrecisionPlugin(precision=16, device="cuda")
     with multiprocessing.get_context("fork").Pool(1) as pool:
         in_bad_fork = pool.apply(torch.cuda._is_in_bad_fork)
     assert not in_bad_fork

--- a/tests/tests_pytorch/models/test_hooks.py
+++ b/tests/tests_pytorch/models/test_hooks.py
@@ -302,7 +302,6 @@ class HookedModel(BoringModel):
     def _auto_train_batch(
         trainer, model, batches, device=torch.device("cpu"), current_epoch=0, current_batch=0, **kwargs
     ):
-        using_native_amp = kwargs.get("amp_backend") == "native"
         using_deepspeed = kwargs.get("strategy") == "deepspeed"
         out = []
         for i in range(current_batch, batches):
@@ -344,7 +343,7 @@ class HookedModel(BoringModel):
                     dict(
                         name="optimizer_step",
                         args=(current_epoch, i, ANY, 0, ANY),
-                        kwargs=dict(on_tpu=False, using_lbfgs=False, using_native_amp=using_native_amp),
+                        kwargs=dict(on_tpu=False, using_lbfgs=False),
                     ),
                     *(
                         [dict(name="lr_scheduler_step", args=(ANY, 0, None))]

--- a/tests/tests_pytorch/models/test_hooks.py
+++ b/tests/tests_pytorch/models/test_hooks.py
@@ -485,17 +485,31 @@ def test_trainer_model_hook_system_fit(tmpdir, kwargs, automatic_optimization):
     callback = HookedCallback(called)
     train_batches = 2
     val_batches = 2
-    trainer = Trainer(
-        default_root_dir=tmpdir,
-        max_epochs=1,
-        limit_train_batches=train_batches,
-        limit_val_batches=val_batches,
-        enable_progress_bar=False,
-        enable_model_summary=False,
-        callbacks=[callback],
-        track_grad_norm=1,
-        **kwargs,
-    )
+    if kwargs.get("amp_backend") == "apex":
+        with pytest.deprecated_call(match="apex AMP implementation has been deprecated"):
+            trainer = Trainer(
+                default_root_dir=tmpdir,
+                max_epochs=1,
+                limit_train_batches=train_batches,
+                limit_val_batches=val_batches,
+                enable_progress_bar=False,
+                enable_model_summary=False,
+                callbacks=[callback],
+                track_grad_norm=1,
+                **kwargs,
+            )
+    else:
+        trainer = Trainer(
+            default_root_dir=tmpdir,
+            max_epochs=1,
+            limit_train_batches=train_batches,
+            limit_val_batches=val_batches,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            callbacks=[callback],
+            track_grad_norm=1,
+            **kwargs,
+        )
     trainer.fit(model)
     saved_ckpt = {
         "callbacks": ANY,

--- a/tests/tests_pytorch/models/test_hooks.py
+++ b/tests/tests_pytorch/models/test_hooks.py
@@ -448,9 +448,7 @@ class HookedModel(BoringModel):
     [
         {},
         # these precision plugins modify the optimization flow, so testing them explicitly
-        pytest.param(
-            dict(accelerator="gpu", devices=1, precision=16, amp_backend="native"), marks=RunIf(min_cuda_gpus=1)
-        ),
+        pytest.param(dict(accelerator="gpu", devices=1, precision=16), marks=RunIf(min_cuda_gpus=1)),
         pytest.param(
             dict(accelerator="gpu", devices=1, precision=16, amp_backend="apex"),
             marks=RunIf(min_cuda_gpus=1, amp_apex=True),
@@ -520,7 +518,7 @@ def test_trainer_model_hook_system_fit(tmpdir, kwargs, automatic_optimization):
         "state_dict": ANY,
         "loops": ANY,
     }
-    if kwargs.get("amp_backend") == "native" or kwargs.get("amp_backend") == "apex":
+    if kwargs.get("precision") == 16:
         saved_ckpt[trainer.precision_plugin.__class__.__qualname__] = ANY
     device = torch.device("cuda:0" if "accelerator" in kwargs and kwargs["accelerator"] == "gpu" else "cpu")
     expected = [

--- a/tests/tests_pytorch/models/test_horovod.py
+++ b/tests/tests_pytorch/models/test_horovod.py
@@ -200,29 +200,6 @@ def test_horovod_multi_gpu_grad_by_value(tmpdir):
     _run_horovod(trainer_options)
 
 
-# todo: need to be fixed :]
-# https://discuss.pytorch.org/t/torch-cuda-amp-vs-nvidia-apex/74994
-# Check with (tgaddair) on Horovod issues if this feature is needed
-@pytest.mark.skip(reason="TODO: Horovod currently doesn't work with Apex")
-@RunIf(min_cuda_gpus=2, amp_apex=True, horovod_nccl=True, skip_windows=True)
-def test_horovod_apex(tmpdir):
-    """Test Horovod with multi-GPU support using apex amp."""
-    trainer_options = dict(
-        default_root_dir=str(tmpdir),
-        gradient_clip_val=1.0,
-        enable_progress_bar=False,
-        max_epochs=1,
-        limit_train_batches=0.4,
-        limit_val_batches=0.2,
-        accelerator="gpu",
-        devices=2,
-        strategy="horovod",
-        amp_backend="apex",
-        precision=16,
-    )
-    _run_horovod(trainer_options)
-
-
 @RunIf(min_cuda_gpus=2, horovod_nccl=True, skip_windows=True)
 def test_horovod_amp(tmpdir):
     """Test Horovod with multi-GPU support using native amp."""

--- a/tests/tests_pytorch/plugins/precision/test_deepspeed_precision.py
+++ b/tests/tests_pytorch/plugins/precision/test_deepspeed_precision.py
@@ -28,12 +28,15 @@ def test_deepspeed_precision_apex_not_installed(monkeypatch):
     import pytorch_lightning.plugins.precision.deepspeed as deepspeed_apex
 
     monkeypatch.setattr(deepspeed_apex, "_APEX_AVAILABLE", False)
-    with pytest.raises(MisconfigurationException, match="You have asked for Apex AMP but `apex` is not installed."):
+    with pytest.raises(
+        MisconfigurationException, match="You have asked for Apex AMP but `apex` is not installed."
+    ), pytest.deprecated_call(match="apex AMP implementation has been deprecated"):
         DeepSpeedPrecisionPlugin(precision=16, amp_type="apex")
 
 
 @mock.patch("pytorch_lightning.plugins.precision.deepspeed._APEX_AVAILABLE", return_value=True)
 def test_deepspeed_precision_apex_default_level(_):
-    precision_plugin = DeepSpeedPrecisionPlugin(precision=16, amp_type="apex")
+    with pytest.deprecated_call(match="apex AMP implementation has been deprecated"):
+        precision_plugin = DeepSpeedPrecisionPlugin(precision=16, amp_type="apex")
     assert isinstance(precision_plugin, DeepSpeedPrecisionPlugin)
     assert precision_plugin.amp_level == "O2"

--- a/tests/tests_pytorch/plugins/precision/test_deepspeed_precision.py
+++ b/tests/tests_pytorch/plugins/precision/test_deepspeed_precision.py
@@ -20,7 +20,9 @@ from pytorch_lightning.utilities.exceptions import MisconfigurationException
 
 
 def test_invalid_precision_with_deepspeed_precision():
-    with pytest.raises(ValueError, match="is not supported. `precision` must be one of"):
+    with pytest.deprecated_call(match=r"amp_type='native'\)` been deprecated in v1.9.0"), pytest.raises(
+        ValueError, match="is not supported. `precision` must be one of"
+    ):
         DeepSpeedPrecisionPlugin(precision=64, amp_type="native")
 
 

--- a/tests/tests_pytorch/plugins/precision/test_native_amp.py
+++ b/tests/tests_pytorch/plugins/precision/test_native_amp.py
@@ -16,14 +16,14 @@ from unittest.mock import Mock
 import pytest
 from torch.optim import Optimizer
 
-from pytorch_lightning.plugins import NativeMixedPrecisionPlugin
+from pytorch_lightning.plugins import MixedPrecisionPlugin
 from pytorch_lightning.utilities import GradClipAlgorithmType
 
 
 def test_clip_gradients():
     """Test that `.clip_gradients()` is a no-op when clipping is disabled."""
     optimizer = Mock(spec=Optimizer)
-    precision = NativeMixedPrecisionPlugin(precision=16, device="cuda:0", scaler=Mock())
+    precision = MixedPrecisionPlugin(precision=16, device="cuda:0", scaler=Mock())
     precision.clip_grad_by_value = Mock()
     precision.clip_grad_by_norm = Mock()
     precision.clip_gradients(optimizer)
@@ -47,7 +47,7 @@ def test_optimizer_amp_scaling_support_in_step_method():
     gradient clipping (example: fused Adam)."""
 
     optimizer = Mock(_step_supports_amp_scaling=True)
-    precision = NativeMixedPrecisionPlugin(precision=16, device="cuda:0", scaler=Mock())
+    precision = MixedPrecisionPlugin(precision=16, device="cuda:0", scaler=Mock())
 
     with pytest.raises(RuntimeError, match="The current optimizer.*does not allow for gradient clipping"):
         precision.clip_gradients(optimizer, clip_val=1.0)

--- a/tests/tests_pytorch/plugins/test_amp_plugins.py
+++ b/tests/tests_pytorch/plugins/test_amp_plugins.py
@@ -205,6 +205,8 @@ def test_amp_apex_ddp_fit(amp_level, tmpdir):
             assert self.trainer.precision_plugin._connected
             return super().training_step(batch, batch_idx)
 
+    with pytest.deprecated_call(match="apex AMP implementation has been deprecated"):
+        plugin = ApexMixedPrecisionPlugin(amp_level=amp_level)
     trainer = Trainer(
         default_root_dir=tmpdir,
         fast_dev_run=True,
@@ -213,7 +215,7 @@ def test_amp_apex_ddp_fit(amp_level, tmpdir):
         accelerator="gpu",
         devices=2,
         strategy="ddp",
-        plugins=ApexMixedPrecisionPlugin(amp_level=amp_level),
+        plugins=plugin,
         enable_progress_bar=False,
         enable_model_summary=False,
     )
@@ -226,16 +228,17 @@ def test_amp_apex_ddp_fit(amp_level, tmpdir):
 @RunIf(min_cuda_gpus=2, amp_apex=True)
 @pytest.mark.parametrize("amp_level", ["O2"])
 def test_amp_apex_ddp_spawn_fit(amp_level, tmpdir):
-    trainer = Trainer(
-        default_root_dir=tmpdir,
-        fast_dev_run=True,
-        precision=16,
-        amp_backend="apex",
-        accelerator="gpu",
-        devices=2,
-        strategy="ddp_spawn",
-        plugins=ApexMixedPrecisionPlugin(amp_level=amp_level),
-    )
+    with pytest.deprecated_call(match="apex AMP implementation has been deprecated"):
+        trainer = Trainer(
+            default_root_dir=tmpdir,
+            fast_dev_run=True,
+            precision=16,
+            amp_backend="apex",
+            accelerator="gpu",
+            devices=2,
+            strategy="ddp_spawn",
+            plugins=ApexMixedPrecisionPlugin(amp_level=amp_level),
+        )
     assert isinstance(trainer.precision_plugin, ApexMixedPrecisionPlugin)
     model = BoringModel()
     trainer.fit(model)
@@ -271,5 +274,5 @@ def test_precision_selection_raises(monkeypatch):
     monkeypatch.setattr(apex, "_APEX_AVAILABLE", False)
     with mock.patch("lightning_lite.accelerators.cuda.is_cuda_available", return_value=True), pytest.raises(
         MisconfigurationException, match="asked for Apex AMP but `apex` is not installed"
-    ):
+    ), pytest.deprecated_call(match="apex AMP implementation has been deprecated"):
         Trainer(amp_backend="apex", precision=16, accelerator="gpu", devices=1)

--- a/tests/tests_pytorch/plugins/test_amp_plugins.py
+++ b/tests/tests_pytorch/plugins/test_amp_plugins.py
@@ -151,7 +151,6 @@ def test_amp_gradient_unscale(tmpdir, accum: int):
         default_root_dir=tmpdir,
         limit_train_batches=2,
         limit_val_batches=0,
-        amp_backend="native",
         strategy="ddp_spawn",
         accelerator="gpu",
         devices=2,

--- a/tests/tests_pytorch/plugins/test_amp_plugins.py
+++ b/tests/tests_pytorch/plugins/test_amp_plugins.py
@@ -61,16 +61,21 @@ class MyApexPlugin(ApexMixedPrecisionPlugin):
 def test_amp_apex_ddp(cuda_count_2, strategy, devices, amp, custom_plugin, plugin_cls):
     plugin = None
     if custom_plugin:
-        plugin = plugin_cls(16, "cpu") if amp == "native" else plugin_cls()
-    trainer = Trainer(
-        fast_dev_run=True,
-        precision=16,
-        amp_backend=amp,
-        accelerator="gpu",
-        devices=devices,
-        strategy=strategy,
-        plugins=plugin,
-    )
+        if amp == "native":
+            plugin = plugin_cls(16, "cpu")
+        else:
+            with pytest.deprecated_call(match="apex AMP implementation has been deprecated"):
+                plugin = plugin_cls()
+    with pytest.deprecated_call(match="apex AMP implementation has been deprecated"):
+        trainer = Trainer(
+            fast_dev_run=True,
+            precision=16,
+            amp_backend=amp,
+            accelerator="gpu",
+            devices=devices,
+            strategy=strategy,
+            plugins=plugin,
+        )
     assert isinstance(trainer.precision_plugin, plugin_cls)
 
 

--- a/tests/tests_pytorch/plugins/test_amp_plugins.py
+++ b/tests/tests_pytorch/plugins/test_amp_plugins.py
@@ -198,7 +198,7 @@ def test_amp_skip_optimizer(tmpdir):
     trainer.fit(model)
 
 
-@RunIf(min_cuda_gpus=2, amp_apex=True, standalone=True)
+@RunIf(min_cuda_gpus=1, amp_apex=True)
 @pytest.mark.parametrize("amp_level", ["O2"])
 def test_amp_apex_ddp_fit(amp_level, tmpdir):
     class CustomBoringModel(BoringModel):
@@ -213,9 +213,8 @@ def test_amp_apex_ddp_fit(amp_level, tmpdir):
         default_root_dir=tmpdir,
         fast_dev_run=True,
         precision=16,
-        amp_backend="apex",
         accelerator="gpu",
-        devices=2,
+        devices=1,
         strategy="ddp",
         plugins=plugin,
         enable_progress_bar=False,

--- a/tests/tests_pytorch/strategies/test_deepspeed_strategy.py
+++ b/tests/tests_pytorch/strategies/test_deepspeed_strategy.py
@@ -140,15 +140,25 @@ def test_deepspeed_precision_choice(cuda_count_1, amp_backend, tmpdir):
 
     DeepSpeed handles precision via Custom DeepSpeedPrecisionPlugin
     """
-
-    trainer = Trainer(
-        fast_dev_run=True,
-        default_root_dir=tmpdir,
-        accelerator="gpu",
-        strategy="deepspeed",
-        amp_backend=amp_backend,
-        precision=16,
-    )
+    if amp_backend == "apex":
+        with pytest.deprecated_call(match="apex AMP implementation has been deprecated"):
+            trainer = Trainer(
+                fast_dev_run=True,
+                default_root_dir=tmpdir,
+                accelerator="gpu",
+                strategy="deepspeed",
+                amp_backend=amp_backend,
+                precision=16,
+            )
+    else:
+        trainer = Trainer(
+            fast_dev_run=True,
+            default_root_dir=tmpdir,
+            accelerator="gpu",
+            strategy="deepspeed",
+            amp_backend=amp_backend,
+            precision=16,
+        )
 
     assert isinstance(trainer.strategy, DeepSpeedStrategy)
     assert isinstance(trainer.strategy.precision_plugin, DeepSpeedPrecisionPlugin)

--- a/tests/tests_pytorch/strategies/test_sharded_strategy.py
+++ b/tests/tests_pytorch/strategies/test_sharded_strategy.py
@@ -58,6 +58,7 @@ def test_ddp_sharded_precision_16_clip_gradients(mock_oss_clip_grad_norm, clip_v
     """Ensure that clip gradients is only called if the value is greater than 0."""
     model = BoringModel()
     trainer = Trainer(
+        default_root_dir=tmpdir,
         strategy="ddp_sharded",
         accelerator="gpu",
         devices=1,

--- a/tests/tests_pytorch/strategies/test_sharded_strategy.py
+++ b/tests/tests_pytorch/strategies/test_sharded_strategy.py
@@ -10,7 +10,7 @@ import torch
 from lightning_lite.strategies.fairscale import _FAIRSCALE_AVAILABLE
 from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning.demos.boring_classes import BoringModel
-from pytorch_lightning.plugins import NativeMixedPrecisionPlugin
+from pytorch_lightning.plugins import MixedPrecisionPlugin
 from pytorch_lightning.strategies import DDPShardedStrategy, DDPSpawnShardedStrategy
 from pytorch_lightning.trainer.states import TrainerFn
 from tests_pytorch.helpers.runif import RunIf
@@ -91,7 +91,7 @@ def test_ddp_choice_sharded_amp(strategy, expected):
     """Test to ensure that plugin native amp plugin is correctly chosen when using sharded."""
     trainer = Trainer(fast_dev_run=True, accelerator="gpu", devices=1, precision=16, strategy=strategy)
     assert isinstance(trainer.strategy, expected)
-    assert isinstance(trainer.precision_plugin, NativeMixedPrecisionPlugin)
+    assert isinstance(trainer.precision_plugin, MixedPrecisionPlugin)
 
 
 @RunIf(fairscale=True)

--- a/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
@@ -432,9 +432,9 @@ def test_validate_precision_type(precision):
 
 
 def test_amp_level_raises_error_with_native():
-    with pytest.deprecated_call(
-        match="Setting `amp_level` inside the `Trainer` is deprecated in v1.8.0"
-    ), pytest.raises(MisconfigurationException, match="O2'` but it's only supported with `amp_backend='apex'`"):
+    with pytest.deprecated_call(match="apex AMP implementation has been deprecated"), pytest.raises(
+        MisconfigurationException, match="O2'` but it's only supported with `amp_backend='apex'`"
+    ):
         _ = Trainer(amp_level="O2", amp_backend="native", precision=16)
 
 

--- a/tests/tests_pytorch/trainer/logging_/test_train_loop_logging.py
+++ b/tests/tests_pytorch/trainer/logging_/test_train_loop_logging.py
@@ -730,7 +730,6 @@ def test_move_metrics_to_cpu(tmpdir):
     trainer = Trainer(
         default_root_dir=tmpdir,
         fast_dev_run=True,
-        amp_backend="native",
         precision=16,
         move_metrics_to_cpu=True,
         accelerator="gpu",

--- a/tests/tests_pytorch/trainer/optimization/test_manual_optimization.py
+++ b/tests/tests_pytorch/trainer/optimization/test_manual_optimization.py
@@ -114,7 +114,11 @@ def test_multiple_optimizers_manual_no_return(tmpdir, kwargs):
     model.val_dataloader = None
 
     limit_train_batches = 2
-    plugins = [ApexMixedPrecisionPlugin(amp_level="O2")] if kwargs.get("amp_backend") == "apex" else []
+    plugins = []
+    if kwargs.get("amp_backend") == "apex":
+        with pytest.deprecated_call(match="apex AMP implementation has been deprecated"):
+            apex_plugin = ApexMixedPrecisionPlugin(amp_level="O2")
+        plugins.append(apex_plugin)
 
     trainer = Trainer(
         default_root_dir=tmpdir,

--- a/tests/tests_pytorch/trainer/optimization/test_manual_optimization.py
+++ b/tests/tests_pytorch/trainer/optimization/test_manual_optimization.py
@@ -324,7 +324,6 @@ def test_manual_optimization_and_return_tensor(tmpdir):
         limit_test_batches=0,
         limit_val_batches=0,
         precision=16,
-        amp_backend="native",
         strategy="ddp_spawn",
         accelerator="gpu",
         devices=2,

--- a/tests/tests_pytorch/tuner/test_scale_batch_size.py
+++ b/tests/tests_pytorch/tuner/test_scale_batch_size.py
@@ -23,7 +23,6 @@ from torch.utils.data import DataLoader
 from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks.batch_size_finder import BatchSizeFinder
 from pytorch_lightning.demos.boring_classes import BoringDataModule, BoringModel, RandomDataset
-from pytorch_lightning.utilities import AMPType
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from tests_pytorch.helpers.runif import RunIf
 
@@ -256,7 +255,6 @@ def test_auto_scale_batch_size_with_amp(tmpdir):
     )
     trainer.tune(model)
     after_batch_size = model.batch_size
-    assert trainer.amp_backend == AMPType.NATIVE
     assert trainer.scaler is not None
     assert after_batch_size != before_batch_size
 

--- a/tests/tests_pytorch/utilities/test_imports.py
+++ b/tests/tests_pytorch/utilities/test_imports.py
@@ -23,8 +23,9 @@ import pytest
 from lightning_utilities.core.imports import compare_version, module_available, RequirementCache
 from torch.distributed import is_available
 
+from pytorch_lightning.plugins.precision.apex_amp import _APEX_AVAILABLE
 from pytorch_lightning.strategies.bagua import _BAGUA_AVAILABLE
-from pytorch_lightning.utilities import _APEX_AVAILABLE, _HOROVOD_AVAILABLE, _OMEGACONF_AVAILABLE, _POPTORCH_AVAILABLE
+from pytorch_lightning.utilities import _HOROVOD_AVAILABLE, _OMEGACONF_AVAILABLE, _POPTORCH_AVAILABLE
 from tests_pytorch.helpers.runif import RunIf
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes #14416

**PyTorch Lightning package changes**:
- Removes apex from the docs and the deprecated pieces below
- Updates tests to avoid the deprecation messages, or catch them
- Deprecates `NativeMixedPrecisionPlugin` in favor of `MixedPrecisionPlugin`
- Deprecates the `LightningModule.optimizer_step(..., using_native_amp=bool)` argument
- Deprecates `Trainer(amp_backend)`
- Deprecates `Trainer.amp_backend`
- Deprecates `Trainer(amp_level)`. This was already deprecated but the previous deprecation has been replaced with the one in this PR for consistency.
- Deprecates the `ApexMixedPrecisionPlugin`. The deprecation message triggered by Apex internally is replaced by ours.
- Deprecates the `AMPType` enum and updates the codebase to avoid it. The `_DeprecatedEnumMeta` class is re-introduced to do this.
- Deprecates `DeepSpeedPrecisionPlugin(amp_type, amp_level)` arguments.

**Lite package changes**:
- Renames the `NativeMixedPrecision` class to `MixedPrecision`
- Removes `DeepSpeedPrecision(amp_type, amp_level)` arguments and their support
- Remvoes the `AMPType` enum and its uses.

### Follow-up items (out of scope for this PR):
- Remove native_ from the appropriate filenames
- Remove "Native" from the FSDP class names

### Does your PR introduce any breaking changes? If yes, please list them.

None intended

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

cc @tchaton @carmocca @justusschock @awaelchli