### PR TITLE
Inform user about `set_to_none` when using DeepSpeed in Lite

### DIFF
--- a/src/lightning_fabric/wrappers.py
+++ b/src/lightning_fabric/wrappers.py
@@ -27,7 +27,7 @@ from lightning_fabric.strategies import Strategy, DeepSpeedStrategy
 from lightning_fabric.utilities import move_data_to_device
 from lightning_fabric.utilities.device_dtype_mixin import _DeviceDtypeModuleMixin
 from lightning_fabric.utilities.types import Optimizable
-from lightning_fabric.utilities.warnings import PossibleUserWarning
+from lightning_fabric.utilities import rank_zero_info
 
 
 T_destination = TypeVar("T_destination", bound=Dict[str, Any])


### PR DESCRIPTION
## What does this PR do?

The deepspeed optimizer does not accept the argument `optimizer.zero_grad(set_to_none=...)`. This would create an error, but in Fabric, we can automatically drop it and inform the user.

Should we do this? Perhaps it should be left to the user to resolve any deepspeed errors?

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
