### PR TITLE
Ensure SIGTERM handlers other than ours can be added

### DIFF
--- a/src/pytorch_lightning/trainer/connectors/signal_connector.py
+++ b/src/pytorch_lightning/trainer/connectors/signal_connector.py
@@ -56,14 +56,14 @@ class SignalConnector:
         # Windows seems to have signal incompatibilities
         if not self._is_on_windows():
             sigusr = environment.requeue_signal if isinstance(environment, SLURMEnvironment) else signal.SIGUSR1
-
             assert sigusr is not None
-
             if sigusr_handlers and not self._has_already_handler(sigusr):
                 self._register_signal(sigusr, HandlersCompose(sigusr_handlers))
 
-            if sigterm_handlers and not self._has_already_handler(signal.SIGTERM):
-                self._register_signal(signal.SIGTERM, HandlersCompose(sigterm_handlers))
+            # we have our own handler, but include existing ones too
+            if self._has_already_handler(signal.SIGTERM):
+                sigterm_handlers.append(signal.getsignal(signal.SIGTERM))
+            self._register_signal(signal.SIGTERM, HandlersCompose(sigterm_handlers))
 
     def slurm_sigusr_handler_fn(self, signum: _SIGNUM, frame: FrameType) -> None:
         rank_zero_info("handling auto-requeue signal")

--- a/tests/tests_pytorch/trainer/connectors/test_signal_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_signal_connector.py
@@ -14,7 +14,6 @@
 import concurrent.futures
 import os
 import signal
-from time import sleep
 from unittest import mock
 
 import pytest
@@ -42,35 +41,29 @@ def test_signal_handlers_restored_in_teardown():
     assert signal.getsignal(signal.SIGTERM) is signal.SIG_DFL
 
 
-@pytest.mark.parametrize("register_handler", [False, True])
-@pytest.mark.parametrize("terminate_gracefully", [False, True])
 @RunIf(skip_windows=True)
-def test_fault_tolerant_sig_handler(register_handler, terminate_gracefully, tmpdir):
+def test_sigterm_handler_can_be_added(tmpdir):
+    handler_ran = False
 
-    if register_handler:
+    def handler(*_):
+        nonlocal handler_ran
+        handler_ran = True
 
-        def handler(*_):
-            pass
-
-        signal.signal(signal.SIGTERM, handler)
+    signal.signal(signal.SIGTERM, handler)
 
     class TestModel(BoringModel):
         def training_step(self, batch, batch_idx):
-            if terminate_gracefully or register_handler:
-                os.kill(os.getpid(), signal.SIGTERM)
-                sleep(0.1)
-            return super().training_step(batch, batch_idx)
+            os.kill(os.getpid(), signal.SIGTERM)
 
     model = TestModel()
+    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, limit_train_batches=2, limit_val_batches=0)
 
-    with mock.patch.dict(os.environ, {"PL_FAULT_TOLERANT_TRAINING": str(int(terminate_gracefully))}):
-        trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, limit_train_batches=2, limit_val_batches=0)
-        if terminate_gracefully and not register_handler:
-            with pytest.raises(SIGTERMException):
-                trainer.fit(model)
-        else:
-            trainer.fit(model)
-        assert trainer.received_sigterm == (False if register_handler else terminate_gracefully)
+    assert not trainer.received_sigterm
+    assert not handler_ran
+    with pytest.raises(SIGTERMException):
+        trainer.fit(model)
+    assert trainer.received_sigterm
+    assert handler_ran
 
     # reset the signal to system defaults
     signal.signal(signal.SIGTERM, signal.SIG_DFL)
@@ -134,7 +127,6 @@ def _registering_signals():
 
 
 @RunIf(skip_windows=True)
-@mock.patch.dict(os.environ, {"PL_FAULT_TOLERANT_TRAINING": "1"})
 def test_signal_connector_in_thread():
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
         for future in concurrent.futures.as_completed([executor.submit(_registering_signals)]):


### PR DESCRIPTION
## What does this PR do?

If the user had set a SIGTERM handler, ours (previously only under fault-tolerance) wouldn't be registered.

This PR allows it.
A stale test is updated to check it.

This PR is only relevant for 2.0, even though it's a bugfix. Not adding a CHANGELOG because this wasn't an issue in 1.9.

Follow-up to #16501

### Does your PR introduce any breaking changes? If yes, please list them.

None

cc @borda