### PR TITLE
[App] Reserve APP_SERVER_PORT in cloud port allocation

### DIFF
--- a/src/lightning/app/utilities/network.py
+++ b/src/lightning/app/utilities/network.py
@@ -66,7 +66,7 @@ def find_free_network_port() -> int:
 def _find_free_network_port_cloudspace():
     """Finds a free port in the exposed range when running in a cloudspace."""
     for port in range(
-        constants.APP_SERVER_PORT,
+        constants.APP_SERVER_PORT + 1,  # constants.APP_SERVER_PORT is reserved for the app server
         constants.APP_SERVER_PORT + constants.LIGHTNING_CLOUDSPACE_EXPOSED_PORT_COUNT,
     ):
         if port in _reserved_ports:

--- a/tests/tests_app/utilities/test_network.py
+++ b/tests/tests_app/utilities/test_network.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 
+from lightning.app.core import constants
 from lightning.app.utilities.network import find_free_network_port, LightningClient
 
 
@@ -39,6 +40,9 @@ def test_find_free_network_port_cloudspace(_, patch_constants):
 
     # Check that all ports are unique
     assert len(ports) == num_ports
+
+    # Shouldn't use the APP_SERVER_PORT
+    assert constants.APP_SERVER_PORT not in ports
 
 
 def test_lightning_client_retry_enabled():


### PR DESCRIPTION
## What does this PR do?

There is a bug where we can accidentally assign the APP_SERVER_PORT to a work. This changes the logic to start looking from `APP_SERVER_PORT + 1` to avoid the issue.

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


cc @borda