### PR TITLE
Revert "Load app before setting LIGHTNING_DISPATCHED"

### DIFF
--- a/src/lightning_app/runners/runtime.py
+++ b/src/lightning_app/runners/runtime.py
@@ -55,6 +55,9 @@ def dispatch(
     from lightning_app.runners.runtime_type import RuntimeType
     from lightning_app.utilities.component import _set_flow_context
 
+    # Used to indicate Lightning has been dispatched
+    os.environ["LIGHTNING_DISPATCHED"] = "1"
+
     _set_flow_context()
 
     runtime_type = RuntimeType(runtime_type)
@@ -77,8 +80,6 @@ def dispatch(
         secrets=secrets,
         run_app_comment_commands=run_app_comment_commands,
     )
-    # Used to indicate Lightning has been dispatched
-    os.environ["LIGHTNING_DISPATCHED"] = "1"
     # a cloud dispatcher will return the result while local
     # dispatchers will be running the app in the main process
     return runtime.dispatch(open_ui=open_ui, name=name, no_cache=no_cache, cluster_id=cluster_id)


### PR DESCRIPTION
## What does this PR do?
Reverts commit 8d3339a0e99ed91871e0c4f7214aca1146e95a89  (#16057) for #16065.

This is a quick workaround to unblock people using master.

<details><summary>repro</summary>

Running any app on the cloud from cli fails due to the following error:
```console
$ gh repo clone Lightning-AI/lightning
$ cd lightning
$ pip install -e .
$ lightning run app examples/app_v0/app.py --cloud
...
Traceback (most recent call last):
  File "/home/aki/.pyenv/versions/3.9.15/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/home/aki/.pyenv/versions/3.9.15/lib/python3.9/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/aki/work/github.com/Lightning-AI/lightning/src/lightning/app/frontend/web.py", line 87, in _start_server
    uvicorn.run(app=fastapi_service, host=host, port=port, log_config=log_config, root_path=root_path)
  File "/home/aki/work/github.com/Lightning-AI/lightning/venv/lib/python3.9/site-packages/uvicorn/main.py", line 569, in run
    server.run()
  File "/home/aki/work/github.com/Lightning-AI/lightning/venv/lib/python3.9/site-packages/uvicorn/server.py", line 60, in run
    return asyncio.run(self.serve(sockets=sockets))
  File "/home/aki/.pyenv/versions/3.9.15/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "uvloop/loop.pyx", line 1517, in uvloop.loop.Loop.run_until_complete
  File "/home/aki/work/github.com/Lightning-AI/lightning/venv/lib/python3.9/site-packages/uvicorn/server.py", line 77, in serve
    await self.startup(sockets=sockets)
  File "/home/aki/work/github.com/Lightning-AI/lightning/venv/lib/python3.9/site-packages/uvicorn/server.py", line 151, in startup
    server = await loop.create_server(
  File "uvloop/loop.pyx", line 1743, in create_server
  File "uvloop/loop.pyx", line 905, in uvloop.loop.Loop._getaddrinfo
  File "/home/aki/.pyenv/versions/3.9.15/lib/python3.9/encodings/__init__.py", line 98, in search_function
    mod = __import__('encodings.' + modname, fromlist=_import_tail,
TypeError: _mock_import() got an unexpected keyword argument 'fromlist'
```

</details>

### Does your PR introduce any breaking changes? If yes, please list them.
None

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [n/a] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @borda @tchaton