### PR TITLE
Allow specifying output file used by TQDMProgressBar

### DIFF
--- a/src/lightning/pytorch/callbacks/progress/tqdm_progress.py
+++ b/src/lightning/pytorch/callbacks/progress/tqdm_progress.py
@@ -98,12 +98,14 @@ class TQDMProgressBar(ProgressBarBase):
             together. This corresponds to
             :paramref:`~lightning.pytorch.trainer.trainer.Trainer.process_position` in the
             :class:`~lightning.pytorch.trainer.trainer.Trainer`.
+        file: The file stream to write the progress bar to. Defaults to ``sys.stdout``.
     """
 
-    def __init__(self, refresh_rate: int = 1, process_position: int = 0):
+    def __init__(self, refresh_rate: int = 1, process_position: int = 0, file: Any = sys.stdout):
         super().__init__()
         self._refresh_rate = self._resolve_refresh_rate(refresh_rate)
         self._process_position = process_position
+        self._file = file
         self._enabled = True
         self._train_progress_bar: Optional[_tqdm] = None
         self._val_progress_bar: Optional[_tqdm] = None
@@ -184,7 +186,7 @@ class TQDMProgressBar(ProgressBarBase):
             disable=self.is_disabled,
             leave=False,
             dynamic_ncols=True,
-            file=sys.stdout,
+            file=self._file,
         )
         return bar
 
@@ -196,7 +198,7 @@ class TQDMProgressBar(ProgressBarBase):
             disable=self.is_disabled,
             leave=True,
             dynamic_ncols=True,
-            file=sys.stdout,
+            file=self._file,
             smoothing=0,
         )
         return bar
@@ -209,7 +211,7 @@ class TQDMProgressBar(ProgressBarBase):
             disable=self.is_disabled,
             leave=True,
             dynamic_ncols=True,
-            file=sys.stdout,
+            file=self._file,
             smoothing=0,
         )
         return bar
@@ -224,7 +226,7 @@ class TQDMProgressBar(ProgressBarBase):
             disable=self.is_disabled,
             leave=not has_main_bar,
             dynamic_ncols=True,
-            file=sys.stdout,
+            file=self._file,
         )
         return bar
 
@@ -236,7 +238,7 @@ class TQDMProgressBar(ProgressBarBase):
             disable=self.is_disabled,
             leave=True,
             dynamic_ncols=True,
-            file=sys.stdout,
+            file=self._file,
         )
         return bar
 


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

The TQDMProgressBar currently hard-codes all bars to output to stdout. This is different from the default TQDM behavior, which outputs to stderr, and causes difficulty when redirecting output. For example...

```bash
python -u train_my_model.py | tee output.log
```

... will result in the progress bars being saved into `output.log`, which is undesirable.

The proposed changes keep stdout as the default output file used by TQDMProgressBar for backwards-compatibility, but optionally allows specifying an alternative output file, such as stderr, via the constructor, e.g.

```python
bar = TQDMProgressBar(file=sys.stderr)
```

Fixes #N/A (no issue filed)

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

No breaking changes.

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
  - No (tiny change)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
