### PR TITLE
Avoid using the deprecated `LooseVersion`

### DIFF
--- a/src/lightning_app/storage/path.py
+++ b/src/lightning_app/storage/path.py
@@ -2,8 +2,7 @@ import hashlib
 import os
 import pathlib
 import shutil
-from distutils.version import LooseVersion
-from platform import python_version
+import sys
 from time import sleep
 from typing import Any, List, Optional, Sequence, TYPE_CHECKING, Union
 
@@ -54,7 +53,7 @@ class Path(PathlibPath):
             parts[0] = parts[0][len("lit://") :]
             args = (_storage_root_dir(), *parts)
 
-        if LooseVersion(python_version()) < "3.10":
+        if (sys.version_info.major, sys.version_info.minor) < (3, 10):
             __unused.setdefault("init", True)
             new_path = super()._from_parts(args, **__unused)
         else:

--- a/src/pytorch_lightning/trainer/connectors/signal_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/signal_connector.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Dict, List, Set, Union
 import pytorch_lightning as pl
 from lightning_lite.plugins.environments import SLURMEnvironment
 from lightning_lite.utilities.imports import _IS_WINDOWS
-from pytorch_lightning.utilities.imports import _fault_tolerant_training
+from pytorch_lightning.utilities.imports import _fault_tolerant_training, _PYTHON_GREATER_EQUAL_3_8_0
 from pytorch_lightning.utilities.rank_zero import rank_zero_info
 
 # copied from signal.pyi
@@ -135,7 +135,7 @@ class SignalConnector:
         Behaves identically to :func:`signals.valid_signals` in Python 3.8+ and implements the equivalent behavior for
         older Python versions.
         """
-        if sys.version_info >= (3, 8):
+        if _PYTHON_GREATER_EQUAL_3_8_0:
             return signal.valid_signals()
         elif _IS_WINDOWS:
             # supported signals on Windows: https://docs.python.org/3/library/signal.html#signal.signal

--- a/src/pytorch_lightning/utilities/migration/utils.py
+++ b/src/pytorch_lightning/utilities/migration/utils.py
@@ -14,11 +14,11 @@
 import logging
 import os
 import sys
-from distutils.version import LooseVersion
 from types import ModuleType, TracebackType
 from typing import Any, Dict, List, Optional, Tuple, Type
 
 from lightning_utilities.core.rank_zero import rank_zero_warn
+from packaging.version import Version
 
 import pytorch_lightning as pl
 from lightning_lite.utilities.imports import _IS_WINDOWS
@@ -38,7 +38,7 @@ def migrate_checkpoint(checkpoint: _CHECKPOINT) -> Tuple[_CHECKPOINT, Dict[str, 
         checkpoints and objects that do not support being deep-copied.
     """
     ckpt_version = _get_version(checkpoint)
-    if LooseVersion(ckpt_version) > LooseVersion(pl.__version__):
+    if Version(ckpt_version) > Version(pl.__version__):
         rank_zero_warn(
             f"The loaded checkpoint was produced with Lightning v{ckpt_version}, which is newer than your current"
             f" Lightning version: v{pl.__version__}",
@@ -141,4 +141,4 @@ def _set_legacy_version(checkpoint: _CHECKPOINT, version: str) -> None:
 
 def _should_upgrade(checkpoint: _CHECKPOINT, target: str) -> bool:
     """Returns whether a checkpoint qualifies for an upgrade when the version is lower than the given target."""
-    return LooseVersion(_get_version(checkpoint)) < LooseVersion(target)
+    return Version(_get_version(checkpoint)) < Version(target)

--- a/tests/tests_pytorch/utilities/migration/test_migration.py
+++ b/tests/tests_pytorch/utilities/migration/test_migration.py
@@ -146,6 +146,6 @@ def test_migrate_model_checkpoint_save_on_train_epoch_end_default_collision():
         "epoch": 1,
     }
     _set_version(old_checkpoint, "1.8.9")  # pretend a checkpoint prior to 1.9.0
-    with pytest.warns(PossibleUserWarning, match="callback states in this ckkjheckpoint.* colliding with each other"):
+    with pytest.warns(PossibleUserWarning, match="callback states in this checkpoint.* colliding with each other"):
         updated_checkpoint, _ = migrate_checkpoint(old_checkpoint.copy())
     assert updated_checkpoint["callbacks"] == old_checkpoint["callbacks"]  # no migration was performed

--- a/tests/tests_pytorch/utilities/migration/test_migration.py
+++ b/tests/tests_pytorch/utilities/migration/test_migration.py
@@ -146,6 +146,6 @@ def test_migrate_model_checkpoint_save_on_train_epoch_end_default_collision():
         "epoch": 1,
     }
     _set_version(old_checkpoint, "1.8.9")  # pretend a checkpoint prior to 1.9.0
-    with pytest.warns(PossibleUserWarning, match="callback states in this checkpoint.* colliding with each other"):
+    with pytest.warns(PossibleUserWarning, match="callback states in this ckkjheckpoint.* colliding with each other"):
         updated_checkpoint, _ = migrate_checkpoint(old_checkpoint.copy())
     assert updated_checkpoint["callbacks"] == old_checkpoint["callbacks"]  # no migration was performed


### PR DESCRIPTION
## What does this PR do?

Avoids raising deprecation warnings for `distutils.version.LooseVersion`

### Does your PR introduce any breaking changes? If yes, please list them.

None

cc @borda