### PR TITLE
Explain `configure_sharded_model` in ColossalAI docs

### DIFF
--- a/docs/source-pytorch/advanced/third_party/colossalai.rst
+++ b/docs/source-pytorch/advanced/third_party/colossalai.rst
@@ -61,6 +61,25 @@ See a full example of a benchmark with the a `GPT-2 model <https://github.com/hp
 
 .. _colossal_placement_policy:
 
+Model Definition
+================
+
+ColossalAI requires the layers of your model to be created in the special :meth:`~lightning.pytorch.core.module.LightningModule.configure_sharded_model` hook.
+This allows the strategy to efficiently shard your model before materializing the weight tensors.
+
+.. code-block:: python
+
+    class MyModel(LightningModule):
+        def __init__(self):
+            super().__init__()
+            # don't instantiate layers here
+            # move the creation of layers to `configure_sharded_model`
+
+        def configure_sharded_model(self):
+            # create all your layers here
+            self.layers = nn.Sequential(...)
+
+
 Placement Policy
 ================
 


### PR DESCRIPTION
## What does this PR do?

Fixes #16824

The user didn't know that they had to create the model under the special hook.

