### PR TITLE
store: drop `requirements_file_path`

### DIFF
--- a/src/lightning/store/cloud_api.py
+++ b/src/lightning/store/cloud_api.py
@@ -51,7 +51,6 @@ def upload_to_cloud(
     model=None,
     source_code_path: str = "",
     checkpoint_path: str = "",
-    requirements_file_path: str = "",
     requirements: Optional[List[str]] = None,
     weights_only: bool = False,
     api_key: str = "",
@@ -77,12 +76,9 @@ def upload_to_cloud(
                 will raise an error. (Optional)
         checkpoint_path:
             The path to the checkpoint that needs to be uploaded. (Optional)
-        requirements_file_path:
-            The path to the requirements file, will always be uploaded with the name of `requirements.txt`.
         requirements:
             List of requirements as strings, that will be written as `requirements.txt` and
-                then uploaded. If both `requirements_file_path` and `requirements` are passed,
-                a warning is raised as `requirements` is given the priority over `requirements_file_path`.
+                then uploaded.
         weights_only:
             If set to `True`, it will only save model weights and nothing else. This raises
                 an error if `weights_only` is `True` but no `model` is passed.
@@ -146,25 +142,10 @@ def upload_to_cloud(
                         stored=stored,
                     )
 
-        if requirements and requirements_file_path:
-            # TODO: Later on, figure out how to merge requirements from both args
-            logging.warning(
-                "You provided a requirements file (..., requirements_file_path=...)"
-                " and requirements list (..., requirements=...). In case of any collisions,"
-                " anything that comes from requirements=... will be given the priority."
-            )
-
         if requirements:
             stored = _write_and_save_requirements(
                 model_name,
                 requirements=requirements,
-                stored=stored,
-                tmpdir=tmpdir,
-            )
-        elif requirements_file_path:
-            stored = _save_requirements_file(
-                model_name,
-                requirements_file_path=requirements_file_path,
                 stored=stored,
                 tmpdir=tmpdir,
             )

--- a/src/lightning/store/cloud_api.py
+++ b/src/lightning/store/cloud_api.py
@@ -36,7 +36,6 @@ from lightning.store.save import (
     _save_model,
     _save_model_code,
     _save_model_weights,
-    _save_requirements_file,
     _submit_data_to_url,
     _write_and_save_requirements,
 )

--- a/tests/tests_cloud/test_requirements.py
+++ b/tests/tests_cloud/test_requirements.py
@@ -8,28 +8,7 @@ from lightning.store.save import _LIGHTNING_STORAGE_DIR
 from pytorch_lightning.demos.boring_classes import BoringModel
 
 
-def test_requirements_as_a_file(version: str = "latest", model_name: str = "boring_model"):
-    cleanup()
-
-    requirements_file_path = os.path.join(_PROJECT_ROOT, "requirements", "app", "base.txt")
-
-    upload_to_cloud(
-        model_name,
-        version=version,
-        model=BoringModel(),
-        requirements_file_path=requirements_file_path,
-        api_key=_API_KEY,
-        project_id=_PROJECT_ID,
-    )
-
-    download_from_cloud(f"{_USERNAME}/{model_name}")
-
-    req_folder_path = os.path.join(_LIGHTNING_STORAGE_DIR, _USERNAME, model_name, version)
-    assert os.path.isdir(req_folder_path), "missing: %s" % req_folder_path
-    assert "requirements.txt" in os.listdir(req_folder_path), "among files: %r" % os.listdir(req_folder_path)
-
-
-def test_requirements_as_a_list(version: str = "1.0.0", model_name: str = "boring_model"):
+def test_requirements(version: str = "1.0.0", model_name: str = "boring_model"):
     cleanup()
 
     requirements_list = ["pytorch_lightning==1.7.7", "lightning"]

--- a/tests/tests_cloud/test_requirements.py
+++ b/tests/tests_cloud/test_requirements.py
@@ -1,6 +1,6 @@
 import os
 
-from tests_cloud import _API_KEY, _PROJECT_ID, _PROJECT_ROOT, _USERNAME
+from tests_cloud import _API_KEY, _PROJECT_ID, _USERNAME
 from tests_cloud.helpers import cleanup
 
 from lightning.store import download_from_cloud, upload_to_cloud


### PR DESCRIPTION
## What does this PR do?

this argument was duplicated to `requirements` as you can simply load requirements from a file in a single line... 
follow-up for #15811

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
