### PR TITLE
Disable the IPU check group

### DIFF
--- a/.github/checkgroup.yml
+++ b/.github/checkgroup.yml
@@ -90,24 +90,25 @@ subprojects:
     checks:
       - "pytorch-lightning (HPUs)"
 
-  - id: "pytorch_lightning: Azure IPU"
-    paths:
-      - ".actions/**"
-      - ".azure/ipu-tests.yml"
-      - "requirements/fabric/**"
-      - "src/lightning/fabric/**"
-      - "src/lightning_fabric/*"
-      - "requirements/pytorch/**"
-      - "src/lightning/pytorch/**"
-      - "src/pytorch_lightning/*"
-      - "tests/tests_pytorch/**"
-      - "pyproject.toml"  # includes pytest config
-      - "!requirements/docs.txt"
-      - "!requirements/*/docs.txt"
-      - "!*.md"
-      - "!**/*.md"
-    checks:
-      - "pytorch-lightning (IPUs)"
+# TODO: enable IPU again once machine is ready
+#  - id: "pytorch_lightning: Azure IPU"
+#    paths:
+#      - ".actions/**"
+#      - ".azure/ipu-tests.yml"
+#      - "requirements/fabric/**"
+#      - "src/lightning/fabric/**"
+#      - "src/lightning_fabric/*"
+#      - "requirements/pytorch/**"
+#      - "src/lightning/pytorch/**"
+#      - "src/pytorch_lightning/*"
+#      - "tests/tests_pytorch/**"
+#      - "pyproject.toml"  # includes pytest config
+#      - "!requirements/docs.txt"
+#      - "!requirements/*/docs.txt"
+#      - "!*.md"
+#      - "!**/*.md"
+#    checks:
+#      - "pytorch-lightning (IPUs)"
 
   # TODO: since this job has intermittent availability, it cannot be required
   #- id: "pytorch-lightning: TPU workflow"


### PR DESCRIPTION
## What does this PR do?

The IPU machine is currently down. We will disable the PR merge requirement in checkgroup until the machine is available again.


cc @carmocca @akihironitta @borda