### PR TITLE
Make dataloader_idx optional for batch start/end hooks

### DIFF
--- a/src/lightning/app/cli/pl-app-template/core/callbacks.py
+++ b/src/lightning/app/cli/pl-app-template/core/callbacks.py
@@ -110,7 +110,7 @@ class PLAppProgressTracker(Callback):
         outputs: Any,
         batch: Any,
         batch_idx: int,
-        dataloader_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         self._state.metrics = self._progress_bar_metrics(trainer, pl_module)
         current = self._test_batch_idx(trainer)
@@ -141,7 +141,7 @@ class PLAppProgressTracker(Callback):
         outputs: Any,
         batch: Any,
         batch_idx: int,
-        dataloader_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         self._state.metrics = self._progress_bar_metrics(trainer, pl_module)
         current = self._predict_batch_idx(trainer)

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -84,7 +84,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Disabled strict loading in multiprocessing launcher ("ddp_spawn", etc.) when loading weights back into the main process ([#16365](https://github.com/Lightning-AI/lightning/pull/16365))
 
 
-- Renamed `CombinedLoader.loaders` to `CombinedLoader.iterables`([#16743](https://github.com/Lightning-AI/lightning/pull/16743))
+- Renamed `CombinedLoader.loaders` to `CombinedLoader.iterables` ([#16743](https://github.com/Lightning-AI/lightning/pull/16743))
+
+
+- The `dataloader_idx` argument is now optional for the `on_{validation,test,predict}_batch_{start,end}` hooks. Remove it or default it to 0 if you don't use multiple dataloaders ([#16753](https://github.com/Lightning-AI/lightning/pull/16753))
 
 ### Deprecated
 

--- a/src/lightning/pytorch/callbacks/callback.py
+++ b/src/lightning/pytorch/callbacks/callback.py
@@ -139,7 +139,12 @@ class Callback:
         """Called when the predict epoch ends."""
 
     def on_validation_batch_start(
-        self, trainer: "pl.Trainer", pl_module: "pl.LightningModule", batch: Any, batch_idx: int, dataloader_idx: int
+        self,
+        trainer: "pl.Trainer",
+        pl_module: "pl.LightningModule",
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Called when the validation batch begins."""
 
@@ -150,12 +155,17 @@ class Callback:
         outputs: Optional[STEP_OUTPUT],
         batch: Any,
         batch_idx: int,
-        dataloader_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Called when the validation batch ends."""
 
     def on_test_batch_start(
-        self, trainer: "pl.Trainer", pl_module: "pl.LightningModule", batch: Any, batch_idx: int, dataloader_idx: int
+        self,
+        trainer: "pl.Trainer",
+        pl_module: "pl.LightningModule",
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Called when the test batch begins."""
 
@@ -166,12 +176,17 @@ class Callback:
         outputs: Optional[STEP_OUTPUT],
         batch: Any,
         batch_idx: int,
-        dataloader_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Called when the test batch ends."""
 
     def on_predict_batch_start(
-        self, trainer: "pl.Trainer", pl_module: "pl.LightningModule", batch: Any, batch_idx: int, dataloader_idx: int
+        self,
+        trainer: "pl.Trainer",
+        pl_module: "pl.LightningModule",
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Called when the predict batch begins."""
 
@@ -182,7 +197,7 @@ class Callback:
         outputs: Any,
         batch: Any,
         batch_idx: int,
-        dataloader_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Called when the predict batch ends."""
 

--- a/src/lightning/pytorch/callbacks/device_stats_monitor.py
+++ b/src/lightning/pytorch/callbacks/device_stats_monitor.py
@@ -111,7 +111,12 @@ class DeviceStatsMonitor(Callback):
         self._get_and_log_device_stats(trainer, "on_train_batch_end")
 
     def on_validation_batch_start(
-        self, trainer: "pl.Trainer", pl_module: "pl.LightningModule", batch: Any, batch_idx: int, dataloader_idx: int
+        self,
+        trainer: "pl.Trainer",
+        pl_module: "pl.LightningModule",
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         self._get_and_log_device_stats(trainer, "on_validation_batch_start")
 
@@ -122,12 +127,17 @@ class DeviceStatsMonitor(Callback):
         outputs: Optional[STEP_OUTPUT],
         batch: Any,
         batch_idx: int,
-        dataloader_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         self._get_and_log_device_stats(trainer, "on_validation_batch_end")
 
     def on_test_batch_start(
-        self, trainer: "pl.Trainer", pl_module: "pl.LightningModule", batch: Any, batch_idx: int, dataloader_idx: int
+        self,
+        trainer: "pl.Trainer",
+        pl_module: "pl.LightningModule",
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         self._get_and_log_device_stats(trainer, "on_test_batch_start")
 
@@ -138,7 +148,7 @@ class DeviceStatsMonitor(Callback):
         outputs: Optional[STEP_OUTPUT],
         batch: Any,
         batch_idx: int,
-        dataloader_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         self._get_and_log_device_stats(trainer, "on_test_batch_end")
 

--- a/src/lightning/pytorch/callbacks/prediction_writer.py
+++ b/src/lightning/pytorch/callbacks/prediction_writer.py
@@ -136,12 +136,14 @@ class BasePredictionWriter(Callback):
         outputs: Any,
         batch: Any,
         batch_idx: int,
-        dataloader_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         if not self.interval.on_batch:
             return
         batch_indices = trainer.predict_loop.epoch_loop.current_batch_indices
-        self.write_on_batch_end(trainer, pl_module, outputs, batch_indices, batch, batch_idx, dataloader_idx)
+        self.write_on_batch_end(
+            trainer, pl_module, outputs, batch_indices, batch, batch_idx, dataloader_idx=dataloader_idx
+        )
 
     def on_predict_epoch_end(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
         if not self.interval.on_epoch:

--- a/src/lightning/pytorch/callbacks/prediction_writer.py
+++ b/src/lightning/pytorch/callbacks/prediction_writer.py
@@ -141,9 +141,7 @@ class BasePredictionWriter(Callback):
         if not self.interval.on_batch:
             return
         batch_indices = trainer.predict_loop.epoch_loop.current_batch_indices
-        self.write_on_batch_end(
-            trainer, pl_module, outputs, batch_indices, batch, batch_idx, dataloader_idx=dataloader_idx
-        )
+        self.write_on_batch_end(trainer, pl_module, outputs, batch_indices, batch, batch_idx, dataloader_idx)
 
     def on_predict_epoch_end(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
         if not self.interval.on_epoch:

--- a/src/lightning/pytorch/callbacks/progress/rich_progress.py
+++ b/src/lightning/pytorch/callbacks/progress/rich_progress.py
@@ -379,7 +379,12 @@ class RichProgressBar(ProgressBarBase):
         self.refresh()
 
     def on_validation_batch_start(
-        self, trainer: "pl.Trainer", pl_module: "pl.LightningModule", batch: Any, batch_idx: int, dataloader_idx: int
+        self,
+        trainer: "pl.Trainer",
+        pl_module: "pl.LightningModule",
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         if self.is_disabled or not self.has_dataloader_changed(dataloader_idx):
             return
@@ -442,7 +447,12 @@ class RichProgressBar(ProgressBarBase):
         self.reset_dataloader_idx_tracker()
 
     def on_test_batch_start(
-        self, trainer: "pl.Trainer", pl_module: "pl.LightningModule", batch: Any, batch_idx: int, dataloader_idx: int
+        self,
+        trainer: "pl.Trainer",
+        pl_module: "pl.LightningModule",
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         if self.is_disabled or not self.has_dataloader_changed(dataloader_idx):
             return
@@ -484,7 +494,7 @@ class RichProgressBar(ProgressBarBase):
         outputs: Optional[STEP_OUTPUT],
         batch: Any,
         batch_idx: int,
-        dataloader_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         if self.is_disabled:
             return
@@ -501,7 +511,7 @@ class RichProgressBar(ProgressBarBase):
         outputs: Optional[STEP_OUTPUT],
         batch: Any,
         batch_idx: int,
-        dataloader_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         if self.is_disabled:
             return
@@ -516,7 +526,7 @@ class RichProgressBar(ProgressBarBase):
         outputs: Any,
         batch: Any,
         batch_idx: int,
-        dataloader_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         if self.is_disabled:
             return

--- a/src/lightning/pytorch/callbacks/progress/rich_progress.py
+++ b/src/lightning/pytorch/callbacks/progress/rich_progress.py
@@ -464,7 +464,12 @@ class RichProgressBar(ProgressBarBase):
         self.refresh()
 
     def on_predict_batch_start(
-        self, trainer: "pl.Trainer", pl_module: "pl.LightningModule", batch: Any, batch_idx: int, dataloader_idx: int
+        self,
+        trainer: "pl.Trainer",
+        pl_module: "pl.LightningModule",
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         if self.is_disabled or not self.has_dataloader_changed(dataloader_idx):
             return

--- a/src/lightning/pytorch/callbacks/progress/tqdm_progress.py
+++ b/src/lightning/pytorch/callbacks/progress/tqdm_progress.py
@@ -274,7 +274,12 @@ class TQDMProgressBar(ProgressBarBase):
             self.val_progress_bar = self.init_validation_tqdm()
 
     def on_validation_batch_start(
-        self, trainer: "pl.Trainer", pl_module: "pl.LightningModule", batch: Any, batch_idx: int, dataloader_idx: int
+        self,
+        trainer: "pl.Trainer",
+        pl_module: "pl.LightningModule",
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         if not self.has_dataloader_changed(dataloader_idx):
             return
@@ -298,7 +303,12 @@ class TQDMProgressBar(ProgressBarBase):
         self.test_progress_bar = self.init_test_tqdm()
 
     def on_test_batch_start(
-        self, trainer: "pl.Trainer", pl_module: "pl.LightningModule", batch: Any, batch_idx: int, dataloader_idx: int
+        self,
+        trainer: "pl.Trainer",
+        pl_module: "pl.LightningModule",
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         if not self.has_dataloader_changed(dataloader_idx):
             return
@@ -319,7 +329,12 @@ class TQDMProgressBar(ProgressBarBase):
         self.predict_progress_bar = self.init_predict_tqdm()
 
     def on_predict_batch_start(
-        self, trainer: "pl.Trainer", pl_module: "pl.LightningModule", batch: Any, batch_idx: int, dataloader_idx: int
+        self,
+        trainer: "pl.Trainer",
+        pl_module: "pl.LightningModule",
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         if not self.has_dataloader_changed(dataloader_idx):
             return

--- a/src/lightning/pytorch/core/hooks.py
+++ b/src/lightning/pytorch/core/hooks.py
@@ -82,7 +82,7 @@ class ModelHooks:
             batch_idx: the index of the batch
         """
 
-    def on_validation_batch_start(self, batch: Any, batch_idx: int, dataloader_idx: int) -> None:
+    def on_validation_batch_start(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
         """Called in the validation loop before anything happens for that batch.
 
         Args:
@@ -92,7 +92,7 @@ class ModelHooks:
         """
 
     def on_validation_batch_end(
-        self, outputs: Optional[STEP_OUTPUT], batch: Any, batch_idx: int, dataloader_idx: int
+        self, outputs: Optional[STEP_OUTPUT], batch: Any, batch_idx: int, dataloader_idx: int = 0
     ) -> None:
         """Called in the validation loop after the batch.
 
@@ -103,7 +103,7 @@ class ModelHooks:
             dataloader_idx: the index of the dataloader
         """
 
-    def on_test_batch_start(self, batch: Any, batch_idx: int, dataloader_idx: int) -> None:
+    def on_test_batch_start(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
         """Called in the test loop before anything happens for that batch.
 
         Args:
@@ -113,7 +113,7 @@ class ModelHooks:
         """
 
     def on_test_batch_end(
-        self, outputs: Optional[STEP_OUTPUT], batch: Any, batch_idx: int, dataloader_idx: int
+        self, outputs: Optional[STEP_OUTPUT], batch: Any, batch_idx: int, dataloader_idx: int = 0
     ) -> None:
         """Called in the test loop after the batch.
 
@@ -124,7 +124,7 @@ class ModelHooks:
             dataloader_idx: the index of the dataloader
         """
 
-    def on_predict_batch_start(self, batch: Any, batch_idx: int, dataloader_idx: int) -> None:
+    def on_predict_batch_start(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
         """Called in the predict loop before anything happens for that batch.
 
         Args:
@@ -133,7 +133,7 @@ class ModelHooks:
             dataloader_idx: the index of the dataloader
         """
 
-    def on_predict_batch_end(self, outputs: Optional[Any], batch: Any, batch_idx: int, dataloader_idx: int) -> None:
+    def on_predict_batch_end(self, outputs: Optional[Any], batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
         """Called in the predict loop after the batch.
 
         Args:

--- a/src/lightning/pytorch/loops/epoch/evaluation_epoch_loop.py
+++ b/src/lightning/pytorch/loops/epoch/evaluation_epoch_loop.py
@@ -202,7 +202,6 @@ class _EvaluationEpochLoop(_Loop):
         trainer = self.trainer
         trainer._logger_connector.on_batch_start(**kwargs)
 
-        kwargs.setdefault("dataloader_idx", 0)  # TODO: the argument should be keyword for these
         hook_name = "on_test_batch_start" if trainer.testing else "on_validation_batch_start"
         call._call_callback_hooks(trainer, hook_name, *kwargs.values())
         call._call_lightning_module_hook(trainer, hook_name, *kwargs.values())
@@ -218,7 +217,6 @@ class _EvaluationEpochLoop(_Loop):
         """
         trainer = self.trainer
 
-        kwargs.setdefault("dataloader_idx", 0)  # TODO: the argument should be keyword for these
         hook_name = "on_test_batch_end" if trainer.testing else "on_validation_batch_end"
         call._call_callback_hooks(trainer, hook_name, output, *kwargs.values())
         call._call_lightning_module_hook(trainer, hook_name, output, *kwargs.values())

--- a/src/lightning/pytorch/loops/epoch/prediction_epoch_loop.py
+++ b/src/lightning/pytorch/loops/epoch/prediction_epoch_loop.py
@@ -134,8 +134,8 @@ class _PredictionEpochLoop(_Loop):
         self.current_batch_indices = batch_indices[batch_idx] if batch_indices else []
 
         trainer = self.trainer
-        call._call_callback_hooks(trainer, "on_predict_batch_start", batch, batch_idx, dataloader_idx)
-        call._call_lightning_module_hook(trainer, "on_predict_batch_start", batch, batch_idx, dataloader_idx)
+        call._call_callback_hooks(trainer, "on_predict_batch_start", *step_kwargs.values())
+        call._call_lightning_module_hook(trainer, "on_predict_batch_start", *step_kwargs.values())
 
         self.batch_progress.increment_started()
 
@@ -146,8 +146,8 @@ class _PredictionEpochLoop(_Loop):
         if predictions is None:
             self._warning_cache.warn("predict returned None if it was on purpose, ignore this warning...")
 
-        call._call_callback_hooks(trainer, "on_predict_batch_end", predictions, batch, batch_idx, dataloader_idx)
-        call._call_lightning_module_hook(trainer, "on_predict_batch_end", predictions, batch, batch_idx, dataloader_idx)
+        call._call_callback_hooks(trainer, "on_predict_batch_end", predictions, *step_kwargs.values())
+        call._call_lightning_module_hook(trainer, "on_predict_batch_end", predictions, *step_kwargs.values())
 
         self.batch_progress.increment_completed()
 

--- a/tests/tests_pytorch/accelerators/test_hpu.py
+++ b/tests/tests_pytorch/accelerators/test_hpu.py
@@ -138,16 +138,16 @@ def test_stages_correct(tmpdir):
             return (output - output) + torch.tensor(4)
 
     class TestCallback(Callback):
-        def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx) -> None:
+        def on_train_batch_end(self, trainer, pl_module, outputs, *_) -> None:
             assert outputs["loss"].item() == 1
 
-        def on_validation_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx) -> None:
+        def on_validation_batch_end(self, trainer, pl_module, outputs, *_) -> None:
             assert outputs["x"].item() == 2
 
-        def on_test_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx) -> None:
+        def on_test_batch_end(self, trainer, pl_module, outputs, *_) -> None:
             assert outputs["y"].item() == 3
 
-        def on_predict_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx) -> None:
+        def on_predict_batch_end(self, trainer, pl_module, outputs, *_) -> None:
             assert torch.all(outputs == 4).item()
 
     model = StageModel()

--- a/tests/tests_pytorch/accelerators/test_ipu.py
+++ b/tests/tests_pytorch/accelerators/test_ipu.py
@@ -294,16 +294,16 @@ def test_stages_correct(tmpdir):
             return (output - output) + torch.tensor(4)
 
     class TestCallback(Callback):
-        def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx) -> None:
+        def on_train_batch_end(self, trainer, pl_module, outputs, *_) -> None:
             assert outputs["loss"].item() == 1
 
-        def on_validation_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx) -> None:
+        def on_validation_batch_end(self, trainer, pl_module, outputs, *_) -> None:
             assert outputs.item() == 2
 
-        def on_test_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx) -> None:
+        def on_test_batch_end(self, trainer, pl_module, outputs, *_) -> None:
             assert outputs.item() == 3
 
-        def on_predict_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx) -> None:
+        def on_predict_batch_end(self, trainer, pl_module, outputs, *_) -> None:
             assert torch.all(outputs == 4).item()
 
     model = StageModel()

--- a/tests/tests_pytorch/accelerators/test_tpu.py
+++ b/tests/tests_pytorch/accelerators/test_tpu.py
@@ -129,7 +129,7 @@ def test_manual_optimization_tpus(tmpdir):
                 opt.zero_grad()
             return loss
 
-        def on_train_batch_end(self, outputs, batch, batch_idx):
+        def on_train_batch_end(self, *_):
             self.called["on_train_batch_end"] += 1
             after_before = self.layer.weight.clone()
             if self.should_update:

--- a/tests/tests_pytorch/callbacks/progress/test_tqdm_progress_bar.py
+++ b/tests/tests_pytorch/callbacks/progress/test_tqdm_progress_bar.py
@@ -126,13 +126,13 @@ def test_tqdm_progress_bar_totals(tmpdir, num_dl):
         def predict_dataloader(self):
             return self._get_dataloaders()
 
-        def validation_step(self, batch, batch_idx, dataloader_idx=None):
+        def validation_step(self, batch, batch_idx, dataloader_idx=0):
             return
 
-        def test_step(self, batch, batch_idx, dataloader_idx=None):
+        def test_step(self, batch, batch_idx, dataloader_idx=0):
             return
 
-        def predict_step(self, batch, batch_idx, dataloader_idx=None):
+        def predict_step(self, batch, batch_idx, dataloader_idx=0):
             return
 
     model = CustomModel()
@@ -243,16 +243,16 @@ def test_tqdm_progress_bar_progress_refresh(tmpdir, refresh_rate: int):
         val_batches_seen = 0
         test_batches_seen = 0
 
-        def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
-            super().on_train_batch_end(trainer, pl_module, outputs, batch, batch_idx)
+        def on_train_batch_end(self, *args):
+            super().on_train_batch_end(*args)
             self.train_batches_seen += 1
 
-        def on_validation_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx):
-            super().on_validation_batch_end(trainer, pl_module, outputs, batch, batch_idx, dataloader_idx)
+        def on_validation_batch_end(self, *args):
+            super().on_validation_batch_end(*args)
             self.val_batches_seen += 1
 
-        def on_test_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx):
-            super().on_test_batch_end(trainer, pl_module, outputs, batch, batch_idx, dataloader_idx)
+        def on_test_batch_end(self, *args):
+            super().on_test_batch_end(*args)
             self.test_batches_seen += 1
 
     pbar = CurrentProgressBar(refresh_rate=refresh_rate)

--- a/tests/tests_pytorch/callbacks/test_callback_hook_outputs.py
+++ b/tests/tests_pytorch/callbacks/test_callback_hook_outputs.py
@@ -22,23 +22,23 @@ def test_train_step_no_return(tmpdir, single_cb: bool):
     """Tests that only training_step can be used."""
 
     class CB(Callback):
-        def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
+        def on_train_batch_end(self, trainer, pl_module, outputs, *_):
             assert "loss" in outputs
 
-        def on_validation_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx):
+        def on_validation_batch_end(self, trainer, pl_module, outputs, *_):
             assert "x" in outputs
 
-        def on_test_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx):
+        def on_test_batch_end(self, trainer, pl_module, outputs, *_):
             assert "x" in outputs
 
     class TestModel(BoringModel):
-        def on_train_batch_end(self, outputs, batch, batch_idx: int) -> None:
+        def on_train_batch_end(self, outputs, *_):
             assert "loss" in outputs
 
-        def on_validation_batch_end(self, outputs, batch, batch_idx: int, dataloader_idx: int) -> None:
+        def on_validation_batch_end(self, outputs, *_):
             assert "x" in outputs
 
-        def on_test_batch_end(self, outputs, batch, batch_idx: int, dataloader_idx: int) -> None:
+        def on_test_batch_end(self, outputs, *_):
             assert "x" in outputs
 
     model = TestModel()

--- a/tests/tests_pytorch/loops/test_all.py
+++ b/tests/tests_pytorch/loops/test_all.py
@@ -29,54 +29,54 @@ def _device_check_helper(batch_device, module_device):
 
 
 class BatchHookObserverCallback(Callback):
-    def on_train_batch_start(self, trainer, pl_module, batch, *args):
+    def on_train_batch_start(self, trainer, pl_module, batch, *_):
         _device_check_helper(batch.device, pl_module.device)
 
-    def on_train_batch_end(self, trainer, pl_module, outputs, batch, *args):
+    def on_train_batch_end(self, trainer, pl_module, outputs, batch, *_):
         _device_check_helper(batch.device, pl_module.device)
 
-    def on_validation_batch_start(self, trainer, pl_module, batch, *args):
+    def on_validation_batch_start(self, trainer, pl_module, batch, *_):
         _device_check_helper(batch.device, pl_module.device)
 
-    def on_validation_batch_end(self, trainer, pl_module, outputs, batch, *args):
+    def on_validation_batch_end(self, trainer, pl_module, outputs, batch, *_):
         _device_check_helper(batch.device, pl_module.device)
 
-    def on_test_batch_start(self, trainer, pl_module, batch, *args):
+    def on_test_batch_start(self, trainer, pl_module, batch, *_):
         _device_check_helper(batch.device, pl_module.device)
 
-    def on_test_batch_end(self, trainer, pl_module, outputs, batch, *args):
+    def on_test_batch_end(self, trainer, pl_module, outputs, batch, *_):
         _device_check_helper(batch.device, pl_module.device)
 
-    def on_predict_batch_start(self, trainer, pl_module, batch, *args):
+    def on_predict_batch_start(self, trainer, pl_module, batch, *_):
         _device_check_helper(batch.device, pl_module.device)
 
-    def on_predict_batch_end(self, trainer, pl_module, outputs, batch, *args):
+    def on_predict_batch_end(self, trainer, pl_module, outputs, batch, *_):
         _device_check_helper(batch.device, pl_module.device)
 
 
 class BatchHookObserverModel(BoringModel):
-    def on_train_batch_start(self, batch, *args):
+    def on_train_batch_start(self, batch, *_):
         _device_check_helper(batch.device, self.device)
 
-    def on_train_batch_end(self, outputs, batch, *args):
+    def on_train_batch_end(self, outputs, batch, *_):
         _device_check_helper(batch.device, self.device)
 
-    def on_validation_batch_start(self, batch, *args):
+    def on_validation_batch_start(self, batch, *_):
         _device_check_helper(batch.device, self.device)
 
-    def on_validation_batch_end(self, outputs, batch, *args):
+    def on_validation_batch_end(self, outputs, batch, *_):
         _device_check_helper(batch.device, self.device)
 
-    def on_test_batch_start(self, batch, *args):
+    def on_test_batch_start(self, batch, *_):
         _device_check_helper(batch.device, self.device)
 
-    def on_test_batch_end(self, outputs, batch, *args):
+    def on_test_batch_end(self, outputs, batch, *_):
         _device_check_helper(batch.device, self.device)
 
-    def on_predict_batch_start(self, batch, *args):
+    def on_predict_batch_start(self, batch, *_):
         _device_check_helper(batch.device, self.device)
 
-    def on_predict_batch_end(self, outputs, batch, *args):
+    def on_predict_batch_end(self, outputs, batch, *_):
         _device_check_helper(batch.device, self.device)
 
 

--- a/tests/tests_pytorch/loops/test_fetchers.py
+++ b/tests/tests_pytorch/loops/test_fetchers.py
@@ -375,7 +375,7 @@ def test_on_train_batch_end_overridden(tmpdir) -> None:
     `LightningModule`."""
 
     class InvalidModel(AsyncBoringModel):
-        def on_train_batch_end(self, outputs, batch, batch_idx):
+        def on_train_batch_end(self, *_):
             pass
 
     trainer = Trainer(fast_dev_run=1, default_root_dir=tmpdir)

--- a/tests/tests_pytorch/loops/test_training_loop.py
+++ b/tests/tests_pytorch/loops/test_training_loop.py
@@ -38,9 +38,8 @@ def test_outputs_format(tmpdir):
             assert "foo" in output
             assert output["foo"] == 123
 
-        def on_train_batch_end(self, outputs, batch, batch_idx):
+        def on_train_batch_end(self, outputs, *_):
             HookedModel._check_output(outputs)
-            super().on_train_batch_end(outputs, batch, batch_idx)
 
     model = HookedModel()
 

--- a/tests/tests_pytorch/models/test_hooks.py
+++ b/tests/tests_pytorch/models/test_hooks.py
@@ -364,13 +364,13 @@ class HookedModel(BoringModel):
                     dict(name="on_before_batch_transfer", args=(ANY, 0)),
                     dict(name="transfer_batch_to_device", args=(ANY, device, 0)),
                     dict(name="on_after_batch_transfer", args=(ANY, 0)),
-                    dict(name=f"Callback.on_{fn}_batch_start", args=(trainer, model, ANY, i, 0)),
-                    dict(name=f"on_{fn}_batch_start", args=(ANY, i, 0)),
+                    dict(name=f"Callback.on_{fn}_batch_start", args=(trainer, model, ANY, i)),
+                    dict(name=f"on_{fn}_batch_start", args=(ANY, i)),
                     dict(name="forward", args=(ANY,)),
                     dict(name=f"{fn}_step", args=(ANY, i)),
                     dict(name=f"{fn}_step_end", args=(outputs,)),
-                    dict(name=f"Callback.on_{fn}_batch_end", args=(trainer, model, outputs, ANY, i, 0)),
-                    dict(name=f"on_{fn}_batch_end", args=(outputs, ANY, i, 0)),
+                    dict(name=f"Callback.on_{fn}_batch_end", args=(trainer, model, outputs, ANY, i)),
+                    dict(name=f"on_{fn}_batch_end", args=(outputs, ANY, i)),
                 ]
             )
         return out
@@ -384,13 +384,13 @@ class HookedModel(BoringModel):
                     dict(name="on_before_batch_transfer", args=(ANY, 0)),
                     dict(name="transfer_batch_to_device", args=(ANY, torch.device("cpu"), 0)),
                     dict(name="on_after_batch_transfer", args=(ANY, 0)),
-                    dict(name="Callback.on_predict_batch_start", args=(trainer, model, ANY, i, 0)),
-                    dict(name="on_predict_batch_start", args=(ANY, i, 0)),
+                    dict(name="Callback.on_predict_batch_start", args=(trainer, model, ANY, i)),
+                    dict(name="on_predict_batch_start", args=(ANY, i)),
                     dict(name="forward", args=(ANY,)),
                     dict(name="predict_step", args=(ANY, i)),
                     # TODO: `predict_step_end`
-                    dict(name="Callback.on_predict_batch_end", args=(trainer, model, ANY, ANY, i, 0)),
-                    dict(name="on_predict_batch_end", args=(ANY, ANY, i, 0)),
+                    dict(name="Callback.on_predict_batch_end", args=(trainer, model, ANY, ANY, i)),
+                    dict(name="on_predict_batch_end", args=(ANY, ANY, i)),
                 ]
             )
         return out

--- a/tests/tests_pytorch/models/test_restore.py
+++ b/tests/tests_pytorch/models/test_restore.py
@@ -46,10 +46,10 @@ class ModelTrainerPropertyParity(Callback):
     def on_train_start(self, trainer, pl_module):
         self._check_properties(trainer, pl_module)
 
-    def on_train_batch_start(self, trainer, pl_module, *args, **kwargs):
+    def on_train_batch_start(self, trainer, pl_module, *_):
         self._check_properties(trainer, pl_module)
 
-    def on_train_batch_end(self, trainer, pl_module, *args, **kwargs):
+    def on_train_batch_end(self, trainer, pl_module, *_):
         self._check_properties(trainer, pl_module)
 
     def on_train_end(self, trainer, pl_module):

--- a/tests/tests_pytorch/strategies/test_deepspeed_strategy.py
+++ b/tests/tests_pytorch/strategies/test_deepspeed_strategy.py
@@ -1128,7 +1128,7 @@ def test_deepspeed_gradient_clip_by_value(tmpdir):
 @RunIf(min_cuda_gpus=2, standalone=True, deepspeed=True)
 def test_specific_gpu_device_id(tmpdir):
     class TestCallback(Callback):
-        def on_train_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
+        def on_train_start(self, *_) -> None:
             assert model.device.index == 1
 
         def on_train_batch_start(
@@ -1136,11 +1136,11 @@ def test_specific_gpu_device_id(tmpdir):
             trainer: Trainer,
             pl_module: LightningModule,
             batch: Any,
-            batch_idx: int,
+            *_,
         ) -> None:
             assert batch.device.index == 1
 
-        def on_test_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
+        def on_test_start(self, *_) -> None:
             assert model.device.index == 1
 
         def on_test_batch_start(
@@ -1148,8 +1148,7 @@ def test_specific_gpu_device_id(tmpdir):
             trainer: Trainer,
             pl_module: LightningModule,
             batch: Any,
-            batch_idx: int,
-            dataloader_idx: int,
+            *_,
         ) -> None:
             assert batch.device.index == 1
 

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -49,16 +49,16 @@ class TestFSDPModel(BoringModel):
     def configure_optimizers(self):
         return torch.optim.SGD(self.layer.parameters(), lr=0.1)
 
-    def on_train_batch_end(self, outputs, batch, batch_idx) -> None:
+    def on_train_batch_end(self, *_) -> None:
         self._assert_layer_fsdp_instance()
 
-    def on_test_batch_end(self, outputs, batch, batch_idx, dataloader_idx) -> None:
+    def on_test_batch_end(self, *_) -> None:
         self._assert_layer_fsdp_instance()
 
-    def on_validation_batch_end(self, outputs, batch, batch_idx, dataloader_idx) -> None:
+    def on_validation_batch_end(self, *_) -> None:
         self._assert_layer_fsdp_instance()
 
-    def on_predict_batch_end(self, outputs, batch, batch_idx, dataloader_idx) -> None:
+    def on_predict_batch_end(self, *_) -> None:
         self._assert_layer_fsdp_instance()
 
     def _assert_layer_fsdp_instance(self) -> None:
@@ -84,16 +84,16 @@ class TestFSDPModelAutoWrapped(BoringModel):
     def configure_optimizers(self):
         return torch.optim.SGD(self.trainer.model.parameters(), lr=0.1)
 
-    def on_train_batch_end(self, outputs, batch, batch_idx) -> None:
+    def on_train_batch_end(self, *_) -> None:
         self._assert_layer_fsdp_instance()
 
-    def on_test_batch_end(self, outputs, batch, batch_idx, dataloader_idx) -> None:
+    def on_test_batch_end(self, *_) -> None:
         self._assert_layer_fsdp_instance()
 
-    def on_validation_batch_end(self, outputs, batch, batch_idx, dataloader_idx) -> None:
+    def on_validation_batch_end(self, *_) -> None:
         self._assert_layer_fsdp_instance()
 
-    def on_predict_batch_end(self, outputs, batch, batch_idx, dataloader_idx) -> None:
+    def on_predict_batch_end(self, *_) -> None:
         self._assert_layer_fsdp_instance()
 
     def _assert_layer_fsdp_instance(self) -> None:

--- a/tests/tests_pytorch/trainer/logging_/test_train_loop_logging.py
+++ b/tests/tests_pytorch/trainer/logging_/test_train_loop_logging.py
@@ -729,16 +729,16 @@ def test_on_epoch_logging_with_sum_and_on_batch_start(tmpdir):
             assert self.trainer._results["on_validation_epoch_end.on_validation_epoch_end"].value == 3.0
             assert all(v == 3 for v in self.trainer.callback_metrics.values())
 
-        def on_train_batch_start(self, batch, batch_idx):
+        def on_train_batch_start(self, *_):
             self.log("on_train_batch_start", 1.0, on_step=False, on_epoch=True, reduce_fx="sum")
 
-        def on_train_batch_end(self, outputs, batch, batch_idx):
+        def on_train_batch_end(self, *_):
             self.log("on_train_batch_end", 1.0, on_step=False, on_epoch=True, reduce_fx="sum")
 
-        def on_validation_batch_start(self, batch, batch_idx, dataloader_idx):
+        def on_validation_batch_start(self, *_):
             self.log("on_validation_batch_start", 1.0, reduce_fx="sum")
 
-        def on_validation_batch_end(self, outputs, batch, batch_idx, dataloader_idx):
+        def on_validation_batch_end(self, *_):
             self.log("on_validation_batch_end", 1.0, reduce_fx="sum")
 
     model = TestModel()

--- a/tests/tests_pytorch/trainer/optimization/test_manual_optimization.py
+++ b/tests/tests_pytorch/trainer/optimization/test_manual_optimization.py
@@ -184,7 +184,7 @@ class ManualOptimizationExtendedModel(BoringModel):
 
         return loss.detach() if self.detach else loss
 
-    def on_train_batch_end(self, outputs, batch, batch_idx):
+    def on_train_batch_end(self, *_):
         self.called["on_train_batch_end"] += 1
         after_before = self.layer.weight.clone()
         if self.should_update:
@@ -280,7 +280,7 @@ def test_manual_optimization_and_accumulated_gradient(tmpdir):
 
             return loss.detach() if self.detach else loss
 
-        def on_train_batch_end(self, outputs, batch, batch_idx):
+        def on_train_batch_end(self, *_):
             self.called["on_train_batch_end"] += 1
             after_before = self.layer.weight.clone()
             if self.should_update and self.should_have_updated:

--- a/tests/tests_pytorch/trainer/test_dataloaders.py
+++ b/tests/tests_pytorch/trainer/test_dataloaders.py
@@ -214,22 +214,22 @@ class Counter(Callback):
         self.val_batches_seen = 0
         self.test_batches_seen = 0
 
-    def on_train_batch_start(self, trainer, pl_module, batch, batch_idx):
+    def on_train_batch_start(self, *_):
         self.train_batches_seen += 1
 
-    def on_train_epoch_start(self, trainer, pl_module):
+    def on_train_epoch_start(self, *_):
         self.train_epoch_count += 1
 
-    def on_validation_batch_start(self, trainer, pl_module, batch, batch_idx, dataloader_idx):
+    def on_validation_batch_start(self, *_):
         self.val_batches_seen += 1
 
-    def on_test_batch_start(self, trainer, pl_module, batch, batch_idx, dataloader_idx):
+    def on_test_batch_start(self, *_):
         self.test_batches_seen += 1
 
-    def on_validation_epoch_start(self, trainer, pl_module):
+    def on_validation_epoch_start(self, *_):
         self.val_epoch_count += 1
 
-    def on_test_epoch_start(self, trainer, pl_module):
+    def on_test_epoch_start(self, *_):
         self.test_epoch_count += 1
 
 
@@ -1323,7 +1323,7 @@ def test_request_dataloader(tmpdir):
             loader = super().val_dataloader()
             return DataLoaderWrapper(loader)
 
-        def on_validation_batch_start(self, batch, batch_idx: int, dataloader_idx: int) -> None:
+        def on_validation_batch_start(self, *_):
             assert isinstance(self.trainer.val_dataloaders[0], DataLoaderWrapper)
             self.on_val_batch_start_called = True
 

--- a/tests/tests_pytorch/trainer/test_trainer.py
+++ b/tests/tests_pytorch/trainer/test_trainer.py
@@ -1278,7 +1278,7 @@ class CustomPredictionWriter(BasePredictionWriter):
         super().__init__(*args, **kwargs)
         self.output_dir = output_dir
 
-    def write_on_batch_end(self, trainer, pl_module, prediction, batch_indices, *args, **kwargs):
+    def write_on_batch_end(self, trainer, pl_module, prediction, batch_indices, *_):
         assert prediction.shape == torch.Size([1, 2])
         assert len(batch_indices) == 1
         self.write_on_batch_end_called = True
@@ -1427,7 +1427,7 @@ def test_index_batch_sampler_wrapper_with_iterable_dataset(dataset_cls, tmpdir):
             super().__init__(*args, **kwargs)
             self.output_dir = output_dir
 
-        def write_on_batch_end(self, trainer, pl_module, prediction, batch_indices, *args, **kwargs):
+        def write_on_batch_end(self, trainer, pl_module, prediction, batch_indices, *_):
             assert not batch_indices if is_iterable_dataset else batch_indices
 
     cb = CustomPredictionWriter(tmpdir)


### PR DESCRIPTION
## What does this PR do?

When you don't use multiple dataloaders, `training_step` does not take a `dataloader_idx` argument.
However, this is not the case for `on_{validation,test,predict}_batch_{start,end}`.

This PR makes it optional for them too.

This is a breaking change, as the users who define this argument and don't use multiple dataloaders now need to set `dataloader_idx=0` in their signature, or remove it if they don't need it.

cc @justusschock @awaelchli @borda @carmocca