### PR TITLE
Deprecate LightningLite

### DIFF
--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -105,6 +105,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   * Deprecated the `HorovodStrategy` class
 
 
+- Deprecated `pytorch_lightning.lite.LightningLite` in favor of `lightning.fabric.Fabric` ([#16314](https://github.com/Lightning-AI/lightning/pull/16314))
+
+
 ### Removed
 
 - Removed deprecated `pytorch_lightning.utilities.memory.get_gpu_memory_map` in favor of `pytorch_lightning.accelerators.cuda.get_nvidia_gpu_stats` ([#15617](https://github.com/Lightning-AI/lightning/pull/15617))

--- a/src/pytorch_lightning/lite/lite.py
+++ b/src/pytorch_lightning/lite/lite.py
@@ -59,6 +59,11 @@ _PL_PLUGIN_INPUT = Union[_PL_PLUGIN, str]
 class LightningLite(Fabric, ABC):
     """Lite accelerates your PyTorch training or inference code with minimal changes required.
 
+    .. deprecated:: v1.9.0
+        The `pytorch_lightning.lite.LightningLite` class was deprecated in v1.9.0 and will be renamed to
+        `lightning.fabric.Fabric` in v2.0.0. It is no longer part of the pure `pytorch_lightning` package, and now
+        lives in the main `lightning` package.
+
     - Automatic placement of models and data onto the device.
     - Automatic support for mixed and double precision (smaller memory footprint).
     - Seamless switching between hardware (CPU, GPU, TPU) and distributed training strategies
@@ -101,6 +106,12 @@ class LightningLite(Fabric, ABC):
         gpus: Optional[Union[List[int], str, int]] = None,
         tpu_cores: Optional[Union[List[int], str, int]] = None,
     ) -> None:
+
+        rank_zero_deprecation(
+            "The `pytorch_lightning.lite.LightningLite` class was deprecated in v1.9.0 and will be renamed to"
+            " `lightning.fabric.Fabric` in v2.0.0. It is no longer part of the pure `pytorch_lightning` package, and"
+            " now lives in the main `lightning` package."
+        )
 
         if gpus is not None or tpu_cores is not None:
             devices, accelerator = _convert_deprecated_device_flags(

--- a/tests/tests_pytorch/deprecated_api/test_remove_2-0.py
+++ b/tests/tests_pytorch/deprecated_api/test_remove_2-0.py
@@ -20,10 +20,9 @@ import pytorch_lightning
 from pytorch_lightning import Callback, Trainer
 from pytorch_lightning.cli import LightningCLI
 from pytorch_lightning.demos.boring_classes import BoringModel
+from pytorch_lightning.lite import LightningLite
 from tests_pytorch.callbacks.test_callbacks import OldStatefulCallback
 from tests_pytorch.helpers.runif import RunIf
-
-from pytorch_lightning.lite import LightningLite
 
 
 def test_v2_0_0_deprecated_num_processes():

--- a/tests/tests_pytorch/deprecated_api/test_remove_2-0.py
+++ b/tests/tests_pytorch/deprecated_api/test_remove_2-0.py
@@ -23,6 +23,8 @@ from pytorch_lightning.demos.boring_classes import BoringModel
 from tests_pytorch.callbacks.test_callbacks import OldStatefulCallback
 from tests_pytorch.helpers.runif import RunIf
 
+from pytorch_lightning.lite import LightningLite
+
 
 def test_v2_0_0_deprecated_num_processes():
     with pytest.deprecated_call(match=r"is deprecated in v1.7 and will be removed in v2.0."):
@@ -330,3 +332,8 @@ def test_v2_0_0_unsupported_on_init_start_end(callback_class, tmpdir):
 def test_lightningCLI_parser_init_params_deprecation_warning(name, value):
     with mock.patch("sys.argv", ["any.py"]), pytest.deprecated_call(match=f".*{name!r} init parameter is deprecated.*"):
         LightningCLI(BoringModel, run=False, **{name: value})
+
+
+def test_rename_lightning_lite():
+    with pytest.deprecated_call(match="will be renamed to `lightning.fabric.Fabric` in v2.0.0"):
+        LightningLite()

--- a/tests/tests_pytorch/lite/test_lite.py
+++ b/tests/tests_pytorch/lite/test_lite.py
@@ -72,7 +72,9 @@ def test_lite_convert_custom_precision():
     class CustomPrecision(PLPrecisionPlugin):
         pass
 
-    with pytest.deprecated_call(match="will be renamed to `lightning.fabric.Fabric` in v2.0.0"), pytest.raises(TypeError, match=escape("You passed an unsupported plugin as input to Lite(plugins=...)")):
+    with pytest.deprecated_call(match="will be renamed to `lightning.fabric.Fabric` in v2.0.0"), pytest.raises(
+        TypeError, match=escape("You passed an unsupported plugin as input to Lite(plugins=...)")
+    ):
         EmptyLite(plugins=CustomPrecision())
 
 

--- a/tests/tests_pytorch/lite/test_lite.py
+++ b/tests/tests_pytorch/lite/test_lite.py
@@ -31,33 +31,39 @@ def test_lite_convert_pl_plugins(cuda_count_2):
     """
 
     # defaults
-    lite = EmptyLite()
+    with pytest.deprecated_call(match="will be renamed to `lightning.fabric.Fabric` in v2.0.0"):
+        lite = EmptyLite()
     assert isinstance(lite._accelerator, LiteCPUAccelerator)
     assert isinstance(lite._precision, LitePrecision)
     assert isinstance(lite._strategy, LiteSingleDeviceStrategy)
 
     # accelerator and strategy passed separately
-    lite = EmptyLite(accelerator=PLCUDAAccelerator(), strategy=PLDDPStrategy())
+    with pytest.deprecated_call(match="will be renamed to `lightning.fabric.Fabric` in v2.0.0"):
+        lite = EmptyLite(accelerator=PLCUDAAccelerator(), strategy=PLDDPStrategy())
     assert isinstance(lite._accelerator, PLCUDAAccelerator)
     assert isinstance(lite._precision, LitePrecision)
     assert isinstance(lite._strategy, LiteDDPStrategy)
 
     # accelerator passed to strategy
-    lite = EmptyLite(strategy=PLDDPStrategy(accelerator=PLCUDAAccelerator()))
+    with pytest.deprecated_call(match="will be renamed to `lightning.fabric.Fabric` in v2.0.0"):
+        lite = EmptyLite(strategy=PLDDPStrategy(accelerator=PLCUDAAccelerator()))
     assert isinstance(lite._accelerator, PLCUDAAccelerator)
     assert isinstance(lite._strategy, LiteDDPStrategy)
 
     # kwargs passed to strategy
-    lite = EmptyLite(strategy=PLDDPStrategy(find_unused_parameters=False))
+    with pytest.deprecated_call(match="will be renamed to `lightning.fabric.Fabric` in v2.0.0"):
+        lite = EmptyLite(strategy=PLDDPStrategy(find_unused_parameters=False))
     assert isinstance(lite._strategy, LiteDDPStrategy)
     assert lite._strategy._ddp_kwargs == dict(find_unused_parameters=False)
 
     # plugins = instance
-    lite = EmptyLite(plugins=PLDoublePrecisionPlugin())
+    with pytest.deprecated_call(match="will be renamed to `lightning.fabric.Fabric` in v2.0.0"):
+        lite = EmptyLite(plugins=PLDoublePrecisionPlugin())
     assert isinstance(lite._precision, LiteDoublePrecision)
 
     # plugins = list
-    lite = EmptyLite(plugins=[PLDoublePrecisionPlugin(), SLURMEnvironment()], devices=2)
+    with pytest.deprecated_call(match="will be renamed to `lightning.fabric.Fabric` in v2.0.0"):
+        lite = EmptyLite(plugins=[PLDoublePrecisionPlugin(), SLURMEnvironment()], devices=2)
     assert isinstance(lite._precision, LiteDoublePrecision)
     assert isinstance(lite._strategy.cluster_environment, SLURMEnvironment)
 
@@ -66,13 +72,14 @@ def test_lite_convert_custom_precision():
     class CustomPrecision(PLPrecisionPlugin):
         pass
 
-    with pytest.raises(TypeError, match=escape("You passed an unsupported plugin as input to Lite(plugins=...)")):
+    with pytest.deprecated_call(match="will be renamed to `lightning.fabric.Fabric` in v2.0.0"), pytest.raises(TypeError, match=escape("You passed an unsupported plugin as input to Lite(plugins=...)")):
         EmptyLite(plugins=CustomPrecision())
 
 
 @RunIf(deepspeed=True)
 def test_lite_convert_pl_strategies_deepspeed():
-    lite = EmptyLite(strategy=PLDeepSpeedStrategy(stage=2, initial_scale_power=32, loss_scale_window=500))
+    with pytest.deprecated_call(match="will be renamed to `lightning.fabric.Fabric` in v2.0.0"):
+        lite = EmptyLite(strategy=PLDeepSpeedStrategy(stage=2, initial_scale_power=32, loss_scale_window=500))
     assert isinstance(lite._strategy, LiteDeepSpeedStrategy)
     assert lite._strategy.config["zero_optimization"]["stage"] == 2
     assert lite._strategy.initial_scale_power == 32


### PR DESCRIPTION
## What does this PR do?

Deprecates the LightningLite class in favor of the new Fabric class.

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃


cc @borda @tchaton @carmocca @justusschock @awaelchli