### PR TITLE
Ignore leaked XLA environment variables

### DIFF
--- a/tests/tests_pytorch/conftest.py
+++ b/tests/tests_pytorch/conftest.py
@@ -75,6 +75,12 @@ def restore_env_variables():
         "KMP_INIT_AT_FORK",  # leaked since PyTorch 1.13
         "KMP_DUPLICATE_LIB_OK",  # leaked since PyTorch 1.13
         "CRC32C_SW_MODE",  # leaked by tensorboardX
+        # leaked by XLA
+        "ALLOW_MULTIPLE_LIBTPU_LOAD",
+        "GRPC_VERBOSITY",
+        "TF_CPP_MIN_LOG_LEVEL",
+        "TF_GRPC_DEFAULT_OPTIONS",
+        "XLA_FLAGS",
     }
     leaked_vars.difference_update(allowlist)
     assert not leaked_vars, f"test is leaking environment variable(s): {set(leaked_vars)}"


### PR DESCRIPTION
## What does this PR do?

Fixes the master failures for the `test-on-tpus (pytorch)` job

These started appearing after https://github.com/Lightning-AI/lightning/commit/961fa6a0ea28b5b7346f98f2b2e8fef2833b0d9e
The previous commit was passing: https://github.com/Lightning-AI/lightning/commit/0aef0375cbdde134d402146f46bc40a25e070910

The XLA versions are the same, so I don't know what triggered this.

### Does your PR introduce any breaking changes? If yes, please list them.

None

cc @borda