### PR TITLE
Remove support for `LightningCLI(seed_everything_default=None)`

### DIFF
--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -122,6 +122,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed the deprecated `Trainer.reset_train_val_dataloaders()` in favor of `Trainer.reset_{train,val}_dataloader` ([#16131](https://github.com/Lightning-AI/lightning/pull/16131))
 
 
+- Removed support for `LightningCLI(seed_everything_default=None)` ([#16131](https://github.com/Lightning-AI/lightning/pull/16131))
+
+
 ### Fixed
 
 - Enhanced `reduce_boolean_decision` to accommodate `any`-analogous semantics expected by the `EarlyStopping` callback ([#15253](https://github.com/Lightning-AI/lightning/pull/15253))

--- a/src/pytorch_lightning/cli.py
+++ b/src/pytorch_lightning/cli.py
@@ -358,13 +358,6 @@ class LightningCLI:
             self._run_subcommand(self.subcommand)
 
     def _handle_deprecated_params(self, kwargs: dict) -> None:
-        if self.seed_everything_default is None:
-            rank_zero_deprecation(
-                "Setting `LightningCLI.seed_everything_default` to `None` is deprecated in v1.7 "
-                "and will be removed in v1.9. Set it to `False` instead."
-            )
-            self.seed_everything_default = False
-
         for name in kwargs.keys() & ["save_config_filename", "save_config_overwrite", "save_config_multifile"]:
             value = kwargs.pop(name)
             key = name.replace("save_config_", "").replace("filename", "config_filename")

--- a/tests/tests_pytorch/deprecated_api/test_remove_1-9.py
+++ b/tests/tests_pytorch/deprecated_api/test_remove_1-9.py
@@ -12,12 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest import mock
-
 import pytest
-
-from pytorch_lightning.cli import LightningCLI
-from pytorch_lightning.core.module import LightningModule
 
 
 def test_old_lightningmodule_path():
@@ -45,14 +40,6 @@ def test_old_loop_path():
 
     with pytest.deprecated_call(match="pytorch_lightning.loops.base.Loop has been deprecated in v1.7"):
         MyLoop()
-
-
-def test_lightningCLI_seed_everything_default_to_None_deprecation_warning():
-    with mock.patch("sys.argv", ["any.py"]), pytest.deprecated_call(
-        match="Setting `LightningCLI.seed_everything_default` to `None` is deprecated in v1.7 "
-        "and will be removed in v1.9. Set it to `False` instead."
-    ):
-        LightningCLI(LightningModule, run=False, seed_everything_default=None)
 
 
 def test_old_callback_path():


### PR DESCRIPTION
## What does this PR do?

See title

### Does your PR introduce any breaking changes? If yes, please list them.

Removes deprecated code


cc @justusschock @awaelchli @borda