### PR TITLE
Fix amp ddp test in Fabric

### DIFF
--- a/tests/tests_fabric/plugins/precision/test_amp_integration.py
+++ b/tests/tests_fabric/plugins/precision/test_amp_integration.py
@@ -68,9 +68,7 @@ class MixedPrecisionBoringFabric(BoringFabric):
     ],
 )
 def test_amp(accelerator, precision, expected_dtype):
-    # TODO: devices>1 fails with:
-    # DDP expects same model across all ranks, but Rank 0 has 2 params, while rank 1 has inconsistent 1 params
-    fabric = MixedPrecisionBoringFabric(accelerator=accelerator, precision=precision, devices=2)
+    fabric = MixedPrecisionBoringFabric(accelerator=accelerator, precision=precision, devices=2, strategy="ddp_spawn")
     fabric.expected_dtype = expected_dtype
     fabric.run()
 

--- a/tests/tests_fabric/plugins/precision/test_amp_integration.py
+++ b/tests/tests_fabric/plugins/precision/test_amp_integration.py
@@ -70,7 +70,7 @@ class MixedPrecisionBoringFabric(BoringFabric):
 def test_amp(accelerator, precision, expected_dtype):
     # TODO: devices>1 fails with:
     # DDP expects same model across all ranks, but Rank 0 has 2 params, while rank 1 has inconsistent 1 params
-    fabric = MixedPrecisionBoringFabric(accelerator=accelerator, precision=precision, devices=1)
+    fabric = MixedPrecisionBoringFabric(accelerator=accelerator, precision=precision, devices=2)
     fabric.expected_dtype = expected_dtype
     fabric.run()
 


### PR DESCRIPTION
## What does this PR do?

Fixes #16852

One can either mark the test standalone, or fix the strategy to ddp_spawn. I chose the latter. 


cc @carmocca @justusschock @awaelchli @borda