### PR TITLE
Remove CUDA_LAUNCH_BLOCKING from Lite tests

### DIFF
--- a/.azure/gpu-tests-lite.yml
+++ b/.azure/gpu-tests-lite.yml
@@ -96,7 +96,6 @@ jobs:
     - bash: python -m coverage run --source lightning_lite -m pytest --ignore benchmarks -v --junitxml=$(Build.StagingDirectory)/test-results.xml --durations=50
       env:
         PL_RUN_CUDA_TESTS: "1"
-        CUDA_LAUNCH_BLOCKING: "1"
       workingDirectory: tests/tests_lite
       displayName: 'Testing: Lite standard'
       timeoutInMinutes: "10"


### PR DESCRIPTION
## What does this PR do?

This variable is not necessary and slows our tests.

It was mistakenly added in https://github.com/Lightning-AI/lightning/pull/15942. CUDA tests failed there because the GPU CI nodes are being used at the moment for training.

### Does your PR introduce any breaking changes? If yes, please list them.

None

cc @carmocca @akihironitta @borda