### PR TITLE
Fix race condition in Fabric test

### DIFF
--- a/tests/tests_fabric/parity/test_parity_ddp.py
+++ b/tests/tests_fabric/parity/test_parity_ddp.py
@@ -133,8 +133,8 @@ def train_fabric_ddp(fabric):
 @pytest.mark.parametrize(
     "accelerator, devices, tolerance",
     [
-        ("cpu", 2, 0.01),
-        # pytest.param("cuda", 2, 0.005, marks=RunIf(min_cuda_gpus=2)),
+        # ("cpu", 2, 0.01),
+        pytest.param("cuda", 2, 0.005, marks=RunIf(min_cuda_gpus=2)),
     ],
 )
 def test_parity_ddp(accelerator, devices, tolerance):

--- a/tests/tests_fabric/parity/test_parity_ddp.py
+++ b/tests/tests_fabric/parity/test_parity_ddp.py
@@ -125,7 +125,7 @@ def train_fabric_ddp(fabric):
     return model.state_dict(), torch.tensor(iteration_timings), memory_stats
 
 
-@pytest.mark.flaky(reruns=3)
+# @pytest.mark.flaky(reruns=3)
 @RunIf(standalone=True)
 @pytest.mark.usefixtures("reset_deterministic_algorithm", "reset_cudnn_benchmark")
 @pytest.mark.parametrize(

--- a/tests/tests_fabric/parity/test_parity_ddp.py
+++ b/tests/tests_fabric/parity/test_parity_ddp.py
@@ -45,8 +45,6 @@ def train_torch_ddp(
     memory_stats = {}
 
     os.environ["LOCAL_RANK"] = str(rank)
-    print('ddp', rank, os.environ["MASTER_ADDR"])
-    print('ddp', rank, os.environ["MASTER_PORT"])
     torch.distributed.init_process_group(backend, rank=rank, world_size=world_size)
 
     model = ConvNet().to(device)

--- a/tests/tests_fabric/parity/test_parity_ddp.py
+++ b/tests/tests_fabric/parity/test_parity_ddp.py
@@ -150,6 +150,7 @@ def test_parity_ddp(accelerator, devices, tolerance):
     fabric.barrier()
     cuda_reset()
     torch.distributed.destroy_process_group()
+    time.sleep(2)
 
     # Train with raw PyTorch
     state_dict_torch, timings_torch, memory_torch = train_torch_ddp(

--- a/tests/tests_fabric/parity/test_parity_ddp.py
+++ b/tests/tests_fabric/parity/test_parity_ddp.py
@@ -44,8 +44,10 @@ def train_torch_ddp(
     make_deterministic()
     memory_stats = {}
 
-    # os.environ["LOCAL_RANK"] = str(rank)
-    # torch.distributed.init_process_group(backend, rank=rank, world_size=world_size)
+    os.environ["LOCAL_RANK"] = str(rank)
+    print('ddp', rank, os.environ["MASTER_ADDR"])
+    print('ddp', rank, os.environ["MASTER_PORT"])
+    torch.distributed.init_process_group(backend, rank=rank, world_size=world_size)
 
     model = ConvNet().to(device)
     initial_state_dict = deepcopy(model.state_dict())

--- a/tests/tests_fabric/parity/test_parity_ddp.py
+++ b/tests/tests_fabric/parity/test_parity_ddp.py
@@ -134,7 +134,7 @@ def train_fabric_ddp(fabric):
     "accelerator, devices, tolerance",
     [
         ("cpu", 2, 0.01),
-        pytest.param("cuda", 2, 0.005, marks=RunIf(min_cuda_gpus=2)),
+        # pytest.param("cuda", 2, 0.005, marks=RunIf(min_cuda_gpus=2)),
     ],
 )
 def test_parity_ddp(accelerator, devices, tolerance):
@@ -149,7 +149,7 @@ def test_parity_ddp(accelerator, devices, tolerance):
 
     fabric.barrier()
     cuda_reset()
-    # torch.distributed.destroy_process_group()
+    torch.distributed.destroy_process_group()
 
     # Train with raw PyTorch
     state_dict_torch, timings_torch, memory_torch = train_torch_ddp(

--- a/tests/tests_fabric/parity/test_parity_ddp.py
+++ b/tests/tests_fabric/parity/test_parity_ddp.py
@@ -44,8 +44,8 @@ def train_torch_ddp(
     make_deterministic()
     memory_stats = {}
 
-    os.environ["LOCAL_RANK"] = str(rank)
-    torch.distributed.init_process_group(backend, rank=rank, world_size=world_size)
+    # os.environ["LOCAL_RANK"] = str(rank)
+    # torch.distributed.init_process_group(backend, rank=rank, world_size=world_size)
 
     model = ConvNet().to(device)
     initial_state_dict = deepcopy(model.state_dict())
@@ -147,7 +147,7 @@ def test_parity_ddp(accelerator, devices, tolerance):
 
     fabric.barrier()
     cuda_reset()
-    torch.distributed.destroy_process_group()
+    # torch.distributed.destroy_process_group()
 
     # Train with raw PyTorch
     state_dict_torch, timings_torch, memory_torch = train_torch_ddp(

--- a/tests/tests_fabric/parity/test_parity_ddp.py
+++ b/tests/tests_fabric/parity/test_parity_ddp.py
@@ -127,7 +127,6 @@ def train_fabric_ddp(fabric):
     return model.state_dict(), torch.tensor(iteration_timings), memory_stats
 
 
-# @pytest.mark.flaky(reruns=3)
 @RunIf(standalone=True)
 @pytest.mark.usefixtures("reset_deterministic_algorithm", "reset_cudnn_benchmark")
 @pytest.mark.parametrize(
@@ -150,7 +149,9 @@ def test_parity_ddp(accelerator, devices, tolerance):
     fabric.barrier()
     cuda_reset()
     torch.distributed.destroy_process_group()
-    time.sleep(2)
+    # sleep for a bit to avoid race conditions, since the very first call in `train_torch_ddp`
+    # is initializing a new process group
+    time.sleep(3)
 
     # Train with raw PyTorch
     state_dict_torch, timings_torch, memory_torch = train_torch_ddp(

--- a/tests/tests_fabric/parity/test_parity_ddp.py
+++ b/tests/tests_fabric/parity/test_parity_ddp.py
@@ -133,7 +133,7 @@ def train_fabric_ddp(fabric):
 @pytest.mark.parametrize(
     "accelerator, devices, tolerance",
     [
-        # ("cpu", 2, 0.01),
+        ("cpu", 2, 0.01),
         pytest.param("cuda", 2, 0.005, marks=RunIf(min_cuda_gpus=2)),
     ],
 )


### PR DESCRIPTION
## What does this PR do?

There is a race condition if we do these in a sequence:

```py
torch.distributed.destroy_process_group()
torch.distributed.init_process_group()
```

If one of the processes is slightly faster, and enters the init call before the other one finished destruction, we get in trouble.
