### PR TITLE
Remove the redundant precision attribute from LightningModule

### DIFF
--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -155,6 +155,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
+- Removed the `LightningModule.precision` attribute ([#16203](https://github.com/Lightning-AI/lightning/pull/16203))
+
+
 - Removed deprecated `pytorch_lightning.utilities.memory.get_gpu_memory_map` in favor of `pytorch_lightning.accelerators.cuda.get_nvidia_gpu_stats` ([#15617](https://github.com/Lightning-AI/lightning/pull/15617))
 
 

--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -49,6 +49,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   * Removed the `FitLoop.split_idx` property
   * Removed the `LoggerConnector.on_train_split_start` method
 
+- Removed the `LightningModule.precision` attribute ([#16203](https://github.com/Lightning-AI/lightning/pull/16203))
+
 
 ## [unreleased] - 202Y-MM-DD
 
@@ -154,9 +156,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
 ### Removed
-
-- Removed the `LightningModule.precision` attribute ([#16203](https://github.com/Lightning-AI/lightning/pull/16203))
-
 
 - Removed deprecated `pytorch_lightning.utilities.memory.get_gpu_memory_map` in favor of `pytorch_lightning.accelerators.cuda.get_nvidia_gpu_stats` ([#15617](https://github.com/Lightning-AI/lightning/pull/15617))
 

--- a/src/pytorch_lightning/core/module.py
+++ b/src/pytorch_lightning/core/module.py
@@ -108,9 +108,6 @@ class LightningModule(
         # pointer to the trainer object
         self._trainer: Optional["pl.Trainer"] = None
 
-        # the precision used
-        self.precision: Union[int, str] = 32
-
         # optionally can be set by user
         self._example_input_array: Optional[Union[Tensor, Tuple, Dict]] = None
         self._current_fx_name: Optional[str] = None

--- a/src/pytorch_lightning/trainer/connectors/data_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/data_connector.py
@@ -144,13 +144,8 @@ class DataConnector:
         elif self.trainer.state.fn == TrainerFn.PREDICTING:
             _check_dataloader_none(predict_dataloaders, self._predict_dataloader_source, self.trainer.state.fn)
 
-        # set local properties on the model
-        self._copy_trainer_model_properties(model)
-
-    def _copy_trainer_model_properties(self, model: "pl.LightningModule") -> None:
+        # Attach the trainer to the LightningModule
         model.trainer = proxy(self.trainer)
-        # for backward compatibility
-        model.precision = int(self.trainer.precision) if self.trainer.precision != "bf16" else "bf16"
 
     def attach_dataloaders(
         self,

--- a/src/pytorch_lightning/utilities/model_summary/model_summary.py
+++ b/src/pytorch_lightning/utilities/model_summary/model_summary.py
@@ -189,7 +189,7 @@ class ModelSummary:
         self._layer_summary = self.summarize()
         # 1 byte -> 8 bits
         # TODO: how do we compute precision_megabytes in case of mixed precision?
-        precision = self._model.trainer.precision if isinstance(self._model.trainer.precision, int) else 32
+        precision = self._model.trainer.precision if self._model._trainer is not None and isinstance(self._model.trainer.precision, int) else 32
         self._precision_megabytes = (precision / 8.0) * 1e-6
 
     @property

--- a/src/pytorch_lightning/utilities/model_summary/model_summary.py
+++ b/src/pytorch_lightning/utilities/model_summary/model_summary.py
@@ -189,7 +189,7 @@ class ModelSummary:
         self._layer_summary = self.summarize()
         # 1 byte -> 8 bits
         # TODO: how do we compute precision_megabytes in case of mixed precision?
-        precision = self._model.precision if isinstance(self._model.precision, int) else 32
+        precision = self._model.trainer.precision if isinstance(self._model.trainer.precision, int) else 32
         self._precision_megabytes = (precision / 8.0) * 1e-6
 
     @property

--- a/src/pytorch_lightning/utilities/model_summary/model_summary.py
+++ b/src/pytorch_lightning/utilities/model_summary/model_summary.py
@@ -189,11 +189,8 @@ class ModelSummary:
         self._layer_summary = self.summarize()
         # 1 byte -> 8 bits
         # TODO: how do we compute precision_megabytes in case of mixed precision?
-        precision = (
-            self._model.trainer.precision
-            if self._model._trainer is not None and isinstance(self._model.trainer.precision, int)
-            else 32
-        )
+        precision_to_bits = {"64": 64, "32": 32, "16": 16, "bf16": 16}
+        precision = precision_to_bits.get(self._model.trainer.precision, 32) if self._model._trainer else 32
         self._precision_megabytes = (precision / 8.0) * 1e-6
 
     @property

--- a/src/pytorch_lightning/utilities/model_summary/model_summary.py
+++ b/src/pytorch_lightning/utilities/model_summary/model_summary.py
@@ -189,7 +189,11 @@ class ModelSummary:
         self._layer_summary = self.summarize()
         # 1 byte -> 8 bits
         # TODO: how do we compute precision_megabytes in case of mixed precision?
-        precision = self._model.trainer.precision if self._model._trainer is not None and isinstance(self._model.trainer.precision, int) else 32
+        precision = (
+            self._model.trainer.precision
+            if self._model._trainer is not None and isinstance(self._model.trainer.precision, int)
+            else 32
+        )
         self._precision_megabytes = (precision / 8.0) * 1e-6
 
     @property

--- a/tests/tests_pytorch/accelerators/test_ipu.py
+++ b/tests/tests_pytorch/accelerators/test_ipu.py
@@ -189,7 +189,7 @@ def test_optimization(tmpdir):
 def test_half_precision(tmpdir):
     class TestCallback(Callback):
         def setup(self, trainer: Trainer, pl_module: LightningModule, stage: str) -> None:
-            assert trainer.strategy.model.precision == 16
+            assert trainer.precision == "16"
             raise SystemExit
 
     model = IPUModel()

--- a/tests/tests_pytorch/plugins/precision/hpu/test_hpu.py
+++ b/tests/tests_pytorch/plugins/precision/hpu/test_hpu.py
@@ -42,7 +42,7 @@ def test_precision_plugin(hmp_params):
 def test_mixed_precision(tmpdir, hmp_params: dict):
     class TestCallback(Callback):
         def setup(self, trainer: Trainer, pl_module: LightningModule, stage: str) -> None:
-            assert trainer.strategy.model.precision == "bf16"
+            assert trainer.precision == "bf16"
             raise SystemExit
 
     model = BoringModel()
@@ -65,7 +65,7 @@ def test_mixed_precision(tmpdir, hmp_params: dict):
 def test_pure_half_precision(tmpdir, hmp_params: dict):
     class TestCallback(Callback):
         def on_train_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
-            assert trainer.strategy.model.precision == "16"
+            assert trainer.precision == "16"
             for param in trainer.strategy.model.parameters():
                 assert param.dtype == torch.float16
             raise SystemExit

--- a/tests/tests_pytorch/strategies/test_ddp_fully_sharded_native.py
+++ b/tests/tests_pytorch/strategies/test_ddp_fully_sharded_native.py
@@ -64,7 +64,7 @@ class TestFSDPModel(BoringModel):
     def _assert_layer_fsdp_instance(self) -> None:
         assert isinstance(self.layer, FullyShardedDataParallel)
         assert isinstance(self.trainer.strategy.precision_plugin, FullyShardedNativeNativeMixedPrecisionPlugin)
-        precision = torch.float16 if self.precision == 16 else torch.bfloat16
+        precision = torch.float16 if self.trainer.precision == "16" else torch.bfloat16
         assert self.layer.mixed_precision.param_dtype == precision
         assert self.layer.mixed_precision.reduce_dtype == precision
         assert self.layer.mixed_precision.buffer_dtype == precision
@@ -100,7 +100,7 @@ class TestFSDPModelAutoWrapped(BoringModel):
         assert isinstance(self.layer, torch.nn.Sequential)
         assert isinstance(self.trainer.strategy.precision_plugin, FullyShardedNativeNativeMixedPrecisionPlugin)
 
-        precision = torch.float16 if self.precision == 16 else torch.bfloat16
+        precision = torch.float16 if self.trainer.precision == "16" else torch.bfloat16
         for layer_num in [0, 2]:
             assert isinstance(self.layer[layer_num], FullyShardedDataParallel)
             assert self.layer[layer_num].mixed_precision.param_dtype == precision


### PR DESCRIPTION
## What does this PR do?

Today, the LightningModule has a precision attribute that is being set during use with the Trainer. However, it is not reliable to use it in your code, because it only makes sense when a trainer is attached. If no trainer is attached, then the value is simply "outdated" and incorrect. Example: The LightningModule is being used without a Trainer, or within a Lite training loop.

### Does your PR introduce any breaking changes? If yes, please list them.

Yes, but there is no point in keeping this unreliable attribute. We also want to change the precision representation to string, see #14857 

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃


cc @borda