### PR TITLE
Remove the deprecated `Accelerator.setup_environment` method

### DIFF
--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -64,6 +64,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Removed the deprecated code in `pl.utilities.seed` ([#16422](https://github.com/Lightning-AI/lightning/pull/16422))
 
+- Removed the deprecated `Accelerator.setup_environment` method ([#16436](https://github.com/Lightning-AI/lightning/pull/16436))
+
 - Mark the `forward_module` argument as required ([#16386](https://github.com/Lightning-AI/lightning/pull/16386))
   * Removed the deprecated `pl_module` argument from the distributed module wrappers
   * Removed the deprecated `pytorch_lightning.overrides.base.unwrap_lightning_module` function

--- a/src/pytorch_lightning/accelerators/accelerator.py
+++ b/src/pytorch_lightning/accelerators/accelerator.py
@@ -14,12 +14,9 @@
 from abc import ABC
 from typing import Any, Dict
 
-import torch
-
 import pytorch_lightning as pl
 from lightning_fabric.accelerators.accelerator import Accelerator as _Accelerator
 from lightning_fabric.utilities.types import _DEVICE
-from pytorch_lightning.utilities.rank_zero import rank_zero_deprecation
 
 
 class Accelerator(_Accelerator, ABC):
@@ -27,17 +24,6 @@ class Accelerator(_Accelerator, ABC):
 
     An Accelerator is meant to deal with one type of hardware.
     """
-
-    def setup_environment(self, root_device: torch.device) -> None:
-        """
-        .. deprecated:: v1.8.0
-            This hook was deprecated in v1.8.0 and will be removed in v2.0.0. Please use ``setup_device()`` instead.
-        """
-        rank_zero_deprecation(
-            "`Accelerator.setup_environment` has been deprecated in deprecated in v1.8.0 and will be removed in"
-            " v2.0.0. Please use `setup_device()` instead."
-        )
-        self.setup_device(root_device)
 
     def setup(self, trainer: "pl.Trainer") -> None:
         """Setup plugins for the trainer fit and creates optimizers.

--- a/tests/tests_pytorch/deprecated_api/test_remove_2-0.py
+++ b/tests/tests_pytorch/deprecated_api/test_remove_2-0.py
@@ -16,7 +16,6 @@ import pytest
 import torch
 from torch.utils.data import DataLoader
 
-from pytorch_lightning.accelerators.cpu import CPUAccelerator
 from pytorch_lightning.demos.boring_classes import RandomDataset
 from pytorch_lightning.strategies.utils import on_colab_kaggle
 from pytorch_lightning.utilities.cloud_io import atomic_save, get_filesystem, load
@@ -54,8 +53,3 @@ def test_v1_10_deprecated_optimizer_utilities():
 
     with pytest.deprecated_call(match="optimizer.optimizer_to_device` has been deprecated in v1.8.0"):
         optimizer_to_device(torch.optim.Adam(torch.nn.Linear(1, 1).parameters()), "cpu")
-
-
-def test_v1_10_deprecated_accelerator_setup_environment_method():
-    with pytest.deprecated_call(match="`Accelerator.setup_environment` has been deprecated in deprecated in v1.8.0"):
-        CPUAccelerator().setup_environment(torch.device("cpu"))


### PR DESCRIPTION
## What does this PR do?

See title

### Does your PR introduce any breaking changes? If yes, please list them.

Removes deprecated code