### PR TITLE
Fixes app CLI tests by checking for the dynamically assigned port

### DIFF
--- a/tests/tests_app/cli/test_run_app.py
+++ b/tests/tests_app/cli/test_run_app.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import click
 import pytest
+import lightning_app.core.constants as constants
 from click.testing import CliRunner
 from tests_app import _PROJECT_ROOT
 
@@ -45,7 +46,11 @@ def test_lightning_run_app(lauch_mock: mock.MagicMock, open_ui, caplog, monkeypa
             )
             # capture logs.
             if open_ui:
-                lauch_mock.assert_called_with("http://127.0.0.1:7501/view")
+
+                 # Get the designated port
+                port = constants.APP_SERVER_PORT
+
+                lauch_mock.assert_called_with(f"http://127.0.0.1:{port}/view")
             else:
                 lauch_mock.assert_not_called()
         assert result.exit_code == 0
@@ -99,6 +104,10 @@ def test_lightning_run_app_cloud(mock_dispatch: mock.MagicMock, open_ui, caplog,
             run_app_comment_commands=False,
             enable_basic_auth="",
         )
+
+        # Get the designated port
+        port = constants.APP_SERVER_PORT
+
     # capture logs.
     # TODO(yurij): refactor the test, check if the actual HTTP request is being sent and that the proper admin
     #  page is being opened
@@ -115,7 +124,7 @@ def test_lightning_run_app_cloud(mock_dispatch: mock.MagicMock, open_ui, caplog,
         cluster_id="",
         run_app_comment_commands=False,
         enable_basic_auth="",
-        port=7501,
+        port=port,
     )
 
 
@@ -145,6 +154,10 @@ def test_lightning_run_app_cloud_with_run_app_commands(mock_dispatch: mock.Magic
             run_app_comment_commands=True,
             enable_basic_auth="",
         )
+
+        # Get the designated port
+        port = constants.APP_SERVER_PORT
+
     # capture logs.
     # TODO(yurij): refactor the test, check if the actual HTTP request is being sent and that the proper admin
     #  page is being opened
@@ -161,7 +174,7 @@ def test_lightning_run_app_cloud_with_run_app_commands(mock_dispatch: mock.Magic
         cluster_id="",
         run_app_comment_commands=True,
         enable_basic_auth="",
-        port=7501,
+        port=port,
     )
 
 
@@ -211,6 +224,9 @@ def test_lightning_run_app_enable_basic_auth_passed(mock_dispatch: mock.MagicMoc
             enable_basic_auth="username:password",
         )
 
+        # Get the designated port
+        port = constants.APP_SERVER_PORT
+
     mock_dispatch.assert_called_with(
         Path(os.path.join(_PROJECT_ROOT, "tests/tests_app/core/scripts/app_metadata.py")),
         RuntimeType.CLOUD,
@@ -224,5 +240,5 @@ def test_lightning_run_app_enable_basic_auth_passed(mock_dispatch: mock.MagicMoc
         cluster_id="",
         run_app_comment_commands=False,
         enable_basic_auth="username:password",
-        port=7501,
+        port=port,
     )

--- a/tests/tests_app/cli/test_run_app.py
+++ b/tests/tests_app/cli/test_run_app.py
@@ -5,10 +5,10 @@ from unittest import mock
 
 import click
 import pytest
-import lightning_app.core.constants as constants
 from click.testing import CliRunner
 from tests_app import _PROJECT_ROOT
 
+import lightning_app.core.constants as constants
 from lightning_app import LightningApp
 from lightning_app.cli.lightning_cli import _run_app, run_app
 from lightning_app.runners.runtime_type import RuntimeType
@@ -47,7 +47,7 @@ def test_lightning_run_app(lauch_mock: mock.MagicMock, open_ui, caplog, monkeypa
             # capture logs.
             if open_ui:
 
-                 # Get the designated port
+                # Get the designated port
                 port = constants.APP_SERVER_PORT
 
                 lauch_mock.assert_called_with(f"http://127.0.0.1:{port}/view")


### PR DESCRIPTION
## What does this PR do?
The app CLI tests were flaking sometimes because we were checking for port 7501 while this port can be dynamically assigned (when port 7501 is being used). So, if we run the tests at a moment where 7501 is not free, a different port is chosen and the tests fail because they expect 7501. 

The tests have been updated to retrieve the dynamically assigned port and assert with that port.


<!-- FILL IN or None -->

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @borda