### PR TITLE
fix

### DIFF
--- a/src/lightning/fabric/connector.py
+++ b/src/lightning/fabric/connector.py
@@ -188,6 +188,7 @@ class _Connector:
         if strategy is not None and strategy not in self._registered_strategies and not isinstance(strategy, Strategy):
             raise ValueError(
                 f"You selected an invalid strategy name: `strategy={strategy!r}`."
+                " It must be either a string or an instance of `lightning.fabric.strategies.Strategy`."
                 " Example choices: ddp, ddp_spawn, deepspeed, dp, ..."
                 " Find a complete list of options in our documentation at https://lightning.ai"
             )
@@ -439,12 +440,12 @@ class _Connector:
 
     def _init_strategy(self) -> None:
         """Instantiate the Strategy given depending on the setting of ``_strategy_flag``."""
+        # The validation of `_strategy_flag` already happened earlier on in the connector
+        assert isinstance(self._strategy_flag, (str, Strategy))
         if isinstance(self._strategy_flag, str):
             self.strategy = STRATEGY_REGISTRY.get(self._strategy_flag)
-        elif isinstance(self._strategy_flag, Strategy):
-            self.strategy = self._strategy_flag
         else:
-            raise RuntimeError(f"{self.strategy} is not valid type: {self.strategy}")
+            self.strategy = self._strategy_flag
 
     def _check_and_init_precision(self) -> Precision:
         self._validate_precision_choice()

--- a/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
@@ -206,16 +206,14 @@ class AcceleratorConnector:
 
         if strategy is not None:
             self._strategy_flag = strategy
-            if strategy == "ddp_cpu":
-                raise MisconfigurationException(
-                    "`Trainer(strategy='ddp_cpu')` is not a valid strategy,"
-                    " you can use `Trainer(strategy='ddp'|'ddp_spawn'|'ddp_fork', accelerator='cpu')` instead."
-                )
-            if strategy == "tpu_spawn":
-                raise MisconfigurationException(
-                    "`Trainer(strategy='tpu_spawn')` is not a valid strategy,"
-                    " you can use `Trainer(strategy='ddp_spawn', accelerator='tpu')` instead."
-                )
+
+        if strategy is not None and strategy not in self._registered_strategies and not isinstance(strategy, Strategy):
+            raise ValueError(
+                f"You selected an invalid strategy name: `strategy={strategy!r}`."
+                " It must be either a string or an instance of `lightning.pytorch.strategies.Strategy`."
+                " Example choices: ddp, ddp_spawn, deepspeed, dp, ..."
+                " Find a complete list of options in our documentation at https://lightning.ai"
+            )
 
         if (
             accelerator is not None
@@ -505,13 +503,13 @@ class AcceleratorConnector:
 
     def _init_strategy(self) -> None:
         """Instantiate the Strategy given depending on the setting of ``_strategy_flag``."""
+        # The validation of `_strategy_flag` already happened earlier on in the connector
+        assert isinstance(self._strategy_flag, (str, Strategy))
         if isinstance(self._strategy_flag, str):
             self.strategy = StrategyRegistry.get(self._strategy_flag)
-        elif isinstance(self._strategy_flag, Strategy):
+        else:
             # TODO(fabric): remove ignore after merging Fabric and PL strategies
             self.strategy = self._strategy_flag  # type: ignore[assignment]
-        else:
-            raise RuntimeError(f"{self.strategy} is not valid type: {self.strategy}")
 
     def _check_and_init_precision(self) -> PrecisionPlugin:
         self._validate_precision_choice()

--- a/tests/tests_fabric/test_connector.py
+++ b/tests/tests_fabric/test_connector.py
@@ -386,9 +386,10 @@ def test_invalid_accelerator_choice():
         _Connector(accelerator="cocofruit")
 
 
-def test_invalid_strategy_choice():
-    with pytest.raises(ValueError, match="You selected an invalid strategy name: `strategy='cocofruit'`"):
-        _Connector(strategy="cocofruit")
+@pytest.mark.parametrize("invalid_strategy", ["cocofruit", object()])
+def test_invalid_strategy_choice(invalid_strategy):
+    with pytest.raises(ValueError, match=f"You selected an invalid strategy name:"):
+        _Connector(strategy=invalid_strategy)
 
 
 @pytest.mark.parametrize(

--- a/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
@@ -62,6 +62,12 @@ def test_accelerator_invalid_choice():
         Trainer(accelerator="invalid")
 
 
+@pytest.mark.parametrize("invalid_strategy", ["cocofruit", object()])
+def test_invalid_strategy_choice(invalid_strategy):
+    with pytest.raises(ValueError, match=f"You selected an invalid strategy name:"):
+        AcceleratorConnector(strategy=invalid_strategy)
+
+
 @RunIf(skip_windows=True, standalone=True)
 def test_strategy_choice_ddp_on_cpu(tmpdir):
     """Test that selecting DDPStrategy on CPU works."""
@@ -351,13 +357,6 @@ def test_unsupported_strategy_types_on_cpu_and_fallback():
     assert isinstance(trainer.strategy, DDPStrategy)
 
 
-def test_exception_invalid_strategy():
-    with pytest.raises(MisconfigurationException, match=r"strategy='ddp_cpu'\)` is not a valid"):
-        Trainer(strategy="ddp_cpu")
-    with pytest.raises(MisconfigurationException, match=r"strategy='tpu_spawn'\)` is not a valid"):
-        Trainer(strategy="tpu_spawn")
-
-
 @pytest.mark.parametrize(
     ["strategy", "strategy_class"],
     (
@@ -411,7 +410,7 @@ def test_strategy_choice_cpu_instance(strategy_class):
         pytest.param("deepspeed", DeepSpeedStrategy, marks=RunIf(deepspeed=True)),
     ],
 )
-def test_strategy_choice_gpu_str(strategy, strategy_class, cuda_count_2):
+def test_strategy_choice_gpu_str(strategy, strategy_class, cuda_count_2, mps_count_0):
     trainer = Trainer(strategy=strategy, accelerator="gpu", devices=2)
     assert isinstance(trainer.strategy, strategy_class)
 


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in the validation of strategy input.

To reproduce:

```py
from fabric.strategies import DeepSpeedStrategy
from lightning.pytorch import Trainer
trainer = Trainer(strategy=DeepSpeedStrategy())
```

Output:

```
Traceback (most recent call last):
  File "/Users/adrian/repositories/lightning/examples/pl_bug_report/bug_report_model.py", line 3, in <module>
    trainer = Trainer(strategy=DeepSpeedStrategy())
  File "/Users/adrian/repositories/lightning/src/lightning/pytorch/utilities/argparse.py", line 348, in insert_env_defaults
    return fn(self, **kwargs)
  File "/Users/adrian/repositories/lightning/src/lightning/pytorch/trainer/trainer.py", line 321, in __init__
    self._accelerator_connector = AcceleratorConnector(
  File "/Users/adrian/repositories/lightning/src/lightning/pytorch/trainer/connectors/accelerator_connector.py", line 174, in __init__
    self._init_strategy()
  File "/Users/adrian/repositories/lightning/src/lightning/pytorch/trainer/connectors/accelerator_connector.py", line 514, in _init_strategy
    raise RuntimeError(f"{self.strategy} is not valid type: {self.strategy}")
AttributeError: 'AcceleratorConnector' object has no attribute 'strategy'
```

This came from user feedback on Slack. The user accidentally imported DeepSpeedStrategy from fabric and passed it to the Trainer. This is not allowed. In general, an invalid non-string type passed to the connector is triggering a code path that should never be reached, resulting in the misleading attribute error. 

This PR fixes the issue in both Fabric and Trainer, and aligns both implementations in the type validation.


## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃