### PR TITLE
Promote `Fabric.launch()` as the default experience in Fabric docs

### DIFF
--- a/docs/source-pytorch/fabric/fundamentals/convert.rst
+++ b/docs/source-pytorch/fabric/fundamentals/convert.rst
@@ -14,35 +14,40 @@ Here are five easy steps to let :class:`~lightning_fabric.fabric.Fabric` scale y
 
     fabric = Fabric()
 
-**Step 2:** Call :meth:`~lightning_fabric.fabric.Fabric.setup` on each model and optimizer pair and :meth:`~lightning_fabric.fabric.Fabric.setup_dataloaders` on all your data loaders.
+**Step 2:** Call :class:`~lightning_fabric.fabric.Fabric.launch` if you intend to use multiple devices (e.g., multi-GPU).
+
+.. code-block:: python
+
+    fabric.launch()
+
+**Step 3:** Call :meth:`~lightning_fabric.fabric.Fabric.setup` on each model and optimizer pair and :meth:`~lightning_fabric.fabric.Fabric.setup_dataloaders` on all your data loaders.
 
 .. code-block:: python
 
     model, optimizer = fabric.setup(model, optimizer)
     dataloader = fabric.setup_dataloaders(dataloader)
 
-**Step 3:** Remove all ``.to`` and ``.cuda`` calls since :class:`~lightning_fabric.fabric.Fabric` will take care of it.
+**Step 4:** Remove all ``.to`` and ``.cuda`` calls since :class:`~lightning_fabric.fabric.Fabric` will take care of it.
 
 .. code-block:: diff
 
   - model.to(device)
   - batch.to(device)
 
-**Step 4:** Replace ``loss.backward()`` by ``fabric.backward(loss)``.
+**Step 5:** Replace ``loss.backward()`` by ``fabric.backward(loss)``.
 
 .. code-block:: diff
 
   - loss.backward()
   + fabric.backward(loss)
 
-**Step 5:** Run the script from the terminal with
+
+These are all code changes required to prepare your script for Fabric.
+You can now simply run from the terminal:
 
 .. code-block:: bash
 
-    lightning run model path/to/train.py
-
-or use the :meth:`~lightning_fabric.fabric.Fabric.launch` method in a notebook.
-Learn more about :doc:`launching distributed training <launch>`.
+    python path/to/your/script.py
 
 |
 

--- a/docs/source-pytorch/fabric/fundamentals/convert.rst
+++ b/docs/source-pytorch/fabric/fundamentals/convert.rst
@@ -14,7 +14,7 @@ Here are five easy steps to let :class:`~lightning_fabric.fabric.Fabric` scale y
 
     fabric = Fabric()
 
-**Step 2:** Call :class:`~lightning_fabric.fabric.Fabric.launch` if you intend to use multiple devices (e.g., multi-GPU).
+**Step 2:** Call :meth:`~lightning_fabric.fabric.Fabric.launch` if you intend to use multiple devices (e.g., multi-GPU).
 
 .. code-block:: python
 

--- a/docs/source-pytorch/fabric/fundamentals/launch.rst
+++ b/docs/source-pytorch/fabric/fundamentals/launch.rst
@@ -13,17 +13,51 @@ To run your code distributed across many devices and many machines, you need to 
 ----
 
 
+*************
+Simple Launch
+*************
+
+You can configure and launch processes on your machine directly with Fabric's :meth:`~lightning_fabric.fabric.Fabric.launch` method:
+
+.. code-block:: python
+
+    # train.py
+    ...
+
+    # Configure accelerator, devices, num_nodes, etc.
+    fabric = Fabric(devices=4, ...)
+
+    # This launches itself into multiple processes
+    fabric.launch()
+
+
+In the command line, you run this like any other Python script:
+
+.. code-block:: bash
+
+    python train.py
+
+
+This is the recommended way for running on a single machine and is the most convenient method for development and debugging.
+
+It is also possible to use Fabric in a Jupyter notebook (including Google Colab, Kaggle, etc.) and launch multiple processes there.
+You can learn more about it :ref:`here <Fabric in Notebooks>`.
+
+
+----
+
+
 *******************
 Launch with the CLI
 *******************
 
-The most convenient way to do all of the above is to run your Python script directly with the built-in command line interface (CLI):
+An alternative way to launch your Python script in multiple processes is to use the dedicated command line interface (CLI):
 
 .. code-block:: bash
 
     lightning run model path/to/your/script.py
 
-This is essentially the same as running ``python path/to/your/script.py``, but it also lets you configure:
+This is essentially the same as running ``python path/to/your/script.py``, but it also lets you configure the following settings externally without changing your code:
 
 - ``--accelerator``: The accelerator to use
 - ``--devices``: The number of devices to use (per machine)
@@ -106,46 +140,6 @@ Or `DeepSpeed Zero3 <https://www.deepspeed.ai/2021/03/07/zero3-offload.html>`_ w
         --devices=auto \
         --accelerator=auto \
         --precision=16
-
-
-----
-
-
-*******************
-Programmatic Launch
-*******************
-
-Launching the processes programmatically directly from within the Python script is also possible.
-This is useful for debugging or when you want to build your own CLI around Fabric.
-
-.. code-block:: python
-
-    # train.py
-    ...
-
-    # Configure accelerator, devices, num_nodes, etc.
-    fabric = Fabric(devices=4, ...)
-
-    # This launches itself into multiple processes
-    fabric.launch()
-
-
-In the command line, you run this like any other Python script:
-
-.. code-block:: bash
-
-    python train.py
-
-
-----
-
-
-************************
-Launch inside a Notebook
-************************
-
-It is also possible to use Fabric in a Jupyter notebook (including Google Colab, Kaggle, etc.) and launch multiple processes there.
-You can learn more about it :ref:`here <Fabric in Notebooks>`.
 
 
 ----


### PR DESCRIPTION
## What does this PR do?

In response to feedback, we will change the introduction to showcase `Fabric.launch` instead of the `lightning run model` CLI commands. This is an easier onboarding experience for new users who might be turned off by learning new CLI commands. 

cc @borda @carmocca @justusschock @awaelchli @rasbt 

Closes #16799