### PR TITLE
Avoid deprecated Lite import

### DIFF
--- a/src/lightning/__init__.py
+++ b/src/lightning/__init__.py
@@ -37,7 +37,7 @@ from lightning.app.perf import pdb  # noqa: E402
 from lightning.app.utilities.packaging.build_config import BuildConfig  # noqa: E402
 from lightning.app.utilities.packaging.cloud_compute import CloudCompute  # noqa: E402
 from lightning.lite.lite import LightningLite  # noqa: E402
-from lightning.lite.utilities.seed.seed_everything import seed_everything  # noqa: E402
+from lightning.lite.utilities.seed import seed_everything  # noqa: E402
 from lightning.pytorch.callbacks import Callback  # noqa: E402
 from lightning.pytorch.core import LightningDataModule, LightningModule  # noqa: E402
 from lightning.pytorch.trainer import Trainer  # noqa: E402

--- a/src/lightning/__init__.py
+++ b/src/lightning/__init__.py
@@ -37,10 +37,10 @@ from lightning.app.perf import pdb  # noqa: E402
 from lightning.app.utilities.packaging.build_config import BuildConfig  # noqa: E402
 from lightning.app.utilities.packaging.cloud_compute import CloudCompute  # noqa: E402
 from lightning.lite.lite import LightningLite  # noqa: E402
+from lightning.lite.utilities.seed.seed_everything import seed_everything  # noqa: E402
 from lightning.pytorch.callbacks import Callback  # noqa: E402
 from lightning.pytorch.core import LightningDataModule, LightningModule  # noqa: E402
 from lightning.pytorch.trainer import Trainer  # noqa: E402
-from lightning.pytorch.utilities.seed import seed_everything  # noqa: E402
 
 import lightning.app  # isort: skip # noqa: E402
 


### PR DESCRIPTION
## What does this PR do?

Avoids:

```python
/home/zeus/.local/lib/python3.8/site-packages/lightning/pytorch/utilities/seed.py:48: LightningDeprecationWarning: `lightning.pytorch.utilities.seed.seed_everything` has been deprecated in v1.8.0 and will be removed in v1.10.0. Please use `lightning.lite.utilities.seed.seed_everything` instead.
```

### Does your PR introduce any breaking changes? If yes, please list them.

None