### PR TITLE
Two fixes for handling edge cases in MLflow logging

### DIFF
--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -134,6 +134,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed an issue with `MLFlowLogger` logging the wrong keys with `.log_hyperparams()` ([#16418](https://github.com/Lightning-AI/lightning/pull/16418))
 
+- Fixed logging more than 100 parameters with `MLFlowLogger` and long values are truncated ([#16451](https://github.com/Lightning-AI/lightning/pull/16451))
+
 
 
 ## [1.9.0] - 2023-01-17

--- a/src/pytorch_lightning/loggers/mlflow.py
+++ b/src/pytorch_lightning/loggers/mlflow.py
@@ -238,18 +238,14 @@ class MLFlowLogger(Logger):
     def log_hyperparams(self, params: Union[Dict[str, Any], Namespace]) -> None:
         params = _convert_params(params)
         params = _flatten_dict(params)
-        params_list: List[Param] = []
 
-        for k, v in params.items():
-            # TODO: mlflow 1.28 allows up to 500 characters: https://github.com/mlflow/mlflow/releases/tag/v1.28.0
-            if len(str(v)) > 250:
-                rank_zero_warn(
-                    f"Mlflow only allows parameters with up to 250 characters. Discard {k}={v}", category=RuntimeWarning
-                )
-                continue
-            params_list.append(Param(key=k, value=v))
+        # Truncate parameter values to 250 characters.
+        # TODO: MLflow 1.28 allows up to 500 characters: https://github.com/mlflow/mlflow/releases/tag/v1.28.0
+        params_list = [Param(key=k, value=str(v)[:250]) for k, v in params.items()]
 
-        self.experiment.log_batch(run_id=self.run_id, params=params_list)
+        # Log in chunks of 100 parameters (the maximum allowed by MLflow).
+        for idx in range(0, len(params_list), 100):
+            self.experiment.log_batch(run_id=self.run_id, params=params_list[idx:idx + 100])
 
     @rank_zero_only
     def log_metrics(self, metrics: Mapping[str, float], step: Optional[int] = None) -> None:

--- a/tests/tests_pytorch/loggers/test_mlflow.py
+++ b/tests/tests_pytorch/loggers/test_mlflow.py
@@ -224,30 +224,6 @@ def test_mlflow_logger_with_unexpected_characters(client, _, __, tmpdir):
         logger.log_metrics(metrics)
 
 
-@mock.patch("pytorch_lightning.loggers.mlflow.Param")
-@mock.patch("pytorch_lightning.loggers.mlflow._MLFLOW_AVAILABLE", return_value=True)
-@mock.patch("pytorch_lightning.loggers.mlflow.MlflowClient")
-def test_mlflow_logger_with_long_param_value(client, _, param, tmpdir):
-    """Test that the logger doesn't crash when logging a long parameter value."""
-    logger = MLFlowLogger("test", save_dir=tmpdir)
-    value = "test" * 200
-    key = "test_param"
-    params = {key: value}
-
-    logger.log_hyperparams(params)
-
-
-@mock.patch("pytorch_lightning.loggers.mlflow.Param")
-@mock.patch("pytorch_lightning.loggers.mlflow._MLFLOW_AVAILABLE", return_value=True)
-@mock.patch("pytorch_lightning.loggers.mlflow.MlflowClient")
-def test_mlflow_logger_with_many_params(client, _, param, tmpdir):
-    """Test that the logger doesn't crash when logging more than 100 parameters."""
-    logger = MLFlowLogger("test", save_dir=tmpdir)
-    params = {f"test_param_{idx}": f"test_value_{idx}" for idx in range(200)}
-
-    logger.log_hyperparams(params)
-
-
 @mock.patch("pytorch_lightning.loggers.mlflow.Metric")
 @mock.patch("pytorch_lightning.loggers.mlflow.Param")
 @mock.patch("pytorch_lightning.loggers.mlflow.time")
@@ -279,6 +255,37 @@ def test_mlflow_logger_experiment_calls(client, _, time, param, metric, tmpdir):
     logger._mlflow_client.create_experiment.assert_called_once_with(
         name="test", artifact_location="my_artifact_location"
     )
+
+
+def _check_value_length(value, *args, **kwargs):
+    assert len(value) <= 250
+
+
+@mock.patch("pytorch_lightning.loggers.mlflow.Param", side_effect=_check_value_length)
+@mock.patch("pytorch_lightning.loggers.mlflow._MLFLOW_AVAILABLE", return_value=True)
+@mock.patch("pytorch_lightning.loggers.mlflow.MlflowClient")
+def test_mlflow_logger_with_long_param_value(client, _, param, tmpdir):
+    """Test that long parameter values are truncated to 250 characters."""
+    logger = MLFlowLogger("test", save_dir=tmpdir)
+
+    params = {"test": "test_param" * 50}
+    logger.log_hyperparams(params)
+
+    # assert_called_once_with() won't properly check the parameter value.
+    logger.experiment.log_batch.assert_called_once()
+
+
+@mock.patch("pytorch_lightning.loggers.mlflow.Param")
+@mock.patch("pytorch_lightning.loggers.mlflow._MLFLOW_AVAILABLE", return_value=True)
+@mock.patch("pytorch_lightning.loggers.mlflow.MlflowClient")
+def test_mlflow_logger_with_many_params(client, _, param, tmpdir):
+    """Test that the when logging more than 100 parameters, it will be split into batches of at most 100 parameters."""
+    logger = MLFlowLogger("test", save_dir=tmpdir)
+
+    params = {f"test_{idx}": f"test_param_{idx}" for idx in range(150)}
+    logger.log_hyperparams(params)
+
+    assert logger.experiment.log_batch.call_count == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/tests_pytorch/loggers/test_mlflow.py
+++ b/tests/tests_pytorch/loggers/test_mlflow.py
@@ -279,7 +279,8 @@ def test_mlflow_logger_with_long_param_value(client, _, param, tmpdir):
 @mock.patch("pytorch_lightning.loggers.mlflow._MLFLOW_AVAILABLE", return_value=True)
 @mock.patch("pytorch_lightning.loggers.mlflow.MlflowClient")
 def test_mlflow_logger_with_many_params(client, _, param, tmpdir):
-    """Test that the when logging more than 100 parameters, it will be split into batches of at most 100 parameters."""
+    """Test that the when logging more than 100 parameters, it will be split into batches of at most 100
+    parameters."""
     logger = MLFlowLogger("test", save_dir=tmpdir)
 
     params = {f"test_{idx}": f"test_param_{idx}" for idx in range(150)}

--- a/tests/tests_pytorch/loggers/test_mlflow.py
+++ b/tests/tests_pytorch/loggers/test_mlflow.py
@@ -224,6 +224,7 @@ def test_mlflow_logger_with_unexpected_characters(client, _, __, tmpdir):
         logger.log_metrics(metrics)
 
 
+@mock.patch("pytorch_lightning.loggers.mlflow.Param")
 @mock.patch("pytorch_lightning.loggers.mlflow._MLFLOW_AVAILABLE", return_value=True)
 @mock.patch("pytorch_lightning.loggers.mlflow.MlflowClient")
 def test_mlflow_logger_with_long_param_value(client, _, tmpdir):
@@ -236,6 +237,7 @@ def test_mlflow_logger_with_long_param_value(client, _, tmpdir):
     logger.log_hyperparams(params)
 
 
+@mock.patch("pytorch_lightning.loggers.mlflow.Param")
 @mock.patch("pytorch_lightning.loggers.mlflow._MLFLOW_AVAILABLE", return_value=True)
 @mock.patch("pytorch_lightning.loggers.mlflow.MlflowClient")
 def test_mlflow_logger_with_many_params(client, _, tmpdir):

--- a/tests/tests_pytorch/loggers/test_mlflow.py
+++ b/tests/tests_pytorch/loggers/test_mlflow.py
@@ -227,7 +227,7 @@ def test_mlflow_logger_with_unexpected_characters(client, _, __, tmpdir):
 @mock.patch("pytorch_lightning.loggers.mlflow.Param")
 @mock.patch("pytorch_lightning.loggers.mlflow._MLFLOW_AVAILABLE", return_value=True)
 @mock.patch("pytorch_lightning.loggers.mlflow.MlflowClient")
-def test_mlflow_logger_with_long_param_value(client, _, tmpdir):
+def test_mlflow_logger_with_long_param_value(client, _, param, tmpdir):
     """Test that the logger doesn't crash when logging a long parameter value."""
     logger = MLFlowLogger("test", save_dir=tmpdir)
     value = "test" * 200
@@ -240,7 +240,7 @@ def test_mlflow_logger_with_long_param_value(client, _, tmpdir):
 @mock.patch("pytorch_lightning.loggers.mlflow.Param")
 @mock.patch("pytorch_lightning.loggers.mlflow._MLFLOW_AVAILABLE", return_value=True)
 @mock.patch("pytorch_lightning.loggers.mlflow.MlflowClient")
-def test_mlflow_logger_with_many_params(client, _, tmpdir):
+def test_mlflow_logger_with_many_params(client, _, param, tmpdir):
     """Test that the logger doesn't crash when logging more than 100 parameters."""
     logger = MLFlowLogger("test", save_dir=tmpdir)
     params = {f"test_param_{idx}": f"test_value_{idx}" for idx in range(200)}

--- a/tests/tests_pytorch/loggers/test_mlflow.py
+++ b/tests/tests_pytorch/loggers/test_mlflow.py
@@ -227,14 +227,23 @@ def test_mlflow_logger_with_unexpected_characters(client, _, __, tmpdir):
 @mock.patch("pytorch_lightning.loggers.mlflow._MLFLOW_AVAILABLE", return_value=True)
 @mock.patch("pytorch_lightning.loggers.mlflow.MlflowClient")
 def test_mlflow_logger_with_long_param_value(client, _, tmpdir):
-    """Test that the logger raises warning with special characters not accepted by MLFlow."""
+    """Test that the logger doesn't crash when logging a long parameter value."""
     logger = MLFlowLogger("test", save_dir=tmpdir)
-    value = "test" * 100
+    value = "test" * 200
     key = "test_param"
     params = {key: value}
 
-    with pytest.warns(RuntimeWarning, match=f"Discard {key}={value}"):
-        logger.log_hyperparams(params)
+    logger.log_hyperparams(params)
+
+
+@mock.patch("pytorch_lightning.loggers.mlflow._MLFLOW_AVAILABLE", return_value=True)
+@mock.patch("pytorch_lightning.loggers.mlflow.MlflowClient")
+def test_mlflow_logger_with_many_params(client, _, tmpdir):
+    """Test that the logger doesn't crash when logging more than 100 parameters."""
+    logger = MLFlowLogger("test", save_dir=tmpdir)
+    params = {f"test_param_{idx}": f"test_value_{idx}" for idx in range(200)}
+
+    logger.log_hyperparams(params)
 
 
 @mock.patch("pytorch_lightning.loggers.mlflow.Metric")


### PR DESCRIPTION
## What does this PR do?

* Long parameter values are truncated, instead of not logged at all.
* In case there are more than 100 parameters, they are logged in chunks.

In [another pull request](https://github.com/Lightning-AI/lightning/pull/16418) it was discussed that it's better to truncate the parameter values, rather than not log them at all, if the length exceeds the MLflow limit. I found another problem with the recently introduced change: A batch logging request can contain at most 100 parameters. This PR will log the parameters in chunks of 100 parameters, if there are more than 100.

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
