### PR TITLE
add launch() call

### DIFF
--- a/docs/source-pytorch/fabric/fundamentals/convert.rst
+++ b/docs/source-pytorch/fabric/fundamentals/convert.rst
@@ -13,6 +13,7 @@ Here are five easy steps to let :class:`~lightning_fabric.fabric.Fabric` scale y
     from lightning.fabric import Fabric
 
     fabric = Fabric()
+    fabric.launch()
 
 **Step 2:** Call :meth:`~lightning_fabric.fabric.Fabric.setup` on each model and optimizer pair and :meth:`~lightning_fabric.fabric.Fabric.setup_dataloaders` on all your data loaders.
 


### PR DESCRIPTION
Adding `fabric.launch()` here. Not sure if it is strictly required in this tutorial, but maybe it's best practice (so it would work if someone uses multiple GPUs). At least this way it's consistent with the overview page at https://pytorch-lightning.readthedocs.io/en/stable/fabric/fabric.html then.