### PR TITLE
Revert #16401 and user proper `CSVLogger`

### DIFF
--- a/.github/workflows/ci-tests-pytorch.yml
+++ b/.github/workflows/ci-tests-pytorch.yml
@@ -218,10 +218,3 @@ jobs:
         flags: ${COVERAGE_SCOPE},cpu,pytest-full,python${{ matrix.python-version }},pytorch${{ matrix.pytorch-version }}
         name: CPU-coverage
         fail_ci_if_error: false
-
-# TODO
-#    - name: Testing legacy creation
-#      working-directory: tests/
-#      run: |
-#        export PYTHONPATH=$(dirname $LEGACY_PATH);$PYTHONPATH  # for `import tests_pytorch`
-#        python legacy/simple_classif_training.py

--- a/src/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/src/pytorch_lightning/callbacks/model_checkpoint.py
@@ -582,11 +582,14 @@ class ModelCheckpoint(Checkpoint):
             return self.dirpath
 
         if len(trainer.loggers) > 0:
-            logger_ = trainer.loggers[0]
-            save_dir = getattr(logger_, "save_dir", None) or trainer.default_root_dir
-            version = logger_.version
+            if trainer.loggers[0].save_dir is not None:
+                save_dir = trainer.loggers[0].save_dir
+            else:
+                save_dir = trainer.default_root_dir
+            name = trainer.loggers[0].name
+            version = trainer.loggers[0].version
             version = version if isinstance(version, str) else f"version_{version}"
-            ckpt_path = os.path.join(save_dir, str(logger_.name), version, "checkpoints")
+            ckpt_path = os.path.join(save_dir, str(name), version, "checkpoints")
         else:
             # if no loggers, use default_root_dir
             ckpt_path = os.path.join(trainer.default_root_dir, "checkpoints")

--- a/src/pytorch_lightning/loggers/csv_logs.py
+++ b/src/pytorch_lightning/loggers/csv_logs.py
@@ -39,7 +39,7 @@ class ExperimentWriter(_FabricExperimentWriter):
     r"""
     Experiment writer for CSVLogger.
 
-    Currently supports to log hyperparameters and metrics in YAML and CSV
+    Currently, supports to log hyperparameters and metrics in YAML and CSV
     format, respectively.
 
     Args:

--- a/src/pytorch_lightning/loggers/csv_logs.py
+++ b/src/pytorch_lightning/loggers/csv_logs.py
@@ -39,7 +39,7 @@ class ExperimentWriter(_FabricExperimentWriter):
     r"""
     Experiment writer for CSVLogger.
 
-    Currently, supports to log hyperparameters and metrics in YAML and CSV
+    Currently supports to log hyperparameters and metrics in YAML and CSV
     format, respectively.
 
     Args:

--- a/src/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
@@ -18,12 +18,11 @@ from lightning_utilities.core.rank_zero import WarningCache
 from torch import Tensor
 
 import pytorch_lightning as pl
-from lightning_fabric.loggers import CSVLogger
 from lightning_fabric.loggers.tensorboard import _TENSORBOARD_AVAILABLE, _TENSORBOARDX_AVAILABLE
 from lightning_fabric.plugins.environments import SLURMEnvironment
 from lightning_fabric.utilities import move_data_to_device
 from lightning_fabric.utilities.apply_func import convert_tensors_to_scalars
-from pytorch_lightning.loggers import Logger, TensorBoardLogger
+from pytorch_lightning.loggers import CSVLogger, Logger, TensorBoardLogger
 from pytorch_lightning.trainer.connectors.logger_connector.result import _METRICS, _OUT_DICT, _PBAR_DICT
 
 warning_cache = WarningCache()

--- a/src/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
@@ -71,7 +71,7 @@ class LoggerConnector:
                     " or `tensorboardX` packages are found."
                     " Please `pip install lightning[extra]` or one of them to enable TensorBoard support by default"
                 )
-                logger_ = CSVLogger(root_dir=self.trainer.default_root_dir)  # type: ignore[assignment]
+                logger_ = CSVLogger(save_dir=self.trainer.default_root_dir)  # type: ignore[assignment]
             self.trainer.loggers = [logger_]
         elif isinstance(logger, Iterable):
             self.trainer.loggers = list(logger)

--- a/src/pytorch_lightning/trainer/trainer.py
+++ b/src/pytorch_lightning/trainer/trainer.py
@@ -53,6 +53,7 @@ from pytorch_lightning.callbacks import Callback, Checkpoint, EarlyStopping, Pro
 from pytorch_lightning.callbacks.prediction_writer import BasePredictionWriter
 from pytorch_lightning.core.datamodule import LightningDataModule
 from pytorch_lightning.loggers import Logger
+from pytorch_lightning.loggers.tensorboard import TensorBoardLogger
 from pytorch_lightning.loops import PredictionLoop, TrainingEpochLoop
 from pytorch_lightning.loops.dataloader.evaluation_loop import EvaluationLoop
 from pytorch_lightning.loops.fit_loop import FitLoop
@@ -1806,8 +1807,10 @@ class Trainer:
     @property
     def log_dir(self) -> Optional[str]:
         if len(self.loggers) > 0:
-            logger_ = self.loggers[0]
-            dirpath = getattr(logger_, "log_dir", None) or getattr(logger_, "save_dir", None)
+            if not isinstance(self.loggers[0], TensorBoardLogger):
+                dirpath = self.loggers[0].save_dir
+            else:
+                dirpath = self.loggers[0].log_dir
         else:
             dirpath = self.default_root_dir
 


### PR DESCRIPTION
## What does this PR do?
This reverts commit d46091c.

The true cause was that we were mistakenly importing the CSVLogger from Fabric

### Does your PR introduce any breaking changes? If yes, please list them.

None

cc @borda @tchaton