### PR TITLE
Update link to new forum

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: ❓ Ask a Question
-    url: https://github.com/Lightning-AI/lightning/discussions/new
+    url: https://lightning.ai/forums
     about: Ask and answer Lightning related questions.
   - name: 💬 Chat with us
     url: https://www.pytorchlightning.ai/community


### PR DESCRIPTION
## What does this PR do?

The "ask a question" button in our issues page can now point to the new forum.

cc @Borda 

