### PR TITLE
Make the trainer a required loop argument

### DIFF
--- a/src/lightning/pytorch/loops/dataloader/dataloader_loop.py
+++ b/src/lightning/pytorch/loops/dataloader/dataloader_loop.py
@@ -17,6 +17,7 @@ from typing import Sequence
 
 from torch.utils.data import DataLoader
 
+import lightning.pytorch as pl
 from lightning.pytorch.loops.loop import _Loop
 from lightning.pytorch.loops.progress import DataLoaderProgress
 
@@ -24,8 +25,8 @@ from lightning.pytorch.loops.progress import DataLoaderProgress
 class _DataLoaderLoop(_Loop):
     """Base class to loop over all dataloaders."""
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, trainer: "pl.Trainer") -> None:
+        super().__init__(trainer)
         self.dataloader_progress = DataLoaderProgress()
 
     @property

--- a/src/lightning/pytorch/loops/dataloader/evaluation_loop.py
+++ b/src/lightning/pytorch/loops/dataloader/evaluation_loop.py
@@ -21,6 +21,7 @@ from lightning_utilities.core.apply_func import apply_to_collection
 from torch import Tensor
 from torch.utils.data.dataloader import DataLoader
 
+import lightning.pytorch as pl
 from lightning.pytorch.callbacks.progress.rich_progress import _RICH_AVAILABLE
 from lightning.pytorch.loops.dataloader import _DataLoaderLoop
 from lightning.pytorch.loops.epoch import _EvaluationEpochLoop
@@ -42,9 +43,9 @@ class _EvaluationLoop(_DataLoaderLoop):
     its ``advance()`` method.
     """
 
-    def __init__(self, verbose: bool = True, inference_mode: bool = True) -> None:
-        super().__init__()
-        self.epoch_loop = _EvaluationEpochLoop()
+    def __init__(self, trainer: "pl.Trainer", verbose: bool = True, inference_mode: bool = True) -> None:
+        super().__init__(trainer)
+        self.epoch_loop = _EvaluationEpochLoop(trainer)
         self.verbose = verbose
         self.inference_mode = inference_mode
 

--- a/src/lightning/pytorch/loops/dataloader/prediction_loop.py
+++ b/src/lightning/pytorch/loops/dataloader/prediction_loop.py
@@ -2,6 +2,7 @@ from typing import Any, List, Optional, Sequence, Union
 
 from torch.utils.data import DataLoader
 
+import lightning.pytorch as pl
 from lightning.pytorch.loops.dataloader.dataloader_loop import _DataLoaderLoop
 from lightning.pytorch.loops.epoch.prediction_epoch_loop import _PredictionEpochLoop
 from lightning.pytorch.loops.utilities import _no_grad_context, _set_sampler_epoch
@@ -18,10 +19,10 @@ class _PredictionLoop(_DataLoaderLoop):
     its ``advance()`` method.
     """
 
-    def __init__(self, inference_mode: bool = True) -> None:
-        super().__init__()
+    def __init__(self, trainer: "pl.Trainer", inference_mode: bool = True) -> None:
+        super().__init__(trainer)
         self.epoch_batch_indices: List[List[List[int]]] = []  # used by PredictionWriter
-        self.epoch_loop = _PredictionEpochLoop()
+        self.epoch_loop = _PredictionEpochLoop(trainer)
         self.inference_mode = inference_mode
 
         self._results = None  # for `trainer._results` access

--- a/src/lightning/pytorch/loops/epoch/evaluation_epoch_loop.py
+++ b/src/lightning/pytorch/loops/epoch/evaluation_epoch_loop.py
@@ -15,6 +15,7 @@
 from collections import OrderedDict
 from typing import Any, Optional, Union
 
+import lightning.pytorch as pl
 from lightning.pytorch.loops.fetchers import _DataFetcher, _DataLoaderIterDataFetcher
 from lightning.pytorch.loops.loop import _Loop
 from lightning.pytorch.loops.progress import BatchProgress
@@ -31,8 +32,8 @@ class _EvaluationEpochLoop(_Loop):
     state).
     """
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, trainer: "pl.Trainer") -> None:
+        super().__init__(trainer)
         self.batch_progress = BatchProgress()
 
         self._dl_max_batches: Union[int, float] = 0

--- a/src/lightning/pytorch/loops/epoch/prediction_epoch_loop.py
+++ b/src/lightning/pytorch/loops/epoch/prediction_epoch_loop.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Iterator, List, Tuple, Union
 
 import torch
 
+import lightning.pytorch as pl
 from lightning.fabric.utilities import move_data_to_device
 from lightning.pytorch.callbacks import BasePredictionWriter
 from lightning.pytorch.loops.loop import _Loop
@@ -17,8 +18,8 @@ warning_cache = WarningCache()
 class _PredictionEpochLoop(_Loop):
     """Loop performing prediction on arbitrary sequentially used dataloaders."""
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, trainer: "pl.Trainer") -> None:
+        super().__init__(trainer)
         self.return_predictions = False
         self.predictions: List[Any] = []
         self.current_batch_indices: List[int] = []

--- a/src/lightning/pytorch/loops/epoch/training_epoch_loop.py
+++ b/src/lightning/pytorch/loops/epoch/training_epoch_loop.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, Optional, Union
 
 import torch
 
+import lightning.pytorch as pl
 from lightning.pytorch import loops  # import as loops to avoid circular imports
 from lightning.pytorch.loops.fetchers import _DataFetcher, _DataLoaderIterDataFetcher
 from lightning.pytorch.loops.optimization import _AutomaticOptimization, _ManualOptimization
@@ -55,8 +56,8 @@ class _TrainingEpochLoop(loops._Loop):
         max_steps: The maximum number of steps (batches) to process
     """
 
-    def __init__(self, min_steps: Optional[int] = None, max_steps: int = -1) -> None:
-        super().__init__()
+    def __init__(self, trainer: "pl.Trainer", min_steps: Optional[int] = None, max_steps: int = -1) -> None:
+        super().__init__(trainer)
         if max_steps < -1:
             raise MisconfigurationException(
                 f"`max_steps` must be a non-negative integer or -1 (infinite steps). You passed in {max_steps}."
@@ -67,10 +68,10 @@ class _TrainingEpochLoop(loops._Loop):
         self.batch_progress = BatchProgress()
         self.scheduler_progress = SchedulerProgress()
 
-        self.automatic_optimization = _AutomaticOptimization()
-        self.manual_optimization = _ManualOptimization()
+        self.automatic_optimization = _AutomaticOptimization(trainer)
+        self.manual_optimization = _ManualOptimization(trainer)
 
-        self.val_loop = loops._EvaluationLoop(verbose=False, inference_mode=False)
+        self.val_loop = loops._EvaluationLoop(trainer, verbose=False, inference_mode=False)
 
         self._results = _ResultCollection(training=True)
         self._warning_cache = WarningCache()

--- a/src/lightning/pytorch/loops/fit_loop.py
+++ b/src/lightning/pytorch/loops/fit_loop.py
@@ -14,6 +14,7 @@
 import logging
 from typing import Optional
 
+import lightning.pytorch as pl
 from lightning.pytorch.loops import _Loop
 from lightning.pytorch.loops.epoch import _TrainingEpochLoop
 from lightning.pytorch.loops.fetchers import _DataFetcher
@@ -57,10 +58,11 @@ class _FitLoop(_Loop):
 
     def __init__(
         self,
+        trainer: "pl.Trainer",
         min_epochs: Optional[int] = 0,
         max_epochs: Optional[int] = None,
     ) -> None:
-        super().__init__()
+        super().__init__(trainer)
         if isinstance(max_epochs, int) and max_epochs < -1:
             # Allow max_epochs to be zero, since this will be handled by fit_loop.done
             raise MisconfigurationException(
@@ -69,7 +71,7 @@ class _FitLoop(_Loop):
 
         self.max_epochs = max_epochs
         self.min_epochs = min_epochs
-        self.epoch_loop = _TrainingEpochLoop()
+        self.epoch_loop = _TrainingEpochLoop(trainer)
         self.epoch_progress = Progress()
 
         self._is_fresh_start_epoch: bool = True

--- a/src/lightning/pytorch/loops/loop.py
+++ b/src/lightning/pytorch/loops/loop.py
@@ -20,23 +20,9 @@ from lightning.pytorch.loops.progress import BaseProgress
 class _Loop:
     """Basic Loops interface."""
 
-    def __init__(self) -> None:
+    def __init__(self, trainer: "pl.Trainer") -> None:
         self._restarting = False
-        self._trainer: Optional["pl.Trainer"] = None
-
-    @property
-    def trainer(self) -> "pl.Trainer":
-        if self._trainer is None:
-            raise RuntimeError("The loop is not attached to a Trainer.")
-        return self._trainer
-
-    @trainer.setter
-    def trainer(self, trainer: "pl.Trainer") -> None:
-        """Connects this loop's trainer and its children."""
-        self._trainer = trainer
-        for v in self.__dict__.values():
-            if isinstance(v, _Loop):
-                v.trainer = trainer
+        self.trainer = trainer
 
     @property
     def restarting(self) -> bool:

--- a/src/lightning/pytorch/loops/optimization/automatic.py
+++ b/src/lightning/pytorch/loops/optimization/automatic.py
@@ -19,6 +19,7 @@ import torch
 from torch import Tensor
 from torch.optim import Optimizer
 
+import lightning.pytorch as pl
 from lightning.pytorch.loops.loop import _Loop
 from lightning.pytorch.loops.optimization.closure import AbstractClosure, OutputResult
 from lightning.pytorch.loops.progress import OptimizationProgress
@@ -149,8 +150,8 @@ class _AutomaticOptimization(_Loop):
 
     output_result_cls = ClosureResult
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, trainer: "pl.Trainer") -> None:
+        super().__init__(trainer)
         self.optim_progress: OptimizationProgress = OptimizationProgress()
         self._skip_backward: bool = False
 

--- a/src/lightning/pytorch/loops/optimization/manual.py
+++ b/src/lightning/pytorch/loops/optimization/manual.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, Optional
 
 from torch import Tensor
 
+import lightning.pytorch as pl
 from lightning.pytorch.core.optimizer import do_nothing_closure
 from lightning.pytorch.loops import _Loop
 from lightning.pytorch.loops.optimization.closure import OutputResult
@@ -76,8 +77,8 @@ class _ManualOptimization(_Loop):
 
     output_result_cls = ManualResult
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, trainer: "pl.Trainer") -> None:
+        super().__init__(trainer)
         # since manual optimization does not track lr scheduler or optimizer frequencies, we use a simpler progress than
         # `OptimizationProgress`
         self.optim_step_progress = Progress.from_defaults(ReadyCompletedTracker)

--- a/src/lightning/pytorch/trainer/trainer.py
+++ b/src/lightning/pytorch/trainer/trainer.py
@@ -313,15 +313,11 @@ class Trainer:
         self._signal_connector = SignalConnector(self)
 
         # init loops
-        self.fit_loop = _FitLoop(min_epochs=min_epochs, max_epochs=max_epochs)
-        self.fit_loop.epoch_loop = _TrainingEpochLoop(min_steps=min_steps, max_steps=max_steps)
-        self.validate_loop = _EvaluationLoop(inference_mode=inference_mode)
-        self.test_loop = _EvaluationLoop(inference_mode=inference_mode)
-        self.predict_loop = _PredictionLoop(inference_mode=inference_mode)
-        self.fit_loop.trainer = self
-        self.validate_loop.trainer = self
-        self.test_loop.trainer = self
-        self.predict_loop.trainer = self
+        self.fit_loop = _FitLoop(self, min_epochs=min_epochs, max_epochs=max_epochs)
+        self.fit_loop.epoch_loop = _TrainingEpochLoop(self, min_steps=min_steps, max_steps=max_steps)
+        self.validate_loop = _EvaluationLoop(self, inference_mode=inference_mode)
+        self.test_loop = _EvaluationLoop(self, inference_mode=inference_mode)
+        self.predict_loop = _PredictionLoop(self, inference_mode=inference_mode)
 
         self.accumulate_grad_batches = accumulate_grad_batches
 

--- a/tests/tests_pytorch/loops/test_loop_state_dict.py
+++ b/tests/tests_pytorch/loops/test_loop_state_dict.py
@@ -20,13 +20,10 @@ from lightning.pytorch.trainer.trainer import Trainer
 def test_loops_state_dict():
     trainer = Trainer()
 
-    fit_loop = _FitLoop()
-
-    fit_loop.trainer = trainer
+    fit_loop = _FitLoop(trainer)
     state_dict = fit_loop.state_dict()
 
-    new_fit_loop = _FitLoop()
-    new_fit_loop.trainer = trainer
+    new_fit_loop = _FitLoop(trainer)
 
     new_fit_loop.load_state_dict(state_dict)
     assert fit_loop.state_dict() == new_fit_loop.state_dict()

--- a/tests/tests_pytorch/loops/test_training_loop.py
+++ b/tests/tests_pytorch/loops/test_training_loop.py
@@ -135,9 +135,8 @@ def test_should_stop_mid_epoch(tmpdir):
 
 
 def test_fit_loop_done_log_messages(caplog):
-    fit_loop = _FitLoop(max_epochs=1)
     trainer = Mock(spec=Trainer)
-    fit_loop.trainer = trainer
+    fit_loop = _FitLoop(trainer, max_epochs=1)
 
     trainer.should_stop = False
     trainer.num_training_batches = 5

--- a/tests/tests_pytorch/trainer/flags/test_inference_mode.py
+++ b/tests/tests_pytorch/trainer/flags/test_inference_mode.py
@@ -50,6 +50,8 @@ def test_eval_inference_mode(tmp_path, trainer_fn):
 
 
 def test_no_grad_context():
+    trainer = Mock()
+
     class Foo:
         @_no_grad_context
         def run(self):
@@ -64,13 +66,13 @@ def test_no_grad_context():
         def run(self):
             ...
 
-    f = Foo()
+    f = Foo(trainer)
     with pytest.raises(TypeError, match="Foo.inference_mode` needs to be defined"):
         f.run()
 
     class Foo(_Loop):
         def __init__(self):
-            super().__init__()
+            super().__init__(trainer)
             self.inference_mode = False
 
         @_no_grad_context
@@ -78,7 +80,6 @@ def test_no_grad_context():
             ...
 
     f = Foo()
-    f.trainer = Mock()
     with mock.patch("torch.no_grad") as no_grad_mock:
         f.run()
     no_grad_mock.assert_called_once_with()


### PR DESCRIPTION
## What does this PR do?

Since loop customization was removed, the loops no longer need to set the Trainer instance after the loop is instantiated.

This PR simplifies the logic by making it an init argument.

This also has the advantage that loop attributes can now be initialized in the `__init__` based on the Trainer state, avoiding having to create them later when the reference is set.

cc @justusschock @awaelchli @carmocca