### PR TITLE
Add check for bf16 in deepspeed inference

### DIFF
--- a/src/lightning/pytorch/strategies/deepspeed.py
+++ b/src/lightning/pytorch/strategies/deepspeed.py
@@ -544,6 +544,8 @@ class DeepSpeedStrategy(DDPStrategy):
         inference_config = {"train_micro_batch_size_per_gpu": 1}
         if "fp16" in self.config:
             inference_config.update({"fp16": self.config["fp16"]})
+        if "bf16" in self.config:
+            inference_config.update({"bf16": self.config["bf16"]})
         if self.zero_stage_3:
             inference_config.update(
                 {


### PR DESCRIPTION
## What does this PR do?
Fixes https://github.com/Lightning-AI/lightning/issues/16298#issuecomment-1456569610 by checking for both `fp16` and `bf16` in the deepspeed config before initializing inference.