### PR TITLE
Add back external colossalai test

### DIFF
--- a/requirements/pytorch/strategies.txt
+++ b/requirements/pytorch/strategies.txt
@@ -2,4 +2,4 @@
 #  in case you want to preserve/enforce restrictions on the latest compatible version, add "strict" as an in-line comment
 
 deepspeed>=0.6.0, <0.8.0  # TODO: Include 0.8.x after https://github.com/microsoft/DeepSpeed/commit/b587c7e85470329ac25df7c7c2521ff9b2833db7 gets released
-lightning-colossalai==0.1.0dev
+lightning-colossalai==0.1.0dev1

--- a/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
@@ -841,7 +841,6 @@ def test_connector_defaults_match_trainer_defaults():
 
 @RunIf(min_cuda_gpus=1)  # trigger this test on our GPU pipeline, because we don't install the package on the CPU suite
 @pytest.mark.skipif(not package_available("lightning_colossalai"), reason="Requires Colossal AI Strategy")
-@pytest.mark.skip
 def test_colossalai_external_strategy(monkeypatch):
     with mock.patch(
         "lightning.pytorch.trainer.connectors.accelerator_connector._LIGHTNING_COLOSSALAI_AVAILABLE", False


### PR DESCRIPTION
## What does this PR do?

Follow-Up from #16783 .

Adds back the colossal-ai test for our external strategy after https://github.com/Lightning-AI/lightning-colossalai/releases/tag/0.1.0.dev1


cc @borda