### PR TITLE
Remove the deprecated `Trainer.reset_train_val_dataloaders`

### DIFF
--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -119,6 +119,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed the deprecated `pytorch_lightning.loggers.base` module in favor of `pytorch_lightning.loggers.logger` ([#16120](https://github.com/PyTorchLightning/pytorch-lightning/pull/16120))
 
 
+- Removed the deprecated `Trainer.reset_train_val_dataloaders()` in favor of `Trainer.reset_{train,val}_dataloader` ([#12184](https://github.com/Lightning-AI/lightning/pull/12184))
+
+
 ### Fixed
 
 - Enhanced `reduce_boolean_decision` to accommodate `any`-analogous semantics expected by the `EarlyStopping` callback ([#15253](https://github.com/Lightning-AI/lightning/pull/15253))

--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -119,7 +119,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed the deprecated `pytorch_lightning.loggers.base` module in favor of `pytorch_lightning.loggers.logger` ([#16120](https://github.com/PyTorchLightning/pytorch-lightning/pull/16120))
 
 
-- Removed the deprecated `Trainer.reset_train_val_dataloaders()` in favor of `Trainer.reset_{train,val}_dataloader` ([#12184](https://github.com/Lightning-AI/lightning/pull/12184))
+- Removed the deprecated `Trainer.reset_train_val_dataloaders()` in favor of `Trainer.reset_{train,val}_dataloader` ([#16131](https://github.com/Lightning-AI/lightning/pull/16131))
 
 
 ### Fixed

--- a/src/pytorch_lightning/_graveyard/trainer.py
+++ b/src/pytorch_lightning/_graveyard/trainer.py
@@ -221,7 +221,7 @@ def _convert_to_lightning_optimizers(_: Trainer) -> None:
 def _reset_train_val_dataloaders(_: Trainer, *__: Any, **___: Any) -> None:
     # TODO: Remove in v2.0.0
     raise NotImplementedError(
-        "`Trainer.reset_train_val_dataloaders` was deprecated in v1.6 and is no longer supported as of v1.8."
+        "`Trainer.reset_train_val_dataloaders` was deprecated in v1.7 and is no longer supported as of v1.9."
     )
 
 

--- a/src/pytorch_lightning/_graveyard/trainer.py
+++ b/src/pytorch_lightning/_graveyard/trainer.py
@@ -218,6 +218,13 @@ def _convert_to_lightning_optimizers(_: Trainer) -> None:
     )
 
 
+def _reset_train_val_dataloaders(_: Trainer, *__: Any, **___: Any) -> None:
+    # TODO: Remove in v2.0.0
+    raise NotImplementedError(
+        "`Trainer.reset_train_val_dataloaders` was deprecated in v1.6 and is no longer supported as of v1.8."
+    )
+
+
 _patch_sys_modules()
 
 # Properties/Attributes
@@ -244,3 +251,4 @@ Trainer.prepare_dataloader = _prepare_dataloader
 Trainer.request_dataloader = _request_dataloader
 Trainer.init_optimizers = _init_optimizers
 Trainer.convert_to_lightning_optimizers = _convert_to_lightning_optimizers
+Trainer.reset_train_val_dataloaders = _reset_train_val_dataloaders

--- a/src/pytorch_lightning/trainer/trainer.py
+++ b/src/pytorch_lightning/trainer/trainer.py
@@ -1660,28 +1660,6 @@ class Trainer:
                 RunningStage.PREDICTING, model=pl_module
             )
 
-    def reset_train_val_dataloaders(self, model: Optional["pl.LightningModule"] = None) -> None:
-        """Resets train and val dataloaders if none are attached to the trainer.
-
-        The val dataloader must be initialized before training loop starts, as the training loop
-        inspects the val dataloader to determine whether to run the evaluation loop.
-
-        Args:
-            model: The ``LightningModule`` if called outside of the trainer scope.
-
-        .. deprecated:: v1.7
-            This method is deprecated in v1.7 and will be removed in v1.9.
-            Please use ``Trainer.reset_{train,val}_dataloader`` instead.
-        """
-        rank_zero_deprecation(
-            "`Trainer.reset_train_val_dataloaders` has been deprecated in v1.7 and will be removed in v1.9."
-            " Use `Trainer.reset_{train,val}_dataloader` instead"
-        )
-        if self.train_dataloader is None:
-            self.reset_train_dataloader(model=model)
-        if self.val_dataloaders is None:
-            self.reset_val_dataloader(model=model)
-
     """
     Accelerator properties
     """

--- a/tests/tests_pytorch/deprecated_api/test_remove_1-9.py
+++ b/tests/tests_pytorch/deprecated_api/test_remove_1-9.py
@@ -16,7 +16,6 @@ from unittest import mock
 
 import pytest
 
-from pytorch_lightning import Trainer
 from pytorch_lightning.cli import LightningCLI
 from pytorch_lightning.core.module import LightningModule
 
@@ -63,9 +62,3 @@ def test_old_callback_path():
         match="pytorch_lightning.callbacks.base.Callback has been deprecated in v1.7 and will be removed in v1.9."
     ):
         Callback()
-
-
-def test_deprecated_dataloader_reset():
-    trainer = Trainer()
-    with pytest.deprecated_call(match="reset_train_val_dataloaders` has been deprecated in v1.7"):
-        trainer.reset_train_val_dataloaders()

--- a/tests/tests_pytorch/graveyard/test_trainer.py
+++ b/tests/tests_pytorch/graveyard/test_trainer.py
@@ -126,3 +126,12 @@ def test_v2_0_0_trainer_optimizers_mixin():
         match="`Trainer.convert_to_lightning_optimizers` was deprecated in v1.6 and is no longer supported as of v1.8.",
     ):
         trainer.convert_to_lightning_optimizers()
+
+
+def test_v2_0_0_trainer_reset_method():
+    trainer = Trainer()
+    with pytest.raises(
+        NotImplementedError,
+        match="`Trainer.reset_train_val_dataloaders` was deprecated in v1.7 and is no longer supported as of v1.9.",
+    ):
+        trainer.reset_train_val_dataloaders()


### PR DESCRIPTION
## What does this PR do?

See title

### Does your PR introduce any breaking changes? If yes, please list them.

Removes deprecated code


cc @justusschock @awaelchli @borda