### PR TITLE
Load app before setting LIGHTNING_DISPATCHED

### DIFF
--- a/src/lightning_app/runners/runtime.py
+++ b/src/lightning_app/runners/runtime.py
@@ -55,9 +55,6 @@ def dispatch(
     from lightning_app.runners.runtime_type import RuntimeType
     from lightning_app.utilities.component import _set_flow_context
 
-    # Used to indicate Lightning has been dispatched
-    os.environ["LIGHTNING_DISPATCHED"] = "1"
-
     _set_flow_context()
 
     runtime_type = RuntimeType(runtime_type)
@@ -80,6 +77,8 @@ def dispatch(
         secrets=secrets,
         run_app_comment_commands=run_app_comment_commands,
     )
+    # Used to indicate Lightning has been dispatched
+    os.environ["LIGHTNING_DISPATCHED"] = "1"
     # a cloud dispatcher will return the result while local
     # dispatchers will be running the app in the main process
     return runtime.dispatch(open_ui=open_ui, name=name, no_cache=no_cache, cluster_id=cluster_id)


### PR DESCRIPTION
## What does this PR do?

Fixes:

```python
Traceback (most recent call last):
  File "app.py", line 89, in <module>
    app = L.LightningApp(TrainerWithTensorboard(Finetune, L.CloudCompute("gpu-fast", disk_size=50)))
  File "/home/carmocca/git/Finetune-miniLM/finetune_minilm/trainerwithtensorboard.py", line 13, in __init__
    self.trainer_work = work_cls(cloud_compute=cloud_compute, tb_drive=tb_drive)
  File "app.py", line 47, in __init__
    self.lightningignore = ("*.ckpt",)
  File "/home/carmocca/git/lightning/src/lightning/app/core/work.py", line 370, in __setattr__
    property_object.fset(self, value)
  File "/home/carmocca/git/lightning/src/lightning/app/core/work.py", line 271, in lightningignore
    raise RuntimeError(
RuntimeError: Your app has been already dispatched, so modifying the `.lightningignore` does not have an effect
```

### Does your PR introduce any breaking changes? If yes, please list them.

None?