### PR TITLE
SIGTERM handling is now unrelated to fault tolerance

### DIFF
--- a/examples/pl_fault_tolerant/automatic.py
+++ b/examples/pl_fault_tolerant/automatic.py
@@ -18,16 +18,16 @@ Find the documentation: https://pytorch-lightning.readthedocs.io/en/stable/advan
 
 RUN WITHOUT FAILURE:
 
-    1. Launch `python pl_examples/fault_tolerant/automatic.py`.
+    1. Launch `python examples/pl_fault_tolerant/automatic.py`.
         - You should see `[-1.1343,  0.0186]` in the logs.
 
 RUN WITH SIMULATED FAILURE:
 
-    1. Launch `python pl_examples/fault_tolerant/automatic.py --emulate_kill_signal`.
+    1. Launch `python examples/pl_fault_tolerant/automatic.py --emulate_kill_signal`.
         - You should see `kill -SIGTERM {PID}` in the logs.
     2. Run this command within another terminal.
-        - You should see `Received signal 15. Saving a fault-tolerant checkpoint and terminating.` in the logs.
-    3. Launch `python pl_examples/fault_tolerant/automatic.py --emulate_kill_signal` again.
+        - You should see `Received signal 15.` in the logs.
+    3. Launch `python examples/pl_fault_tolerant/automatic.py --emulate_kill_signal` again.
         - You should see `Restored all states from the checkpoint file at ./.pl_auto_save.ckpt`
         - And you should see `[-1.1343,  0.0186]` in the logs.
 
@@ -79,11 +79,9 @@ class SimpleMLP(LightningModule):
 
     def training_step(self, batch, batch_idx):
         if self.global_step == self.fail_on_step:
-            log.info(
-                f"READY TO BE KILLED WITH SIGTERM SIGNAL. " f"Run `kill -SIGTERM {os.getpid()}` in another terminal."
-            )
+            log.info(f"READY TO BE KILLED WITH SIGTERM SIGNAL. Run `kill -SIGTERM {os.getpid()}` in another terminal.")
             # this line is used to wait for you to send the signal to exit gracefully.
-            while not self.trainer._terminate_gracefully:
+            while not self.trainer.received_sigterm:
                 sleep(0.1)
         batch = batch["data"] if isinstance(batch, dict) else batch
         self.seen_batches.append(torch.stack(batch) if isinstance(batch, list) else batch)
@@ -97,10 +95,10 @@ class SimpleMLP(LightningModule):
         return DataLoader(RandomGetItemDataset(3, 1))
 
 
-def _run_training(default_root_dir=".", max_epochs=3, fail_on_step: int = -1, ckpt_path=None):
+def _run_training(default_root_dir=".", max_epochs=3, fail_on_step: int = -1):
     model = SimpleMLP(fail_on_step=fail_on_step)
     trainer = Trainer(default_root_dir=default_root_dir, max_epochs=max_epochs)
-    trainer.fit(model, ckpt_path=ckpt_path)
+    trainer.fit(model, ckpt_path="last")
     return model.seen_batches, model.parameters()
 
 

--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -9,8 +9,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added migration logic to warn about checkpoints with apex AMP state ([#16161](https://github.com/Lightning-AI/lightning/pull/16161))
+
+- Added the `Trainer.ckpt_path = ...` setter to statefully set the checkpoint path to load. This can act as a replacement for the removed `Trainer(resume_from_checkpoint=...)` flag ([#16187](https://github.com/Lightning-AI/lightning/pull/16187))
+
 - Added an argument `include_cuda` in `pytorch_lightning.utilities.seed.isolate_rng` to disable managing `torch.cuda`'s rng ([#16423](https://github.com/Lightning-AI/lightning/pull/16423))
 
+- Added a `Trainer.received_sigterm` property to check whether a SIGTERM signal was received in any process ([#16501](https://github.com/Lightning-AI/lightning/pull/16501))
 
 ### Changed
 
@@ -25,13 +30,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Deprecated
 
 -
-
-
-### Added
-
-- Added migration logic to warn about checkpoints with apex AMP state ([#16161](https://github.com/Lightning-AI/lightning/pull/16161))
-
-- Added the `Trainer.ckpt_path = ...` setter to statefully set the checkpoint path to load. This can act as a replacement for the removed `Trainer(resume_from_checkpoint=...)` flag ([#16187](https://github.com/Lightning-AI/lightning/pull/16187))
 
 ### Removed
 

--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added an argument `include_cuda` in `pytorch_lightning.utilities.seed.isolate_rng` to disable managing `torch.cuda`'s rng ([#16423](https://github.com/Lightning-AI/lightning/pull/16423))
 
-- Added a `Trainer.received_sigterm` property to check whether a SIGTERM signal was received in any process ([#16501](https://github.com/Lightning-AI/lightning/pull/16501))
+- Added a `Trainer.received_sigterm` property to check whether a SIGTERM signal was received ([#16501](https://github.com/Lightning-AI/lightning/pull/16501))
 
 ### Changed
 

--- a/src/pytorch_lightning/CHANGELOG.md
+++ b/src/pytorch_lightning/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
  * `pytorch_lightning.plugins.precision.native_amp` is now `pytorch_lightning.plugins.precision.amp`
  * `NativeSyncBatchNorm` is now `TorchSyncBatchNorm`
 
+- Renamed the `pl.utilities.exceptions.GracefulExitException` to `SIGTERMException` ([#16501](https://github.com/Lightning-AI/lightning/pull/16501))
+
 ### Deprecated
 
 -

--- a/src/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
+++ b/src/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
@@ -26,7 +26,7 @@ from pytorch_lightning.utilities.auto_restart import (
     _collect_states_on_rank_zero_over_collection,
     _reload_dataloader_state_dict,
 )
-from pytorch_lightning.utilities.exceptions import MisconfigurationException
+from pytorch_lightning.utilities.exceptions import ExitGracefullyException, MisconfigurationException
 from pytorch_lightning.utilities.fetching import AbstractDataFetcher, DataLoaderIterDataFetcher
 from pytorch_lightning.utilities.imports import _fault_tolerant_training
 from pytorch_lightning.utilities.model_helpers import is_overridden
@@ -168,9 +168,8 @@ class _EvaluationEpochLoop(_Loop):
         if self._should_track_batch_outputs_for_epoch_end() and output is not None:
             self._outputs.append(output)
 
-        if not self.batch_progress.is_last_batch:
-            # if fault tolerant is enabled and process has been notified, exit.
-            self.trainer._exit_gracefully_on_signal()
+        if not self.batch_progress.is_last_batch and self.trainer.received_sigterm:
+            raise ExitGracefullyException
 
     def on_run_end(self) -> EPOCH_OUTPUT:
         """Returns the outputs of the whole run."""

--- a/src/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
+++ b/src/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
@@ -26,7 +26,7 @@ from pytorch_lightning.utilities.auto_restart import (
     _collect_states_on_rank_zero_over_collection,
     _reload_dataloader_state_dict,
 )
-from pytorch_lightning.utilities.exceptions import ExitGracefullyException, MisconfigurationException
+from pytorch_lightning.utilities.exceptions import MisconfigurationException, SIGTERMException
 from pytorch_lightning.utilities.fetching import AbstractDataFetcher, DataLoaderIterDataFetcher
 from pytorch_lightning.utilities.imports import _fault_tolerant_training
 from pytorch_lightning.utilities.model_helpers import is_overridden
@@ -169,7 +169,7 @@ class _EvaluationEpochLoop(_Loop):
             self._outputs.append(output)
 
         if not self.batch_progress.is_last_batch and self.trainer.received_sigterm:
-            raise ExitGracefullyException
+            raise SIGTERMException
 
     def on_run_end(self) -> EPOCH_OUTPUT:
         """Returns the outputs of the whole run."""

--- a/src/pytorch_lightning/loops/epoch/training_epoch_loop.py
+++ b/src/pytorch_lightning/loops/epoch/training_epoch_loop.py
@@ -29,7 +29,7 @@ from pytorch_lightning.trainer.connectors.logger_connector.result import _Result
 from pytorch_lightning.trainer.progress import BatchProgress, SchedulerProgress
 from pytorch_lightning.trainer.supporters import CombinedLoader
 from pytorch_lightning.utilities.auto_restart import _collect_states_on_rank_zero_over_collection
-from pytorch_lightning.utilities.exceptions import ExitGracefullyException, MisconfigurationException
+from pytorch_lightning.utilities.exceptions import MisconfigurationException, SIGTERMException
 from pytorch_lightning.utilities.fetching import AbstractDataFetcher, DataLoaderIterDataFetcher
 from pytorch_lightning.utilities.model_helpers import is_overridden
 from pytorch_lightning.utilities.rank_zero import rank_zero_warn, WarningCache
@@ -293,7 +293,7 @@ class _TrainingEpochLoop(loops._Loop):
         # if training finished, defer exit to the parent. this assumes there will be enough time in between
         # which might not be the case depending on what's in the `*_epoch_end` hooks
         if not self._is_training_done and self.trainer.received_sigterm:
-            raise ExitGracefullyException
+            raise SIGTERMException
 
     def on_run_end(self) -> _OUTPUTS_TYPE:
         outputs, self._outputs = self._outputs, []

--- a/src/pytorch_lightning/loops/epoch/training_epoch_loop.py
+++ b/src/pytorch_lightning/loops/epoch/training_epoch_loop.py
@@ -29,7 +29,7 @@ from pytorch_lightning.trainer.connectors.logger_connector.result import _Result
 from pytorch_lightning.trainer.progress import BatchProgress, SchedulerProgress
 from pytorch_lightning.trainer.supporters import CombinedLoader
 from pytorch_lightning.utilities.auto_restart import _collect_states_on_rank_zero_over_collection
-from pytorch_lightning.utilities.exceptions import MisconfigurationException
+from pytorch_lightning.utilities.exceptions import ExitGracefullyException, MisconfigurationException
 from pytorch_lightning.utilities.fetching import AbstractDataFetcher, DataLoaderIterDataFetcher
 from pytorch_lightning.utilities.model_helpers import is_overridden
 from pytorch_lightning.utilities.rank_zero import rank_zero_warn, WarningCache
@@ -292,9 +292,8 @@ class _TrainingEpochLoop(loops._Loop):
 
         # if training finished, defer exit to the parent. this assumes there will be enough time in between
         # which might not be the case depending on what's in the `*_epoch_end` hooks
-        if not self._is_training_done:
-            # if fault tolerant is enabled and process has been notified, exit.
-            self.trainer._exit_gracefully_on_signal()
+        if not self._is_training_done and self.trainer.received_sigterm:
+            raise ExitGracefullyException
 
     def on_run_end(self) -> _OUTPUTS_TYPE:
         outputs, self._outputs = self._outputs, []

--- a/src/pytorch_lightning/loops/fit_loop.py
+++ b/src/pytorch_lightning/loops/fit_loop.py
@@ -22,7 +22,7 @@ from pytorch_lightning.loops.utilities import _is_max_limit_reached, _set_sample
 from pytorch_lightning.trainer.connectors.logger_connector.result import _ResultCollection
 from pytorch_lightning.trainer.progress import Progress
 from pytorch_lightning.trainer.supporters import CombinedLoader
-from pytorch_lightning.utilities.exceptions import MisconfigurationException
+from pytorch_lightning.utilities.exceptions import ExitGracefullyException, MisconfigurationException
 from pytorch_lightning.utilities.fetching import AbstractDataFetcher, DataFetcher, DataLoaderIterDataFetcher
 from pytorch_lightning.utilities.model_helpers import is_overridden
 from pytorch_lightning.utilities.rank_zero import rank_zero_debug, rank_zero_info, rank_zero_warn
@@ -322,8 +322,8 @@ class _FitLoop(_Loop):
 
         self.epoch_progress.increment_completed()
 
-        # if fault tolerant is enabled and process has been notified, exit.
-        self.trainer._exit_gracefully_on_signal()
+        if self.trainer.received_sigterm:
+            raise ExitGracefullyException
 
     def on_run_end(self) -> None:
         """Calls the ``on_train_end`` hook."""

--- a/src/pytorch_lightning/loops/fit_loop.py
+++ b/src/pytorch_lightning/loops/fit_loop.py
@@ -22,7 +22,7 @@ from pytorch_lightning.loops.utilities import _is_max_limit_reached, _set_sample
 from pytorch_lightning.trainer.connectors.logger_connector.result import _ResultCollection
 from pytorch_lightning.trainer.progress import Progress
 from pytorch_lightning.trainer.supporters import CombinedLoader
-from pytorch_lightning.utilities.exceptions import ExitGracefullyException, MisconfigurationException
+from pytorch_lightning.utilities.exceptions import MisconfigurationException, SIGTERMException
 from pytorch_lightning.utilities.fetching import AbstractDataFetcher, DataFetcher, DataLoaderIterDataFetcher
 from pytorch_lightning.utilities.model_helpers import is_overridden
 from pytorch_lightning.utilities.rank_zero import rank_zero_debug, rank_zero_info, rank_zero_warn
@@ -323,7 +323,7 @@ class _FitLoop(_Loop):
         self.epoch_progress.increment_completed()
 
         if self.trainer.received_sigterm:
-            raise ExitGracefullyException
+            raise SIGTERMException
 
     def on_run_end(self) -> None:
         """Calls the ``on_train_end`` hook."""

--- a/src/pytorch_lightning/trainer/connectors/signal_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/signal_connector.py
@@ -36,12 +36,12 @@ class HandlersCompose:
 
 class SignalConnector:
     def __init__(self, trainer: "pl.Trainer") -> None:
+        self.received_sigterm = False
         self.trainer = trainer
-        self.trainer._received_sigterm = False
         self._original_handlers: Dict[_SIGNUM, _HANDLER] = {}
 
     def register_signal_handlers(self) -> None:
-        self.trainer._received_sigterm = False
+        self.received_sigterm = False
         self._original_handlers = self._get_current_signal_handlers()
 
         sigusr_handlers: List[_HANDLER] = []
@@ -105,7 +105,7 @@ class SignalConnector:
 
     def _sigterm_notifier_fn(self, signum: _SIGNUM, frame: FrameType) -> None:
         log.info(f"Received signal {signum}")
-        self.trainer._received_sigterm = True
+        self.received_sigterm = True
 
     def sigterm_handler_fn(self, signum: _SIGNUM, frame: FrameType) -> None:
         log.info("bypassing sigterm")

--- a/src/pytorch_lightning/trainer/connectors/signal_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/signal_connector.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Dict, List, Set, Union
 import pytorch_lightning as pl
 from lightning_fabric.plugins.environments import SLURMEnvironment
 from lightning_fabric.utilities.imports import _IS_WINDOWS
-from pytorch_lightning.utilities.imports import _fault_tolerant_training, _PYTHON_GREATER_EQUAL_3_8_0
+from pytorch_lightning.utilities.imports import _PYTHON_GREATER_EQUAL_3_8_0
 from pytorch_lightning.utilities.rank_zero import rank_zero_info
 
 # copied from signal.pyi
@@ -37,17 +37,15 @@ class HandlersCompose:
 class SignalConnector:
     def __init__(self, trainer: "pl.Trainer") -> None:
         self.trainer = trainer
-        self.trainer._terminate_gracefully = False
+        self.trainer._received_sigterm = False
         self._original_handlers: Dict[_SIGNUM, _HANDLER] = {}
 
     def register_signal_handlers(self) -> None:
+        self.trainer._received_sigterm = False
         self._original_handlers = self._get_current_signal_handlers()
 
         sigusr_handlers: List[_HANDLER] = []
-        sigterm_handlers: List[_HANDLER] = []
-
-        if _fault_tolerant_training():
-            sigterm_handlers.append(self.fault_tolerant_sigterm_handler_fn)
+        sigterm_handlers: List[_HANDLER] = [self._sigterm_notifier_fn]
 
         environment = self.trainer._accelerator_connector.cluster_environment
         if isinstance(environment, SLURMEnvironment) and environment.auto_requeue:
@@ -105,9 +103,9 @@ class SignalConnector:
             else:
                 log.warning("requeue failed...")
 
-    def fault_tolerant_sigterm_handler_fn(self, signum: _SIGNUM, frame: FrameType) -> None:
-        log.info(f"Received signal {signum}. Saving a fault-tolerant checkpoint and terminating.")
-        self.trainer._terminate_gracefully = True
+    def _sigterm_notifier_fn(self, signum: _SIGNUM, frame: FrameType) -> None:
+        log.info(f"Received signal {signum}")
+        self.trainer._received_sigterm = True
 
     def sigterm_handler_fn(self, signum: _SIGNUM, frame: FrameType) -> None:
         log.info("bypassing sigterm")

--- a/src/pytorch_lightning/trainer/trainer.py
+++ b/src/pytorch_lightning/trainer/trainer.py
@@ -1900,7 +1900,7 @@ class Trainer:
 
         For example, this can be checked to exit gracefully.
         """
-        return self._received_sigterm
+        return self._signal_connector.received_sigterm
 
     """
     Loop properties

--- a/src/pytorch_lightning/trainer/trainer.py
+++ b/src/pytorch_lightning/trainer/trainer.py
@@ -1900,7 +1900,7 @@ class Trainer:
 
         For example, this can be checked to exit gracefully.
         """
-        return self.strategy.reduce_bolean_decision(self._received_sigterm, all=False)
+        return self.strategy.reduce_boolean_decision(self._received_sigterm, all=False)
 
     """
     Loop properties

--- a/src/pytorch_lightning/trainer/trainer.py
+++ b/src/pytorch_lightning/trainer/trainer.py
@@ -1896,11 +1896,11 @@ class Trainer:
 
     @property
     def received_sigterm(self) -> bool:
-        """Whether a SIGTERM signal was received (in at least one process)
+        """Whether a ``signal.SIGTERM`` signal was received.
 
         For example, this can be checked to exit gracefully.
         """
-        return self.strategy.reduce_boolean_decision(self._received_sigterm, all=False)
+        return self._received_sigterm
 
     """
     Loop properties

--- a/src/pytorch_lightning/utilities/exceptions.py
+++ b/src/pytorch_lightning/utilities/exceptions.py
@@ -11,15 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from lightning_fabric.utilities.exceptions import MisconfigurationException  # noqa: F401
 
 
 class ExitGracefullyException(SystemExit):
-    """Exception used when a ``signal.SIGTERM`` is sent to the process.
+    """Exception used when a :class:`signal.SIGTERM` is sent to a process.
 
-    This signals Lightning to try to create a fault-tolerance checkpoint once the current batch or epoch is reached
-    (assuming it can be done under 30 sec). After the checkpoint is saved, Lightning will exit.
+    This exception is raised by the loops at specific points. It can be used to write custom logic in the
+    :meth:`pytorch_lightning.callbacks.callback.Callback.on_exception` method.
+    If fault-tolerance is enabled (experimental), we automatically add a
+    :class:`pytorch_lightning.callbacks.fault_tolerance._FaultToleranceCheckpoint` callback that saves a checkpoint for
+    you when this exception is raised.
     """
 
 

--- a/src/pytorch_lightning/utilities/exceptions.py
+++ b/src/pytorch_lightning/utilities/exceptions.py
@@ -14,7 +14,7 @@
 from lightning_fabric.utilities.exceptions import MisconfigurationException  # noqa: F401
 
 
-class ExitGracefullyException(SystemExit):
+class SIGTERMException(SystemExit):
     """Exception used when a :class:`signal.SIGTERM` is sent to a process.
 
     This exception is raised by the loops at specific points. It can be used to write custom logic in the

--- a/tests/tests_pytorch/trainer/connectors/test_signal_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_signal_connector.py
@@ -24,7 +24,7 @@ from lightning_fabric.utilities.imports import _IS_WINDOWS
 from pytorch_lightning import Trainer
 from pytorch_lightning.demos.boring_classes import BoringModel
 from pytorch_lightning.trainer.connectors.signal_connector import SignalConnector
-from pytorch_lightning.utilities.exceptions import ExitGracefullyException
+from pytorch_lightning.utilities.exceptions import SIGTERMException
 from tests_pytorch.helpers.runif import RunIf
 
 
@@ -66,7 +66,7 @@ def test_fault_tolerant_sig_handler(register_handler, terminate_gracefully, tmpd
     with mock.patch.dict(os.environ, {"PL_FAULT_TOLERANT_TRAINING": str(int(terminate_gracefully))}):
         trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, limit_train_batches=2, limit_val_batches=0)
         if terminate_gracefully and not register_handler:
-            with pytest.raises(ExitGracefullyException):
+            with pytest.raises(SIGTERMException):
                 trainer.fit(model)
         else:
             trainer.fit(model)


### PR DESCRIPTION
## What does this PR do?

Fault-tolerance is composed of several items:
1. Automatic DataLoader state serialization
2. Manual DataLoader state serialization
3. Metrics/Logging results state
4. Sigterm handling to signal to terminate gracefully
5. Save a checkpoint when it is signaled to terminate gracefully

This PR changes (4) so it is not tied to the fault-tolerance feature, as it doesn't need to be and could be used for other purposes, or for manual fault-tolerance.

### Does your PR introduce any breaking changes? If yes, please list them.

None

cc @borda @carmocca @justusschock @awaelchli