### PR TITLE
Remove support for `PL_INTER_BATCH_PARALLELISM`

### DIFF
--- a/src/pytorch_lightning/loops/fit_loop.py
+++ b/src/pytorch_lightning/loops/fit_loop.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-import os
 from typing import Any, Optional, Type
 
 import pytorch_lightning as pl
-from pytorch_lightning.accelerators import CUDAAccelerator
 from pytorch_lightning.loops import Loop
 from pytorch_lightning.loops.epoch import TrainingEpochLoop
 from pytorch_lightning.loops.epoch.training_epoch_loop import _OUTPUTS_TYPE as _EPOCH_OUTPUTS_TYPE
@@ -25,12 +23,7 @@ from pytorch_lightning.trainer.connectors.logger_connector.result import _Result
 from pytorch_lightning.trainer.progress import Progress
 from pytorch_lightning.trainer.supporters import CombinedLoader, TensorRunningAccum
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
-from pytorch_lightning.utilities.fetching import (
-    AbstractDataFetcher,
-    DataFetcher,
-    DataLoaderIterDataFetcher,
-    InterBatchParallelDataFetcher,
-)
+from pytorch_lightning.utilities.fetching import AbstractDataFetcher, DataFetcher, DataLoaderIterDataFetcher
 from pytorch_lightning.utilities.model_helpers import is_overridden
 from pytorch_lightning.utilities.rank_zero import rank_zero_debug, rank_zero_info, rank_zero_warn
 from pytorch_lightning.utilities.signature_utils import is_param_in_hook_signature
@@ -120,8 +113,7 @@ class FitLoop(Loop[None]):
     @property
     def prefetch_batches(self) -> int:
         is_unsized = self.trainer.num_training_batches == float("inf")
-        inter_batch_parallelism = os.getenv("PL_INTER_BATCH_PARALLELISM", "0") == "1"
-        return 1 if is_unsized or inter_batch_parallelism else 0
+        return int(is_unsized)
 
     @property
     def _skip_backward(self) -> bool:
@@ -341,8 +333,4 @@ def _select_data_fetcher(trainer: "pl.Trainer") -> Type[AbstractDataFetcher]:
             "this signature is experimental and the behavior is subject to change."
         )
         return DataLoaderIterDataFetcher
-    elif os.getenv("PL_INTER_BATCH_PARALLELISM", "0") == "1":
-        if not isinstance(trainer.accelerator, CUDAAccelerator):
-            raise MisconfigurationException("Inter batch parallelism is available only when using Nvidia GPUs.")
-        return InterBatchParallelDataFetcher
     return DataFetcher

--- a/src/pytorch_lightning/loops/optimization/optimizer_loop.py
+++ b/src/pytorch_lightning/loops/optimization/optimizer_loop.py
@@ -237,8 +237,7 @@ class OptimizerLoop(Loop[_OUTPUTS_TYPE]):
         # ------------------------------
         # gradient update with accumulated gradients
         else:
-            # the `batch_idx` is optional with inter-batch parallelism
-            self._optimizer_step(optimizer, opt_idx, kwargs.get("batch_idx", 0), closure)
+            self._optimizer_step(optimizer, opt_idx, kwargs["batch_idx"], closure)
 
         result = closure.consume_result()
 
@@ -258,7 +257,7 @@ class OptimizerLoop(Loop[_OUTPUTS_TYPE]):
         opt_idx = kwargs.get("optimizer_idx", 0)
         step_fn = self._make_step_fn(kwargs)
         backward_fn = self._make_backward_fn(optimizer, opt_idx)
-        zero_grad_fn = self._make_zero_grad_fn(kwargs.get("batch_idx", 0), opt_idx, optimizer)
+        zero_grad_fn = self._make_zero_grad_fn(kwargs["batch_idx"], opt_idx, optimizer)
         return Closure(step_fn=step_fn, backward_fn=backward_fn, zero_grad_fn=zero_grad_fn)
 
     def _make_step_fn(self, kwargs: OrderedDict) -> Callable[[], ClosureResult]:


### PR DESCRIPTION
## What does this PR do?

See title
We suggest Fabric as an alternative. It's also unclear the usefulness of this feature in the scope of PyTorch's 2.0 compilation

Closes #9415
Closes #15390

### Does your PR introduce any breaking changes? If yes, please list them.

Removes the experimental feature.