### PR TITLE
Trigger colossalai integration test in CI

### DIFF
--- a/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
@@ -837,6 +837,7 @@ def test_connector_defaults_match_trainer_defaults():
         assert connector_default == trainer_defaults[name]
 
 
+@RunIf(min_cuda_gpus=1)  # trigger this test on our GPU pipeline, because we don't install the package on the CPU suite
 @pytest.mark.skipif(not package_available("lightning_colossalai"), reason="Requires Colossal AI Strategy")
 def test_colossalai_external_strategy(monkeypatch):
     with mock.patch(


### PR DESCRIPTION
## What does this PR do?

Follow up to #16778 to enable the test in CI. 
Currently, the test gets skipped because 1) we don't install the package on the CPU jobs and 2) it didn't run on the GPU jobs either because it didn't have a GPU test marker. 

cc @carmocca @akihironitta @borda