### PR TITLE
Remove deadlock detection / process reconciliation logic

### DIFF
--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -41,6 +41,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Removed the deprecated `pytorch_lightning.profiler` module ([#16359](https://github.com/Lightning-AI/lightning/pull/16359))
 
+- Removed deadlock detection / process reconciliation (`PL_RECONCILE_PROCESS=1`) ([#16204](https://github.com/Lightning-AI/lightning/pull/16204))
+
+
 - Removed the deprecated `LightningCLI` arguments ([#16380](https://github.com/Lightning-AI/lightning/pull/16380))
   * save_config_filename
   * save_config_overwrite

--- a/src/pytorch_lightning/strategies/bagua.py
+++ b/src/pytorch_lightning/strategies/bagua.py
@@ -178,10 +178,6 @@ class BaguaStrategy(DDPStrategy):
         os.environ["LOCAL_RANK"] = str(self.local_rank)
 
     def setup(self, trainer: "pl.Trainer") -> None:
-        self._rank_0_will_call_children_scripts = self.broadcast(self._rank_0_will_call_children_scripts)
-        if self._should_run_deadlock_detection():
-            self._share_information_to_prevent_deadlock()
-
         assert self.accelerator is not None
         self.accelerator.setup(trainer)
 

--- a/src/pytorch_lightning/strategies/ddp.py
+++ b/src/pytorch_lightning/strategies/ddp.py
@@ -12,13 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-import os
-import shutil
-import signal
-import tempfile
-import time
 from datetime import timedelta
-from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import torch
@@ -52,8 +46,7 @@ from pytorch_lightning.strategies.parallel import ParallelStrategy
 from pytorch_lightning.strategies.strategy import TBroadcast
 from pytorch_lightning.trainer.states import TrainerFn
 from pytorch_lightning.utilities.distributed import register_ddp_comm_hook
-from pytorch_lightning.utilities.exceptions import DeadlockDetectedException
-from pytorch_lightning.utilities.rank_zero import rank_zero_info, rank_zero_only, rank_zero_warn
+from pytorch_lightning.utilities.rank_zero import rank_zero_info, rank_zero_only
 from pytorch_lightning.utilities.types import PredictStep, STEP_OUTPUT, TestStep, ValidationStep
 
 if _FAIRSCALE_AVAILABLE:
@@ -101,9 +94,6 @@ class DDPStrategy(ParallelStrategy):
         self._ddp_comm_wrapper = ddp_comm_wrapper
         self._model_averaging_period = model_averaging_period
         self._model_averager: Optional[ModelAverager] = None
-        self._pids: List[int] = []
-        self._sync_dir: Optional[str] = None
-        self._rank_0_will_call_children_scripts: bool = False
         self._process_group_backend: Optional[str] = process_group_backend
         self._timeout: Optional[timedelta] = timeout
 
@@ -145,18 +135,12 @@ class DDPStrategy(ParallelStrategy):
         assert self.cluster_environment is not None
         if not self.cluster_environment.creates_processes_externally:
             self._launcher = _SubprocessScriptLauncher(self.cluster_environment, self.num_processes, self.num_nodes)
-            self._rank_0_will_call_children_scripts = True
 
     def setup_environment(self) -> None:
         self.setup_distributed()
         super().setup_environment()
 
     def setup(self, trainer: "pl.Trainer") -> None:
-        # share ddp pids to all processes
-        self._rank_0_will_call_children_scripts = bool(self.broadcast(self._rank_0_will_call_children_scripts))
-        if self._should_run_deadlock_detection():
-            self._share_information_to_prevent_deadlock()
-
         assert self.accelerator is not None
         self.accelerator.setup(trainer)
 
@@ -390,73 +374,6 @@ class DDPStrategy(ParallelStrategy):
             cls,
             description=f"{cls.__class__.__name__}",
         )
-
-    def _should_run_deadlock_detection(self) -> bool:
-        """Determines whether the plugin will perform process reconciliation in case of errors.
-
-        If the environment variable `PL_RECONCILE_PROCESS` is set, run detection regardless of the cluster environment.
-        By default this is disabled. Otherwise, if the cluster environment creates the processes, allow the scheduler /
-        parent process to perform the process termination, external to Lightning.
-        """
-        return os.getenv("PL_RECONCILE_PROCESS", "0") == "1" or self._rank_0_will_call_children_scripts
-
-    def _share_information_to_prevent_deadlock(self) -> None:
-        self._share_pids()
-
-        # there should be a unique sync_dir per nodes.
-        if self.local_rank == 0:
-            # create a temporary directory used to synchronize processes on deadlock.
-            self._sync_dir = tempfile.mkdtemp()
-
-        sync_dirs = []
-        global_node_rank_zero = 0
-        for _ in range(self.num_nodes):
-            sync_dirs.append(self.broadcast(self._sync_dir, global_node_rank_zero))
-            global_node_rank_zero += self.world_size // self.num_nodes
-
-        self._sync_dir = sync_dirs[self.node_rank]
-
-    def _share_pids(self) -> None:
-        """Make all DDP processes aware of all processes pids."""
-        self.barrier()
-        pids = self.all_gather(torch.tensor(os.getpid(), device=self.root_device))
-        pids = pids.cpu().numpy().tolist()
-        self._pids = pids if isinstance(pids, list) else [pids]
-
-    def reconciliate_processes(self, trace: str) -> None:
-        if self.world_size < 2:
-            return
-
-        if not self._should_run_deadlock_detection():
-            return
-
-        sync_dir = self._sync_dir
-
-        if not sync_dir:
-            rank_zero_warn("Error handling mechanism for deadlock detection is uninitialized. Skipping check.")
-            return
-
-        # The cluster may be configured to periodically purge the `/tmp`
-        # directory, in which case `sync_dir` may not exist anymore at this
-        # point. Idempotently create it to ensure its existence.
-        Path(sync_dir).mkdir(parents=True, exist_ok=True)
-
-        # save a file locally.
-        torch.save(True, os.path.join(sync_dir, f"{self.global_rank}.pl"))
-
-        # sleep for a short time
-        time.sleep(3)
-
-        # return if all processes wrote a file in the `sync_dir`.
-        # todo (tchaton) Add support for non-shared file-system which will fail.
-        if len(os.listdir(sync_dir)) == (self.world_size // self.num_nodes):
-            return
-
-        for pid in self._pids:
-            if pid != os.getpid():
-                os.kill(pid, signal.SIGKILL)
-        shutil.rmtree(sync_dir)
-        raise DeadlockDetectedException(f"DeadLock detected from rank: {self.global_rank} \n {trace}")
 
     def teardown(self) -> None:
         log.detail(f"{self.__class__.__name__}: tearing down strategy")

--- a/src/pytorch_lightning/strategies/parallel.py
+++ b/src/pytorch_lightning/strategies/parallel.py
@@ -82,9 +82,6 @@ class ParallelStrategy(Strategy, ABC):
             rank=self.global_rank,
         )
 
-    def reconciliate_processes(self, trace: str) -> None:
-        """Function to re-conciliate processes on failure."""
-
     def all_gather(self, tensor: Tensor, group: Optional[Any] = None, sync_grads: bool = False) -> Tensor:
         """Perform a all_gather on all processes."""
         return _all_gather_ddp_if_available(tensor, group=group, sync_grads=sync_grads)

--- a/src/pytorch_lightning/strategies/sharded.py
+++ b/src/pytorch_lightning/strategies/sharded.py
@@ -60,11 +60,6 @@ class DDPShardedStrategy(DDPStrategy):
         return super().connect(model)
 
     def setup(self, trainer: "pl.Trainer") -> None:
-        # share ddp pids to all processes
-        self._rank_0_will_call_children_scripts: bool = self.broadcast(self._rank_0_will_call_children_scripts)
-        if self._should_run_deadlock_detection():
-            self._share_information_to_prevent_deadlock()
-
         assert self.accelerator is not None
         self.accelerator.setup(trainer)
 

--- a/src/pytorch_lightning/trainer/call.py
+++ b/src/pytorch_lightning/trainer/call.py
@@ -11,11 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import traceback
 from typing import Any, Callable
 
 import pytorch_lightning as pl
-from lightning_fabric.utilities.distributed import _distributed_available
 from pytorch_lightning.trainer.states import TrainerStatus
 from pytorch_lightning.utilities.exceptions import _TunerExitException
 from pytorch_lightning.utilities.rank_zero import rank_zero_warn
@@ -54,9 +52,6 @@ def _call_and_handle_interrupt(trainer: "pl.Trainer", trainer_fn: Callable, *arg
                 logger.finalize("failed")
     except BaseException as exception:
         trainer.state.status = TrainerStatus.INTERRUPTED
-        if _distributed_available() and trainer.world_size > 1:
-            # try syncing remaining processes, kill otherwise
-            trainer.strategy.reconciliate_processes(traceback.format_exc())
         trainer._call_callback_hooks("on_exception", exception)
         for logger in trainer.loggers:
             logger.finalize("failed")

--- a/src/pytorch_lightning/utilities/exceptions.py
+++ b/src/pytorch_lightning/utilities/exceptions.py
@@ -15,10 +15,6 @@
 from lightning_fabric.utilities.exceptions import MisconfigurationException  # noqa: F401
 
 
-class DeadlockDetectedException(Exception):
-    """Exception used when a deadlock has been detected and processes are being killed."""
-
-
 class ExitGracefullyException(SystemExit):
     """Exception used when a ``signal.SIGTERM`` is sent to the process.
 


### PR DESCRIPTION
## What does this PR do?

Deadlock detection / process reconciliation is a feature of the DDP strategy family. It is not documented, but it is turned on by default when ddp strategies are used, unless PL_RECONCILIATE_PROCESS=0 is set.

- It has reliability issues, such as that it relies on the current working directory be shared among all nodes, which is often the case but not always. 
- TorchElastic already has mechanisms to detect failing processes and can prevent a hang, and can restart the job automatically. TorchElastic has been upstreamed to PyTorch recently.
- The feature is implemented and tested only for the DDP strategy. Others who inherit from DDP are not tested. Other strategies that inherit from ParallelStrategy do not have this implemented.
- With process reconciliation turned off, an exception that occurs only on one rank but not others will lead to a hang, but the error message surfaces regardless. 
- The main benefit of the feature is that processes get terminated immediately and don't hang. This could save you some money for example when running in cloud instances. 

Part of #16410 
Closes #12797

### Does your PR introduce any breaking changes? If yes, please list them.

Yes, for everyone using the ddp strategy, and anyone else that enables `PL_RECONCILIATE_PROCESS=1`, the feature will no longer work. However, errors 

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃


cc @borda @justusschock @awaelchli