### PR TITLE
Loop flattening: remove the default `.run()` implementation

### DIFF
--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -75,6 +75,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   * Removed `Loop.replace()` ([#16361](https://github.com/Lightning-AI/lightning/pull/16361))
   * Removed `Loop.connect()` ([#16384](https://github.com/Lightning-AI/lightning/pull/16384))
   * Removed the `trainer.{fit,validate,test,predict}_loop` properties ([#16384](https://github.com/Lightning-AI/lightning/pull/16384))
+  * Removed the default `Loop.run()` implementation ([#16384](https://github.com/Lightning-AI/lightning/pull/16384))
 
 - Removed special support for truncated backpropagation through time (TBPTT) ([#16172](https://github.com/Lightning-AI/lightning/pull/16172))
   * Removed the `LightningModule.truncated_bptt_steps` attribute

--- a/src/pytorch_lightning/loops/dataloader/dataloader_loop.py
+++ b/src/pytorch_lightning/loops/dataloader/dataloader_loop.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from abc import abstractmethod
-from typing import Any, Sequence
+from typing import Sequence
 
 from torch.utils.data import DataLoader
 
@@ -60,7 +60,7 @@ class DataLoaderLoop(Loop):
         else:
             self.dataloader_progress.reset_on_restart()
 
-    def on_advance_start(self, *args: Any, **kwargs: Any) -> None:
+    def on_advance_start(self) -> None:
         self.dataloader_progress.increment_ready()
 
     def on_advance_end(self) -> None:

--- a/src/pytorch_lightning/loops/dataloader/prediction_loop.py
+++ b/src/pytorch_lightning/loops/dataloader/prediction_loop.py
@@ -16,7 +16,7 @@ class PredictionLoop(DataLoaderLoop):
     def __init__(self) -> None:
         super().__init__()
         self.predictions: List[List[Any]] = []
-        self.epoch_batch_indices: List[List[int]] = []
+        self.epoch_batch_indices: List[List[List[int]]] = []  # used by PredictionWriter
         self.epoch_loop = PredictionEpochLoop()
 
         self._results = None  # for `trainer._results` access

--- a/src/pytorch_lightning/loops/dataloader/prediction_loop.py
+++ b/src/pytorch_lightning/loops/dataloader/prediction_loop.py
@@ -68,7 +68,7 @@ class PredictionLoop(DataLoaderLoop):
 
     def run(self) -> Optional[_PREDICT_OUTPUT]:
         if self.skip:
-            return
+            return None
         self.reset()
         self.on_run_start()
         while not self.done:

--- a/src/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
+++ b/src/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
@@ -14,7 +14,7 @@
 
 from collections import OrderedDict
 from functools import lru_cache
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from torch.utils.data import DataLoader
 
@@ -45,7 +45,7 @@ class EvaluationEpochLoop(Loop):
         self.batch_progress = BatchProgress()
 
         self._outputs: EPOCH_OUTPUT = []
-        self._dl_max_batches = 0
+        self._dl_max_batches: Union[int, float] = 0
         self._data_fetcher: Optional[AbstractDataFetcher] = None
         self._dataloader_state_dict: Dict[str, Any] = {}
         self._dl_batch_idx = [0]
@@ -55,7 +55,9 @@ class EvaluationEpochLoop(Loop):
         """Returns ``True`` if the current iteration count reaches the number of dataloader batches."""
         return self.batch_progress.current.completed >= self._dl_max_batches
 
-    def run(self, data_fetcher: AbstractDataFetcher, dl_max_batches: int, kwargs: OrderedDict) -> EPOCH_OUTPUT:
+    def run(
+        self, data_fetcher: AbstractDataFetcher, dl_max_batches: Union[int, float], kwargs: OrderedDict
+    ) -> EPOCH_OUTPUT:
         self.reset()
         self.on_run_start(data_fetcher, dl_max_batches, kwargs)
         while not self.done:
@@ -82,7 +84,9 @@ class EvaluationEpochLoop(Loop):
         if self.done and self.trainer.state.fn != TrainerFn.FITTING:
             self.batch_progress.reset_on_run()
 
-    def on_run_start(self, data_fetcher: AbstractDataFetcher, dl_max_batches: int, kwargs: OrderedDict) -> None:
+    def on_run_start(
+        self, data_fetcher: AbstractDataFetcher, dl_max_batches: Union[int, float], kwargs: OrderedDict
+    ) -> None:
         """Adds the passed arguments to the loop's state if necessary.
 
         Args:

--- a/src/pytorch_lightning/loops/epoch/prediction_epoch_loop.py
+++ b/src/pytorch_lightning/loops/epoch/prediction_epoch_loop.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Any, Dict, Iterator, List, Tuple
+from typing import Any, Dict, Iterator, List, Tuple, Union
 
 import torch
 
@@ -22,7 +22,7 @@ class PredictionEpochLoop(Loop):
         self.current_batch_indices: List[int] = []
         self.batch_progress = Progress()
 
-        self._dl_max_batches = 0
+        self._dl_max_batches: Union[int, float] = 0
         self._num_dataloaders = 0
         self._warning_cache = WarningCache()
         self._seen_batch_indices: List[List[int]] = []
@@ -42,7 +42,7 @@ class PredictionEpochLoop(Loop):
         self,
         dataloader_iter: Iterator,
         dataloader_idx: int,
-        dl_max_batches: int,
+        dl_max_batches: Union[int, float],
         num_dataloaders: int,
     ) -> Tuple[List[Any], List[List[int]]]:
         self.reset()
@@ -65,7 +65,7 @@ class PredictionEpochLoop(Loop):
     def on_run_start(
         self,
         dataloader_idx: int,
-        dl_max_batches: int,
+        dl_max_batches: Union[int, float],
         num_dataloaders: int,
     ) -> None:
         """Prepares the loops internal state.

--- a/src/pytorch_lightning/trainer/trainer.py
+++ b/src/pytorch_lightning/trainer/trainer.py
@@ -43,6 +43,7 @@ from torch.utils.data import DataLoader
 from typing_extensions import Literal
 
 import pytorch_lightning as pl
+from lightning_fabric.utilities.apply_func import convert_tensors_to_scalars
 from lightning_fabric.utilities.cloud_io import get_filesystem
 from lightning_fabric.utilities.data import _auto_add_worker_init_fn
 from lightning_fabric.utilities.types import _PATH
@@ -1113,13 +1114,7 @@ class Trainer:
             eval_loop_results = self._evaluation_loop.run()
 
         # remove the tensors from the eval results
-        for result in eval_loop_results:
-            if isinstance(result, dict):
-                for k, v in result.items():
-                    if isinstance(v, Tensor):
-                        result[k] = v.cpu().item()
-
-        return eval_loop_results
+        return convert_tensors_to_scalars(eval_loop_results)
 
     def _run_predict(self) -> Optional[_PREDICT_OUTPUT]:
         self.reset_predict_dataloader(self.lightning_module)


### PR DESCRIPTION
## What does this PR do?

Each loop now defines it's own `.run()` method. This avoids a strict interface and simplifies 
debugging as you no longer jump around the inheritance tree.

In a follow-up, I will remove the methods from the base class, leaving only shared utilities.

### Does your PR introduce any breaking changes? If yes, please list them.

Removes support for loop customization

cc @justusschock @awaelchli @borda @carmocca