### PR TITLE
PyTorch 2.0 switched the `set_to_none` default

### DIFF
--- a/docs/source-pytorch/guides/speed.rst
+++ b/docs/source-pytorch/guides/speed.rst
@@ -426,6 +426,7 @@ In order to improve performance, you can override :meth:`~pytorch_lightning.core
 
 For a more detailed explanation of the pros / cons of this technique,
 read the documentation for :meth:`~torch.optim.Optimizer.zero_grad` by the PyTorch team.
+This is enabled by default on ``torch>=2.0.0``.
 
 .. testcode::
 

--- a/src/pytorch_lightning/core/module.py
+++ b/src/pytorch_lightning/core/module.py
@@ -1719,7 +1719,7 @@ class LightningModule(
             def optimizer_zero_grad(self, epoch, batch_idx, optimizer, optimizer_idx):
                 optimizer.zero_grad()
 
-            # Set gradients to `None` instead of zero to improve performance.
+            # Set gradients to `None` instead of zero to improve performance. (not required on `torch>=2.0.0`)
             def optimizer_zero_grad(self, epoch, batch_idx, optimizer, optimizer_idx):
                 optimizer.zero_grad(set_to_none=True)
 

--- a/src/pytorch_lightning/core/module.py
+++ b/src/pytorch_lightning/core/module.py
@@ -1719,7 +1719,7 @@ class LightningModule(
             def optimizer_zero_grad(self, epoch, batch_idx, optimizer, optimizer_idx):
                 optimizer.zero_grad()
 
-            # Set gradients to `None` instead of zero to improve performance. (not required on `torch>=2.0.0`)
+            # Set gradients to `None` instead of zero to improve performance (not required on `torch>=2.0.0`).
             def optimizer_zero_grad(self, epoch, batch_idx, optimizer, optimizer_idx):
                 optimizer.zero_grad(set_to_none=True)
 

--- a/tests/tests_pytorch/accelerators/test_tpu.py
+++ b/tests/tests_pytorch/accelerators/test_tpu.py
@@ -29,6 +29,7 @@ from pytorch_lightning.demos.boring_classes import BoringModel, RandomDataset
 from pytorch_lightning.plugins import PrecisionPlugin, TPUPrecisionPlugin, XLACheckpointIO
 from pytorch_lightning.strategies import DDPStrategy, TPUSpawnStrategy
 from pytorch_lightning.utilities import find_shared_parameters
+from tests.tests_pytorch.trainer.optimization.test_manual_optimization import assert_emtpy_grad
 from tests_pytorch.helpers.runif import RunIf
 
 
@@ -135,7 +136,7 @@ def test_manual_optimization_tpus(tmpdir):
                 assert not torch.equal(self.weight_before, after_before), self.count
             else:
                 assert torch.equal(self.weight_before, after_before)
-            assert torch.all(self.layer.weight.grad == 0)
+            assert_emtpy_grad(self.layer.weight.grad)
             self.count += 1
 
         def on_train_start(self):

--- a/tests/tests_pytorch/accelerators/test_tpu.py
+++ b/tests/tests_pytorch/accelerators/test_tpu.py
@@ -29,8 +29,8 @@ from pytorch_lightning.demos.boring_classes import BoringModel, RandomDataset
 from pytorch_lightning.plugins import PrecisionPlugin, TPUPrecisionPlugin, XLACheckpointIO
 from pytorch_lightning.strategies import DDPStrategy, TPUSpawnStrategy
 from pytorch_lightning.utilities import find_shared_parameters
-from tests.tests_pytorch.trainer.optimization.test_manual_optimization import assert_emtpy_grad
 from tests_pytorch.helpers.runif import RunIf
+from tests_pytorch.trainer.optimization.test_manual_optimization import assert_emtpy_grad
 
 
 class WeightSharingModule(BoringModel):

--- a/tests/tests_pytorch/trainer/optimization/test_manual_optimization.py
+++ b/tests/tests_pytorch/trainer/optimization/test_manual_optimization.py
@@ -32,7 +32,8 @@ def assert_emtpy_grad(grad):
     if _TORCH_GREATER_EQUAL_2_0:
         assert grad is None
     else:
-        assert torch.all(grad == 0)
+        if grad is not None:  # backward has been called
+            assert torch.all(grad == 0)
 
 
 class ManualOptModel(BoringModel):

--- a/tests/tests_pytorch/trainer/optimization/test_manual_optimization.py
+++ b/tests/tests_pytorch/trainer/optimization/test_manual_optimization.py
@@ -21,10 +21,18 @@ import torch
 import torch.distributed as torch_distrib
 import torch.nn.functional as F
 
+from lightning_fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_0
 from pytorch_lightning import seed_everything, Trainer
 from pytorch_lightning.demos.boring_classes import BoringModel, ManualOptimBoringModel
 from pytorch_lightning.strategies import Strategy
 from tests_pytorch.helpers.runif import RunIf
+
+
+def assert_emtpy_grad(grad):
+    if _TORCH_GREATER_EQUAL_2_0:
+        assert grad is None
+    else:
+        assert torch.all(grad == 0)
 
 
 class ManualOptModel(BoringModel):
@@ -36,14 +44,13 @@ class ManualOptModel(BoringModel):
         opt_a, opt_b = self.optimizers()
 
         # make sure there are no grads
-        if batch_idx > 0:
-            assert torch.all(self.layer.weight.grad == 0)
+        assert_emtpy_grad(self.layer.weight.grad)
 
         loss_1 = self.step(batch[0])
         self.manual_backward(loss_1)
         opt_a.step()
         opt_a.zero_grad()
-        assert torch.all(self.layer.weight.grad == 0)
+        assert_emtpy_grad(self.layer.weight.grad)
 
         loss_2 = self.step(batch[0])
         # ensure we forward the correct params to the optimizer
@@ -53,7 +60,7 @@ class ManualOptModel(BoringModel):
         assert self.layer.weight.grad is not None
         opt_b.step()
         opt_b.zero_grad()
-        assert torch.all(self.layer.weight.grad == 0)
+        assert_emtpy_grad(self.layer.weight.grad)
 
         return loss_2
 
@@ -238,7 +245,7 @@ class ManualOptimizationExtendedModel(BoringModel):
             except Exception:
                 # almost no diff between before and after
                 assert torch.abs(torch.sum(self.weight_before) - torch.sum(after_before)).item() < 10e-6
-        assert torch.all(self.layer.weight.grad == 0)
+        assert_emtpy_grad(self.layer.weight.grad)
         self.count += 1
 
     def on_train_end(self):
@@ -323,12 +330,12 @@ def test_manual_optimization_and_accumulated_gradient(tmpdir):
             after_before = self.layer.weight.clone()
             if self.should_update and self.should_have_updated:
                 assert not torch.equal(self.weight_before, after_before), self.count
-                assert torch.all(self.layer.weight.grad == 0)
+                assert_emtpy_grad(self.layer.weight.grad)
             else:
                 assert torch.equal(self.weight_before, after_before)
                 if self.count > 1:
                     if self.count % 4 == 1:
-                        assert torch.all(self.layer.weight.grad == 0)
+                        assert_emtpy_grad(self.layer.weight.grad)
                     else:
                         assert torch.sum(self.layer.weight.grad) != 0
             self.count += 1
@@ -368,8 +375,7 @@ def test_multiple_optimizers_step(tmpdir):
             loss_1 = self.loss(loss_1, loss_1)
 
             # make sure there are no grads
-            if self.layer.weight.grad is not None:
-                assert torch.all(self.layer.weight.grad == 0)
+            assert_emtpy_grad(self.layer.weight.grad)
 
             self.manual_backward(loss_1)
             opt_a.step()
@@ -455,8 +461,7 @@ def test_step_with_optimizer_closure(tmpdir):
 
         def training_step(self, batch, batch_idx):
             # make sure there are no grads
-            if self.layer.weight.grad is not None:
-                assert torch.all(self.layer.weight.grad == 0)
+            assert_emtpy_grad(self.layer.weight.grad)
 
             opt = self.optimizers()
 


### PR DESCRIPTION
## What does this PR do?

See: https://github.com/pytorch/pytorch/pull/92731

### Does your PR introduce any breaking changes? If yes, please list them.

None

cc @borda