### PR TITLE
Remove redundant strategy property

### DIFF
--- a/src/lightning/pytorch/strategies/ddp.py
+++ b/src/lightning/pytorch/strategies/ddp.py
@@ -120,10 +120,6 @@ class DDPStrategy(ParallelStrategy):
         return dict(num_replicas=(self.num_nodes * self.num_processes), rank=self.global_rank)
 
     @property
-    def _is_single_process_single_device(self) -> bool:
-        return True
-
-    @property
     def process_group_backend(self) -> Optional[str]:
         return self._process_group_backend
 
@@ -193,7 +189,7 @@ class DDPStrategy(ParallelStrategy):
 
     def _register_ddp_hooks(self) -> None:
         log.debug(f"{self.__class__.__name__}: registering ddp hooks")
-        if self.root_device.type == "cuda" and self._is_single_process_single_device:
+        if self.root_device.type == "cuda":
             assert isinstance(self.model, DistributedDataParallel)
             register_ddp_comm_hook(
                 model=self.model,

--- a/src/lightning/pytorch/strategies/ddp_spawn.py
+++ b/src/lightning/pytorch/strategies/ddp_spawn.py
@@ -124,10 +124,6 @@ class DDPSpawnStrategy(ParallelStrategy):
         return distributed_sampler_kwargs
 
     @property
-    def _is_single_process_single_device(self) -> bool:
-        return True
-
-    @property
     def process_group_backend(self) -> Optional[str]:
         return self._process_group_backend
 
@@ -192,7 +188,7 @@ class DDPSpawnStrategy(ParallelStrategy):
     def _register_ddp_hooks(self) -> None:
         # currently, DDP communication hooks only work with NCCL backend and SPSD (single process single device) mode
         # https://github.com/pytorch/pytorch/blob/v1.8.0/torch/nn/parallel/distributed.py#L1080-L1084
-        if self.root_device.type == "cuda" and self._is_single_process_single_device:
+        if self.root_device.type == "cuda":
             assert isinstance(self.model, DistributedDataParallel)
             register_ddp_comm_hook(
                 model=self.model,


### PR DESCRIPTION
## What does this PR do?

The `_is_single_process_single_device` is redundant since DDP2 was removed.

cc @borda @justusschock @awaelchli