### PR TITLE
Skip a failing Bagua test for manual optimization

### DIFF
--- a/tests/tests_pytorch/strategies/test_bagua_strategy.py
+++ b/tests/tests_pytorch/strategies/test_bagua_strategy.py
@@ -45,6 +45,7 @@ def test_bagua_default(tmpdir):
     assert isinstance(trainer.strategy, BaguaStrategy)
 
 
+@pytest.skip("Internal error in Bagua")  # Bagua stopped working with 'AssertionError: Unexpected rsp=<Response [500]'
 @RunIf(min_cuda_gpus=1, bagua=True)
 def test_manual_optimization(tmpdir):
     model = ManualOptimBoringModel()

--- a/tests/tests_pytorch/strategies/test_bagua_strategy.py
+++ b/tests/tests_pytorch/strategies/test_bagua_strategy.py
@@ -45,7 +45,7 @@ def test_bagua_default(tmpdir):
     assert isinstance(trainer.strategy, BaguaStrategy)
 
 
-@pytest.skip("Internal error in Bagua")  # Bagua stopped working with 'AssertionError: Unexpected rsp=<Response [500]'
+@pytest.mark.skip("Internal error in Bagua")  # Bagua stopped working: 'AssertionError: Unexpected rsp=<Response [500]'
 @RunIf(min_cuda_gpus=1, bagua=True)
 def test_manual_optimization(tmpdir):
     model = ManualOptimBoringModel()

--- a/tests/tests_pytorch/strategies/test_bagua_strategy.py
+++ b/tests/tests_pytorch/strategies/test_bagua_strategy.py
@@ -45,7 +45,7 @@ def test_bagua_default(tmpdir):
     assert isinstance(trainer.strategy, BaguaStrategy)
 
 
-@pytest.mark.skip("Internal error in Bagua")  # Bagua stopped working: 'AssertionError: Unexpected rsp=<Response [500]'
+@pytest.mark.xfail(raises=AssertionError, reason="Internal error in Bagua")  # Unexpected rsp=<Response [500]'
 @RunIf(min_cuda_gpus=1, bagua=True)
 def test_manual_optimization(tmpdir):
     model = ManualOptimBoringModel()


### PR DESCRIPTION
## What does this PR do?

Unblocks master.
[The test started failing over night with](https://dev.azure.com/Lightning-AI/lightning/_build/results?buildId=125524&view=logs&j=3f274fac-2e11-54ca-487e-194c91f3ae9f&t=8da0b6c4-35de-5c68-3c64-0e4ce0eb560c&l=379):

```
strategies/test_bagua_strategy.py:64: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../src/pytorch_lightning/trainer/trainer.py:602: in fit
    call._call_and_handle_interrupt(
../../src/pytorch_lightning/trainer/call.py:36: in _call_and_handle_interrupt
    return trainer.strategy.launcher.launch(trainer_fn, *args, trainer=trainer, **kwargs)
../../src/pytorch_lightning/strategies/launchers/subprocess_script.py:88: in launch
    return function(*args, **kwargs)
../../src/pytorch_lightning/trainer/trainer.py:644: in _fit_impl
    self._run(model, ckpt_path=self.ckpt_path)
../../src/pytorch_lightning/trainer/trainer.py:1078: in _run
    self.strategy.setup(self)
../../src/pytorch_lightning/strategies/bagua.py:209: in setup
    self._configure_bagua_model(trainer)
../../src/pytorch_lightning/strategies/bagua.py:221: in _configure_bagua_model
    self.model = self._setup_model(model)
../../src/pytorch_lightning/strategies/bagua.py:234: in _setup_model
    return BaguaDistributedDataParallel(
/usr/local/lib/python3.9/dist-packages/bagua/torch_api/data_parallel/distributed.py:148: in __init__
    self.inner = BaguaDistributedDataParallel(
/usr/local/lib/python3.9/dist-packages/bagua/torch_api/data_parallel/bagua_distributed.py:153: in __init__
    self._bagua_init_algorithm()
/usr/local/lib/python3.9/dist-packages/bagua/torch_api/data_parallel/bagua_distributed.py:400: in _bagua_init_algorithm
    self._bagua_autotune_register_tensors()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <bagua.torch_api.data_parallel.bagua_distributed.BaguaDistributedDataParallel object at 0x7f7551791490>

     def _bagua_autotune_register_tensors(self):
        """
        Register tensors on autotune server, and return first bucketing suggestions
        """
        autotune_tensor_list = [
            TensorDeclaration(
                {
                    "name": tensor.bagua_tensor_name,
                    "num_elements": tensor.numel(),
                    "dtype": to_bagua_datatype(tensor.dtype),
                }
            )
            for tensor in self._bagua_tensors
        ]
    
        rsp = self._bagua_autotune_client.register_tensors(
            model_name=self.bagua_module_name,
            tensor_list=autotune_tensor_list,
        )
>       assert rsp.status_code == 200, "Unexpected rsp={}".format(rsp)
E       AssertionError: Unexpected rsp=<Response [500]>

/usr/local/lib/python3.9/dist-packages/bagua/torch_api/data_parallel/bagua_distributed.py:372: AssertionError
```

Bagua version installed: `bagua-cuda116==0.9.1`

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @borda @awaelchli @wangraying