### PR TITLE
fix(cloud): detect and ignore venv

### DIFF
--- a/src/lightning_app/runners/cloud.py
+++ b/src/lightning_app/runners/cloud.py
@@ -236,12 +236,7 @@ class CloudRuntime(Runtime):
                 f.write("venv/\n")
                 if (root / "bin" / "activate").is_file() or (root / "pyvenv.cfg").is_file():
                     # the user is developing inside venv
-                    f.write(
-                        "bin/\n"
-                        "include/\n"
-                        "lib/\n"
-                        "pyvenv.cfg\n"
-                    )
+                    f.write("bin/\n" "include/\n" "lib/\n" "pyvenv.cfg\n")
 
         repo = LocalSourceCodeDir(path=root, ignore_functions=ignore_functions)
         self._check_uploaded_folder(root, repo)

--- a/src/lightning_app/runners/cloud.py
+++ b/src/lightning_app/runners/cloud.py
@@ -236,7 +236,7 @@ class CloudRuntime(Runtime):
                 f.write("venv/\n")
                 if (root / "bin" / "activate").is_file() or (root / "pyvenv.cfg").is_file():
                     # the user is developing inside venv
-                    f.write("bin/\n" "include/\n" "lib/\n" "pyvenv.cfg\n")
+                    f.write("bin/\ninclude/\nlib/\npyvenv.cfg\n")
 
         repo = LocalSourceCodeDir(path=root, ignore_functions=ignore_functions)
         self._check_uploaded_folder(root, repo)
@@ -565,7 +565,8 @@ class CloudRuntime(Runtime):
                 f"The total size is {round(app_folder_size_in_mb, 2)} MB. {len(files)} files were uploaded.\n"
                 + largest_paths_msg
                 + "Perhaps you should try running the app in an empty directory.\n"
-                "You can ignore some files or folders by adding them to `.lightningignore`."
+                + "You can ignore some files or folders by adding them to `.lightningignore`.\n"
+                + " You can also set the `self.lightningingore` attribute in a Flow or Work."
             )
 
             logger.warn(warning_msg)

--- a/src/lightning_app/runners/cloud.py
+++ b/src/lightning_app/runners/cloud.py
@@ -230,6 +230,19 @@ class CloudRuntime(Runtime):
         else:
             ignore_functions = None
 
+        # Create a default dotignore if it doesn't exist
+        if not (root / DOT_IGNORE_FILENAME).is_file():
+            with open(root / DOT_IGNORE_FILENAME, "w") as f:
+                f.write("venv/\n")
+                if (root / "bin" / "activate").is_file() or (root / "pyvenv.cfg").is_file():
+                    # the user is developing inside venv
+                    f.write(
+                        "bin/\n"
+                        "include/\n"
+                        "lib/\n"
+                        "pyvenv.cfg\n"
+                    )
+
         repo = LocalSourceCodeDir(path=root, ignore_functions=ignore_functions)
         self._check_uploaded_folder(root, repo)
         requirements_file = root / "requirements.txt"
@@ -556,15 +569,9 @@ class CloudRuntime(Runtime):
                 f"Your application folder '{root.absolute()}' is more than {CLOUD_UPLOAD_WARNING} MB. "
                 f"The total size is {round(app_folder_size_in_mb, 2)} MB. {len(files)} files were uploaded.\n"
                 + largest_paths_msg
-                + "Perhaps you should try running the app in an empty directory."
+                + "Perhaps you should try running the app in an empty directory.\n"
+                "You can ignore some files or folders by adding them to `.lightningignore`."
             )
-            if not (root / DOT_IGNORE_FILENAME).is_file():
-                warning_msg += (
-                    "\nIn order to ignore some files or folder, create a `.lightningignore` file and add the paths to"
-                    " ignore. You can also set the `lightningingore` attribute in a Flow or Work."
-                )
-            else:
-                warning_msg += "\nYou can ignore some files or folders by adding them to `.lightningignore`."
 
             logger.warn(warning_msg)
 

--- a/tests/tests_app/runners/test_cloud.py
+++ b/tests/tests_app/runners/test_cloud.py
@@ -1335,6 +1335,7 @@ def test_check_uploaded_folder(monkeypatch, tmpdir, caplog):
     assert "3 files were uploaded" in caplog.text
     assert "files:\n6.0 MB: c.jpg\n5.0 MB: b.txt\n4.0 MB: a.png\nPerhaps" in caplog.text  # tests the order
     assert "adding them to `.lightningignore`." in caplog.text
+    assert "lightningingore` attribute in a Flow or Work" in caplog.text
 
 
 @mock.patch("lightning_app.core.queues.QueuingSystem", MagicMock())
@@ -1597,6 +1598,8 @@ def test_default_lightningignore(monkeypatch, caplog, tmpdir):
     # write some files
     write_file_of_size(path / "a.txt", 5 * 1000 * 1000)
     write_file_of_size(path / "venv" / "foo.txt", 4 * 1000 * 1000)
+
+    assert not (path / ".lightningignore").exists()
 
     with mock.patch(
         "lightning_app.runners.cloud._parse_lightningignore", wraps=_parse_lightningignore

--- a/tests/tests_app/runners/test_cloud.py
+++ b/tests/tests_app/runners/test_cloud.py
@@ -1334,8 +1334,7 @@ def test_check_uploaded_folder(monkeypatch, tmpdir, caplog):
     assert "The total size is 15.0 MB" in caplog.text
     assert "3 files were uploaded" in caplog.text
     assert "files:\n6.0 MB: c.jpg\n5.0 MB: b.txt\n4.0 MB: a.png\nPerhaps" in caplog.text  # tests the order
-    assert "create a `.lightningignore` file" in caplog.text
-    assert "lightningingore` attribute in a Flow or Work" in caplog.text
+    assert "adding them to `.lightningignore`." in caplog.text
 
 
 @mock.patch("lightning_app.core.queues.QueuingSystem", MagicMock())

--- a/tests/tests_app/runners/test_cloud.py
+++ b/tests/tests_app/runners/test_cloud.py
@@ -1608,7 +1608,7 @@ def test_default_lightningignore(monkeypatch, caplog, tmpdir):
         cloud_runtime.dispatch()
 
     parse_mock.assert_called_once_with(())
-    assert copy_mock.mock_calls[0].kwargs["ignore_functions"][0].args[1] == {"lightning_logs", "foo"}
+    assert copy_mock.mock_calls[0].kwargs["ignore_functions"][0].args[1] == set()
 
     assert (path / ".lightningignore").exists()
 


### PR DESCRIPTION
## What does this PR do?

This PR speeds up `lightning run app app.py --cloud` by ignoring venv when uploading the app to the cloud.

This PR makes `lightning run app app.py --cloud` create a `.lightningignore` file if one doesn't exist:
```
venv/
```

If the app detects that it's running inside of the `virtual env` dir it will create the following `.lightningignore`:
```
venv/
bin/
include/
lib/
pyvenv.cfg
```

### Does your PR introduce any breaking changes? If yes, please list them.

No.

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @borda