### PR TITLE
Switch theme for Fabric

### DIFF
--- a/docs/source-fabric/conf.py
+++ b/docs/source-fabric/conf.py
@@ -92,7 +92,8 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_paramlinks",
     "sphinx_togglebutton",
-    "lai_sphinx_theme.extensions.lightning",
+    # "lai_sphinx_theme.extensions.lightning",
+    "pt_lightning_sphinx_theme.extensions.lightning",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -154,7 +155,8 @@ pygments_style = None
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "lai_sphinx_theme"
+# html_theme = "lai_sphinx_theme"
+html_theme = "pt_lightning_sphinx_theme"
 html_theme_path = [os.environ.get("LIT_SPHINX_PATH", lai_sphinx_theme.get_html_theme_path())]
 
 # Theme options are theme-specific and customize the look and feel of a theme

--- a/docs/source-fabric/conf.py
+++ b/docs/source-fabric/conf.py
@@ -16,7 +16,7 @@ import os
 import shutil
 import sys
 
-import lai_sphinx_theme
+import pt_lightning_sphinx_theme
 
 import lightning
 
@@ -157,7 +157,7 @@ pygments_style = None
 #
 # html_theme = "lai_sphinx_theme"
 html_theme = "pt_lightning_sphinx_theme"
-html_theme_path = [os.environ.get("LIT_SPHINX_PATH", lai_sphinx_theme.get_html_theme_path())]
+html_theme_path = [os.environ.get("LIT_SPHINX_PATH", pt_lightning_sphinx_theme.get_html_theme_path())]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/requirements/fabric/docs.txt
+++ b/requirements/fabric/docs.txt
@@ -1,4 +1,4 @@
 -r ../docs.txt
 
-lai-sphinx-theme
+pt-lightning-sphinx-theme @ https://github.com/Lightning-AI/lightning_sphinx_theme/archive/master.zip
 tensorboard


### PR DESCRIPTION
## What does this PR do?

Temporarily switch the theme for the Fabric docs back to the PL theme until layout and display issues get fixed in the new theme. There are several issues in the new theme:

- Code block styling has accessibility problems (unreadable, dark texts)
- Code block theme can't properly style code diffs
- Spacing in navigation bar is off.
- Main header navigation disappears and reappears when loading pages.
- Breadcrumb navigation bar disappears when scrolling
- etc. 

After resolving these, we can switch back to the new theme :) 


cc @borda @carmocca @justusschock @awaelchli