### PR TITLE
fix warning so the user has a clear next step

### DIFF
--- a/src/lightning/app/components/serve/auto_scaler.py
+++ b/src/lightning/app/components/serve/auto_scaler.py
@@ -453,7 +453,7 @@ class _LoadBalancer(LightningWork):
         try:
             from lightning_api_access import APIAccessFrontend
         except ModuleNotFoundError:
-            logger.warn("APIAccessFrontend not found. Please install lightning-api-access to enable the UI")
+            logger.warn("APIAccessFrontend not found. To enable the UI run: pip install lightning-api-access")
             return
 
         if is_running_in_cloud():

--- a/src/lightning/app/components/serve/auto_scaler.py
+++ b/src/lightning/app/components/serve/auto_scaler.py
@@ -453,7 +453,9 @@ class _LoadBalancer(LightningWork):
         try:
             from lightning_api_access import APIAccessFrontend
         except ModuleNotFoundError:
-            logger.warn("Some dependencies to run the UI are missing. To resolve, run `pip install lightning-api-access`")
+            logger.warn(
+                "Some dependencies to run the UI are missing. To resolve, run `pip install lightning-api-access`"
+            )
             return
 
         if is_running_in_cloud():

--- a/src/lightning/app/components/serve/auto_scaler.py
+++ b/src/lightning/app/components/serve/auto_scaler.py
@@ -453,7 +453,7 @@ class _LoadBalancer(LightningWork):
         try:
             from lightning_api_access import APIAccessFrontend
         except ModuleNotFoundError:
-            logger.warn("APIAccessFrontend not found. To enable the UI run: pip install lightning-api-access")
+            logger.warn("Some dependencies to run the UI are missing. To resolve, run `pip install lightning-api-access`")
             return
 
         if is_running_in_cloud():

--- a/src/lightning/app/components/serve/python_server.py
+++ b/src/lightning/app/components/serve/python_server.py
@@ -293,7 +293,7 @@ class PythonServer(LightningWork, abc.ABC):
         try:
             from lightning_api_access import APIAccessFrontend
         except ModuleNotFoundError:
-            logger.warn("APIAccessFrontend not found. Please install lightning-api-access to enable the UI")
+            logger.warn("APIAccessFrontend not found. To enable the UI run: pip install lightning-api-access")
             return
 
         class_name = self.__class__.__name__

--- a/src/lightning/app/components/serve/python_server.py
+++ b/src/lightning/app/components/serve/python_server.py
@@ -293,7 +293,7 @@ class PythonServer(LightningWork, abc.ABC):
         try:
             from lightning_api_access import APIAccessFrontend
         except ModuleNotFoundError:
-            logger.warn("APIAccessFrontend not found. To enable the UI run: pip install lightning-api-access")
+            logger.warn("Some dependencies to run the UI are missing. To resolve, run `pip install lightning-api-access`")
             return
 
         class_name = self.__class__.__name__

--- a/src/lightning/app/components/serve/python_server.py
+++ b/src/lightning/app/components/serve/python_server.py
@@ -293,7 +293,9 @@ class PythonServer(LightningWork, abc.ABC):
         try:
             from lightning_api_access import APIAccessFrontend
         except ModuleNotFoundError:
-            logger.warn("Some dependencies to run the UI are missing. To resolve, run `pip install lightning-api-access`")
+            logger.warn(
+                "Some dependencies to run the UI are missing. To resolve, run `pip install lightning-api-access`"
+            )
             return
 
         class_name = self.__class__.__name__


### PR DESCRIPTION
tell the user exactly how to install `lightning-api-access` directly from the warning

cc @borda