### PR TITLE
Avoid wrapping prediction dataloader twice on TPU

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -51,6 +51,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed strict availability check for `torch_xla` requirement ([#16476](https://github.com/Lightning-AI/lightning/pull/16476))
 
+- Fixed an issue where PL would wrap DataLoaders with XLA's MpDeviceLoader more than once ([#16571](https://github.com/Lightning-AI/lightning/pull/16571))
+
+- Fixed the batch_sampler reference for DataLoaders wrapped with XLA's MpDeviceLoader ([#16571](https://github.com/Lightning-AI/lightning/pull/16571))
+
 
 ## [1.9.0] - 2023-01-17
 

--- a/src/lightning/fabric/strategies/xla.py
+++ b/src/lightning/fabric/strategies/xla.py
@@ -114,9 +114,14 @@ class XLAStrategy(ParallelStrategy):
         XLAStrategy._validate_dataloader(dataloader)
         from torch_xla.distributed.parallel_loader import MpDeviceLoader
 
+        if isinstance(dataloader, MpDeviceLoader):
+            # dataloader is already wrapped by MpDeviceLoader
+            return dataloader
+
         dataloader = MpDeviceLoader(dataloader, self.root_device)
         # Mimic interface to torch.utils.data.DataLoader
         dataloader.dataset = dataloader._loader.dataset
+        dataloader.batch_sampler = getattr(dataloader._loader, "batch_sampler", None)
         return dataloader
 
     def all_gather(self, tensor: Tensor, group: Optional[Any] = None, sync_grads: bool = False) -> Tensor:

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -205,6 +205,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed strict availability check for `torch_xla` requirement ([#16476](https://github.com/Lightning-AI/lightning/pull/16476))
 
+- Fixed an issue where PL would wrap DataLoaders with XLA's MpDeviceLoader more than once ([#16571](https://github.com/Lightning-AI/lightning/pull/16571))
+
+- Fixed the batch_sampler reference for DataLoaders wrapped with XLA's MpDeviceLoader ([#16571](https://github.com/Lightning-AI/lightning/pull/16571))
 
 ## [1.9.0] - 2023-01-17
 

--- a/src/lightning/pytorch/strategies/tpu_spawn.py
+++ b/src/lightning/pytorch/strategies/tpu_spawn.py
@@ -170,9 +170,14 @@ class TPUSpawnStrategy(DDPSpawnStrategy):
         TPUSpawnStrategy._validate_dataloader(dataloader)
         from torch_xla.distributed.parallel_loader import MpDeviceLoader
 
+        if isinstance(dataloader, MpDeviceLoader):
+            # dataloader is already wrapped by MpDeviceLoader
+            return dataloader
+
         dataloader = MpDeviceLoader(dataloader, self.root_device)
         # Mimic interface to torch.utils.data.DataLoader
         dataloader.dataset = dataloader._loader.dataset
+        dataloader.batch_sampler = getattr(dataloader._loader, "batch_sampler", None)
         return dataloader
 
     def configure_ddp(self) -> None:

--- a/tests/tests_fabric/strategies/test_xla.py
+++ b/tests/tests_fabric/strategies/test_xla.py
@@ -95,6 +95,7 @@ def test_xla_mp_device_dataloader_attribute(_, monkeypatch):
     processed_dataloader = strategy.process_dataloader(dataloader)
     mp_loader_mock.assert_called_with(dataloader, strategy.root_device)
     assert processed_dataloader.dataset == processed_dataloader._loader.dataset
+    assert processed_dataloader.batch_sampler == processed_dataloader._loader.batch_sampler
 
 
 _loader = DataLoader(RandomDataset(32, 64))


### PR DESCRIPTION
Avoid wrapping dataloader with `MpDeviceLoader` more than once. Add `batch_sampler` back to the dataloader.

## What does this PR do?

Fixes [#16572](https://github.com/Lightning-AI/lightning/issues/16572)

When doing prediction on TPU with:
```
trainer=Trainer(accelerator='tpu', devices=8)
trainer.predict(model=model, dataloaders=dm)
```
the code would crash because the prediction dataloader is wrapped twice with `MpDeviceLoader`, once in [`DataConnector._reset_eval_dataloader()`](https://github.com/Lightning-AI/lightning/blob/master/src/pytorch_lightning/trainer/connectors/data_connector.py#L278) and once in [`PredictionLoop.advance()`](https://github.com/Lightning-AI/lightning/blob/master/src/pytorch_lightning/loops/dataloader/prediction_loop.py#L112).

To avoid double wrapping, a checking is added in `TPUSpawnStrategy.process_dataloader()`. 

The `batch_sampler` is also added to the wrapped dataloader to avoid warning in [prediction_epoch_loop](https://github.com/Lightning-AI/lightning/blob/master/src/pytorch_lightning/loops/epoch/prediction_epoch_loop.py#L182).

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Yes
Make sure you had fun coding 🙃
