### PR TITLE
Review APIs experimental status

### DIFF
--- a/docs/source-fabric/fundamentals/precision.rst
+++ b/docs/source-fabric/fundamentals/precision.rst
@@ -106,7 +106,7 @@ It is also possible to use BFloat16 mixed precision on the CPU, relying on MKLDN
 
 .. note::
 
-    BFloat16 is also experimental and may not provide significant speedups or memory improvements, offering better numerical stability.
+    BFloat16 may not provide significant speedups or memory improvements, offering better numerical stability.
     For GPUs, the most significant benefits require `Ampere <https://en.wikipedia.org/wiki/Ampere_(microarchitecture)>`_ based GPUs, such as A100s or 3090s.
 
 

--- a/docs/source-pytorch/accelerators/gpu_expert.rst
+++ b/docs/source-pytorch/accelerators/gpu_expert.rst
@@ -6,6 +6,8 @@ GPU training (Expert)
 =====================
 **Audience:** Experts creating new scaling techniques such as Deepspeed or FSDP
 
+.. warning::  This is an experimental feature.
+
 ----
 
 Lightning enables experts focused on researching new ways of optimizing distributed training/inference strategies to create new strategies and plug them into Lightning.

--- a/docs/source-pytorch/accelerators/gpu_expert.rst
+++ b/docs/source-pytorch/accelerators/gpu_expert.rst
@@ -6,7 +6,7 @@ GPU training (Expert)
 =====================
 **Audience:** Experts creating new scaling techniques such as Deepspeed or FSDP
 
-.. warning::  This is an experimental feature.
+.. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
 ----
 

--- a/docs/source-pytorch/accelerators/hpu_basic.rst
+++ b/docs/source-pytorch/accelerators/hpu_basic.rst
@@ -6,7 +6,7 @@ Accelerator: HPU training
 =========================
 **Audience:** Users looking to save money and run large models faster using single or multiple Gaudi devices.
 
-.. warning::  This is an experimental feature.
+.. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
 ----
 

--- a/docs/source-pytorch/accelerators/hpu_basic.rst
+++ b/docs/source-pytorch/accelerators/hpu_basic.rst
@@ -6,6 +6,8 @@ Accelerator: HPU training
 =========================
 **Audience:** Users looking to save money and run large models faster using single or multiple Gaudi devices.
 
+.. warning::  This is an experimental feature.
+
 ----
 
 What is an HPU?

--- a/docs/source-pytorch/accelerators/hpu_intermediate.rst
+++ b/docs/source-pytorch/accelerators/hpu_intermediate.rst
@@ -6,7 +6,7 @@ Accelerator: HPU training
 =========================
 **Audience:** Gaudi chip users looking to save memory and scale models with mixed-precision training.
 
-.. warning::  This is an experimental feature.
+.. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
 ----
 

--- a/docs/source-pytorch/accelerators/hpu_intermediate.rst
+++ b/docs/source-pytorch/accelerators/hpu_intermediate.rst
@@ -6,6 +6,8 @@ Accelerator: HPU training
 =========================
 **Audience:** Gaudi chip users looking to save memory and scale models with mixed-precision training.
 
+.. warning::  This is an experimental feature.
+
 ----
 
 Enable Mixed Precision

--- a/docs/source-pytorch/accelerators/ipu_advanced.rst
+++ b/docs/source-pytorch/accelerators/ipu_advanced.rst
@@ -6,7 +6,7 @@ Accelerator: IPU training
 =========================
 **Audience:** Users looking to customize IPU training for massive models.
 
-.. warning::  This is an experimental feature.
+.. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
 ----
 

--- a/docs/source-pytorch/accelerators/ipu_advanced.rst
+++ b/docs/source-pytorch/accelerators/ipu_advanced.rst
@@ -6,6 +6,8 @@ Accelerator: IPU training
 =========================
 **Audience:** Users looking to customize IPU training for massive models.
 
+.. warning::  This is an experimental feature.
+
 ----
 
 Advanced IPU options

--- a/docs/source-pytorch/accelerators/ipu_basic.rst
+++ b/docs/source-pytorch/accelerators/ipu_basic.rst
@@ -19,8 +19,7 @@ IPUs are used to build IPU-PODs, rack-based systems of IPU-Machines for larger w
 
 See the `Graphcore Glossary <https://docs.graphcore.ai/projects/graphcore-glossary/>`__ for the definitions of other IPU-specific terminology.
 
-.. note::
-  IPU support is experimental and a work in progress (see :ref:`known-limitations`). If you run into any problems, please leave an issue.
+.. warning::  This is an experimental feature.
 
 ----
 
@@ -65,8 +64,7 @@ Currently there are some known limitations that are being addressed in the near 
 
 Please see the `MNIST example <https://github.com/Lightning-AI/lightning/blob/master/examples/pytorch/ipu/mnist_sample.py>`__ which displays most of the limitations and how to overcome them till they are resolved.
 
-* ``self.log`` is not supported in the ``training_step``, ``validation_step``, ``test_step`` or ``predict_step``. This is due to the step function being traced and sent to the IPU devices. We're actively working on fixing this.
-* Multiple optimizers are not supported. ``training_step`` only supports returning one loss from the ``training_step`` function as a result.
+* ``self.log`` is not supported in the ``training_step``, ``validation_step``, ``test_step`` or ``predict_step``. This is due to the step function being traced and sent to the IPU devices.
 * Since the step functions are traced, branching logic or any form of primitive values are traced into constants. Be mindful as this could lead to errors in your custom code.
 * Clipping gradients is not supported.
 * It is not possible to use :class:`torch.utils.data.BatchSampler` in your dataloaders if you are using multiple IPUs.

--- a/docs/source-pytorch/accelerators/ipu_basic.rst
+++ b/docs/source-pytorch/accelerators/ipu_basic.rst
@@ -6,6 +6,8 @@ Accelerator: IPU training
 =========================
 **Audience:** Users looking to save money and run large models faster using single or multiple IPU devices.
 
+.. warning::  This is an experimental feature.
+
 ----
 
 What is an IPU?
@@ -18,8 +20,6 @@ IPUs operate in a different way to conventional accelerators such as CPU/GPUs. I
 IPUs are used to build IPU-PODs, rack-based systems of IPU-Machines for larger workloads. See the `IPU Architecture <https://www.graphcore.ai/products/ipu>`__ for more information.
 
 See the `Graphcore Glossary <https://docs.graphcore.ai/projects/graphcore-glossary/>`__ for the definitions of other IPU-specific terminology.
-
-.. warning::  This is an experimental feature.
 
 ----
 

--- a/docs/source-pytorch/accelerators/ipu_basic.rst
+++ b/docs/source-pytorch/accelerators/ipu_basic.rst
@@ -6,7 +6,7 @@ Accelerator: IPU training
 =========================
 **Audience:** Users looking to save money and run large models faster using single or multiple IPU devices.
 
-.. warning::  This is an experimental feature.
+.. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
 ----
 

--- a/docs/source-pytorch/accelerators/ipu_intermediate.rst
+++ b/docs/source-pytorch/accelerators/ipu_intermediate.rst
@@ -6,6 +6,8 @@ Accelerator: IPU training
 =========================
 **Audience:** IPU users looking to increase performance via mixed precision and analysis tools.
 
+.. warning::  This is an experimental feature.
+
 ----
 
 Mixed precision & 16 bit precision

--- a/docs/source-pytorch/accelerators/ipu_intermediate.rst
+++ b/docs/source-pytorch/accelerators/ipu_intermediate.rst
@@ -6,7 +6,7 @@ Accelerator: IPU training
 =========================
 **Audience:** IPU users looking to increase performance via mixed precision and analysis tools.
 
-.. warning::  This is an experimental feature.
+.. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
 ----
 

--- a/docs/source-pytorch/accelerators/tpu_advanced.rst
+++ b/docs/source-pytorch/accelerators/tpu_advanced.rst
@@ -4,6 +4,8 @@ TPU training (Advanced)
 =======================
 **Audience:** Users looking to apply advanced performance techniques to TPU training.
 
+.. warning::  This is an experimental feature.
+
 ----
 
 Weight Sharing/Tying

--- a/docs/source-pytorch/accelerators/tpu_advanced.rst
+++ b/docs/source-pytorch/accelerators/tpu_advanced.rst
@@ -4,7 +4,7 @@ TPU training (Advanced)
 =======================
 **Audience:** Users looking to apply advanced performance techniques to TPU training.
 
-.. warning::  This is an experimental feature.
+.. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
 ----
 

--- a/docs/source-pytorch/accelerators/tpu_basic.rst
+++ b/docs/source-pytorch/accelerators/tpu_basic.rst
@@ -112,7 +112,6 @@ There are cases in which training on TPUs is slower when compared with GPUs, for
 - Limited resources when using TPU's with PyTorch `Link <https://github.com/pytorch/xla/issues/2054#issuecomment-627367729>`_
 - XLA Graph compilation during the initial steps `Reference <https://github.com/pytorch/xla/issues/2383#issuecomment-666519998>`_
 - Some tensor ops are not fully supported on TPU, or not supported at all. These operations will be performed on CPU (context switch).
-- PyTorch integration is still experimental. Some performance bottlenecks may simply be the result of unfinished implementation.
 
 The official PyTorch XLA `performance guide <https://github.com/pytorch/xla/blob/master/TROUBLESHOOTING.md#known-performance-caveats>`_
 has more detailed information on how PyTorch code can be optimized for TPU. In particular, the

--- a/docs/source-pytorch/accelerators/tpu_basic.rst
+++ b/docs/source-pytorch/accelerators/tpu_basic.rst
@@ -4,7 +4,7 @@ TPU training (Basic)
 ====================
 **Audience:** Users looking to train on single or multiple TPU cores.
 
-.. warning::  This is an experimental feature.
+.. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
 ----
 

--- a/docs/source-pytorch/accelerators/tpu_basic.rst
+++ b/docs/source-pytorch/accelerators/tpu_basic.rst
@@ -4,6 +4,8 @@ TPU training (Basic)
 ====================
 **Audience:** Users looking to train on single or multiple TPU cores.
 
+.. warning::  This is an experimental feature.
+
 ----
 
 .. raw:: html

--- a/docs/source-pytorch/accelerators/tpu_intermediate.rst
+++ b/docs/source-pytorch/accelerators/tpu_intermediate.rst
@@ -4,7 +4,7 @@ TPU training (Intermediate)
 ===========================
 **Audience:** Users looking to use cloud TPUs.
 
-.. warning::  This is an experimental feature.
+.. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
 ----
 

--- a/docs/source-pytorch/accelerators/tpu_intermediate.rst
+++ b/docs/source-pytorch/accelerators/tpu_intermediate.rst
@@ -4,6 +4,8 @@ TPU training (Intermediate)
 ===========================
 **Audience:** Users looking to use cloud TPUs.
 
+.. warning::  This is an experimental feature.
+
 ----
 
 DistributedSamplers

--- a/docs/source-pytorch/advanced/model_parallel.rst
+++ b/docs/source-pytorch/advanced/model_parallel.rst
@@ -53,11 +53,11 @@ Sharding techniques help when model sizes are fairly large; roughly 500M+ parame
 * Due to high distributed communication between devices, if running on a slow network/interconnect, the training might be much slower than expected and then it's up to you to determince the tradeoff here.
 
 
-Cutting-edge and Experimental Strategies
-========================================
+Cutting-edge and third-party Strategies
+=======================================
 
 Cutting-edge Lightning strategies are being developed by third-parties outside of Lightning.
-If you want to be the first to try the latest and greatest experimental features for model-parallel training, check out the :doc:`Colossal-AI Strategy <./third_party/colossalai>` integration.
+If you want to try some of the latest and greatest features for model-parallel training, check out the :doc:`Colossal-AI Strategy <./third_party/colossalai>` integration.
 
 
 ----
@@ -193,8 +193,7 @@ Enable checkpointing on large layers (like Transformers) by providing the layer 
 DeepSpeed
 *********
 
-.. note::
-    The DeepSpeed strategy is in beta and the API is subject to change. Please create an `issue <https://github.com/Lightning-AI/lightning/issues>`_ if you run into any issues.
+.. warning::  This is an experimental feature.
 
 `DeepSpeed <https://github.com/microsoft/DeepSpeed>`__ is a deep learning training optimization library, providing the means to train massive billion parameter models at scale.
 Using the DeepSpeed strategy, we were able to **train model sizes of 10 Billion parameters and above**, with a lot of useful information in this `benchmark <https://github.com/huggingface/transformers/issues/9996>`_ and the `DeepSpeed docs <https://www.deepspeed.ai/tutorials/megatron/>`__.

--- a/docs/source-pytorch/advanced/model_parallel.rst
+++ b/docs/source-pytorch/advanced/model_parallel.rst
@@ -73,7 +73,7 @@ PyTorch has it's own version of `FSDP <https://pytorch.org/docs/stable/fsdp.html
 It was introduced in their `v1.11.0 release <https://pytorch.org/blog/introducing-pytorch-fully-sharded-data-parallel-api/>`_ but it is recommended to use it with PyTorch v1.12 or more and that's what
 Lightning supports.
 
-.. warning::  This is an experimental feature.
+.. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
 
 Auto Wrapping
@@ -199,7 +199,7 @@ DeepSpeed
 Using the DeepSpeed strategy, we were able to **train model sizes of 10 Billion parameters and above**, with a lot of useful information in this `benchmark <https://github.com/huggingface/transformers/issues/9996>`_ and the `DeepSpeed docs <https://www.deepspeed.ai/tutorials/megatron/>`__.
 DeepSpeed also offers lower level training optimizations, and efficient optimizers such as `1-bit Adam <https://www.deepspeed.ai/tutorials/onebit-adam/>`_. We recommend using DeepSpeed in environments where speed and memory optimizations are important (such as training large billion parameter models).
 
-.. warning::  This is an experimental feature.
+.. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
 Below is a summary of all the configurations of DeepSpeed.
 

--- a/docs/source-pytorch/advanced/model_parallel.rst
+++ b/docs/source-pytorch/advanced/model_parallel.rst
@@ -73,6 +73,8 @@ PyTorch has it's own version of `FSDP <https://pytorch.org/docs/stable/fsdp.html
 It was introduced in their `v1.11.0 release <https://pytorch.org/blog/introducing-pytorch-fully-sharded-data-parallel-api/>`_ but it is recommended to use it with PyTorch v1.12 or more and that's what
 Lightning supports.
 
+.. warning::  This is an experimental feature.
+
 
 Auto Wrapping
 =============
@@ -193,11 +195,11 @@ Enable checkpointing on large layers (like Transformers) by providing the layer 
 DeepSpeed
 *********
 
-.. warning::  This is an experimental feature.
-
 `DeepSpeed <https://github.com/microsoft/DeepSpeed>`__ is a deep learning training optimization library, providing the means to train massive billion parameter models at scale.
 Using the DeepSpeed strategy, we were able to **train model sizes of 10 Billion parameters and above**, with a lot of useful information in this `benchmark <https://github.com/huggingface/transformers/issues/9996>`_ and the `DeepSpeed docs <https://www.deepspeed.ai/tutorials/megatron/>`__.
 DeepSpeed also offers lower level training optimizations, and efficient optimizers such as `1-bit Adam <https://www.deepspeed.ai/tutorials/onebit-adam/>`_. We recommend using DeepSpeed in environments where speed and memory optimizations are important (such as training large billion parameter models).
+
+.. warning::  This is an experimental feature.
 
 Below is a summary of all the configurations of DeepSpeed.
 

--- a/docs/source-pytorch/advanced/pruning_quantization.rst
+++ b/docs/source-pytorch/advanced/pruning_quantization.rst
@@ -10,9 +10,7 @@ Pruning and Quantization are techniques to compress model size for deployment, a
 Pruning
 *******
 
-.. warning::
-
-     Pruning is in beta and subject to change.
+.. warning::  This is an experimental feature.
 
 Pruning is a technique which focuses on eliminating some of the model weights to reduce the model size and decrease inference requirements.
 

--- a/docs/source-pytorch/advanced/pruning_quantization.rst
+++ b/docs/source-pytorch/advanced/pruning_quantization.rst
@@ -10,7 +10,7 @@ Pruning and Quantization are techniques to compress model size for deployment, a
 Pruning
 *******
 
-.. warning::  This is an experimental feature.
+.. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
 Pruning is a technique which focuses on eliminating some of the model weights to reduce the model size and decrease inference requirements.
 

--- a/docs/source-pytorch/advanced/strategy_registry.rst
+++ b/docs/source-pytorch/advanced/strategy_registry.rst
@@ -1,8 +1,6 @@
 Strategy Registry
 =================
 
-.. warning:: The Strategy Registry is experimental and subject to change.
-
 Lightning includes a registry that holds information about Training strategies and allows for the registration of new custom strategies.
 
 The Strategies are assigned strings that identify them, such as "ddp", "deepspeed_stage_2_offload", and so on.

--- a/docs/source-pytorch/advanced/third_party/colossalai.rst
+++ b/docs/source-pytorch/advanced/third_party/colossalai.rst
@@ -4,11 +4,12 @@
 Colossal-AI
 ###########
 
-
 The `Colossal-AI strategy <https://github.com/Lightning-AI/lightning-colossalai>`_ implements ZeRO-DP with chunk-based memory management.
 With this chunk mechanism, really large models can be trained with a small number of GPUs.
 It supports larger trainable model size and batch size than usual heterogeneous training by reducing CUDA memory fragments and CPU memory consumption.
 Also, it speeds up this kind of heterogeneous training by fully utilizing all kinds of resources.
+
+.. warning::  This is an experimental feature.
 
 When enabling chunk mechanism, a set of consecutive parameters are stored in a chunk, and then the chunk is sharded across different processes.
 This can reduce communication and data transmission frequency and fully utilize communication and PCI-E bandwidth, which makes training faster.

--- a/docs/source-pytorch/advanced/third_party/colossalai.rst
+++ b/docs/source-pytorch/advanced/third_party/colossalai.rst
@@ -9,7 +9,7 @@ With this chunk mechanism, really large models can be trained with a small numbe
 It supports larger trainable model size and batch size than usual heterogeneous training by reducing CUDA memory fragments and CPU memory consumption.
 Also, it speeds up this kind of heterogeneous training by fully utilizing all kinds of resources.
 
-.. warning::  This is an experimental feature.
+.. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
 When enabling chunk mechanism, a set of consecutive parameters are stored in a chunk, and then the chunk is sharded across different processes.
 This can reduce communication and data transmission frequency and fully utilize communication and PCI-E bandwidth, which makes training faster.

--- a/docs/source-pytorch/advanced/training_tricks.rst
+++ b/docs/source-pytorch/advanced/training_tricks.rst
@@ -178,7 +178,7 @@ The algorithm in short works by:
 Customizing Batch Size Finder
 =============================
 
-.. warning::  This is an experimental feature.
+.. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
 1. You can also customize the :class:`~lightning.pytorch.callbacks.batch_size_finder.BatchSizeFinder` callback to run
    at different epochs. This feature is useful while fine-tuning models since you can't always use the same batch size after
@@ -346,7 +346,7 @@ This is the point returned py ``lr_finder.suggestion()``.
 Customizing Learning Rate Finder
 ================================
 
-.. warning::  This is an experimental feature.
+.. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
 You can also customize the :class:`~lightning.pytorch.callbacks.lr_finder.LearningRateFinder` callback to run at different epochs. This feature is useful while fine-tuning models.
 

--- a/docs/source-pytorch/advanced/training_tricks.rst
+++ b/docs/source-pytorch/advanced/training_tricks.rst
@@ -178,6 +178,8 @@ The algorithm in short works by:
 Customizing Batch Size Finder
 =============================
 
+.. warning::  This is an experimental feature.
+
 1. You can also customize the :class:`~lightning.pytorch.callbacks.batch_size_finder.BatchSizeFinder` callback to run
    at different epochs. This feature is useful while fine-tuning models since you can't always use the same batch size after
    unfreezing the backbone.
@@ -343,6 +345,8 @@ This is the point returned py ``lr_finder.suggestion()``.
 
 Customizing Learning Rate Finder
 ================================
+
+.. warning::  This is an experimental feature.
 
 You can also customize the :class:`~lightning.pytorch.callbacks.lr_finder.LearningRateFinder` callback to run at different epochs. This feature is useful while fine-tuning models.
 

--- a/docs/source-pytorch/common/checkpointing_expert.rst
+++ b/docs/source-pytorch/common/checkpointing_expert.rst
@@ -17,7 +17,7 @@ We provide ``Checkpoint`` class, for easier subclassing. Users may want to subcl
 Customize Checkpointing
 ***********************
 
-.. warning::  This is an experimental feature.
+.. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
 Lightning supports modifying the checkpointing save/load functionality through the ``CheckpointIO``. This encapsulates the save/load logic
 that is managed by the ``Strategy``. ``CheckpointIO`` is different from :meth:`~lightning.pytorch.core.hooks.CheckpointHooks.on_save_checkpoint`
@@ -101,7 +101,7 @@ Custom Checkpoint IO Plugin
 Asynchronous Checkpointing
 **************************
 
-.. warning::  This is an experimental feature.
+.. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
 To enable saving the checkpoints asynchronously without blocking your training, you can configure
 :class:`~lightning.pytorch.plugins.io.async_plugin.AsyncCheckpointIO` plugin to ``Trainer``.

--- a/docs/source-pytorch/common/checkpointing_expert.rst
+++ b/docs/source-pytorch/common/checkpointing_expert.rst
@@ -17,10 +17,7 @@ We provide ``Checkpoint`` class, for easier subclassing. Users may want to subcl
 Customize Checkpointing
 ***********************
 
-.. warning::
-
-    The Checkpoint IO API is experimental and subject to change.
-
+.. warning::  This is an experimental feature.
 
 Lightning supports modifying the checkpointing save/load functionality through the ``CheckpointIO``. This encapsulates the save/load logic
 that is managed by the ``Strategy``. ``CheckpointIO`` is different from :meth:`~lightning.pytorch.core.hooks.CheckpointHooks.on_save_checkpoint`
@@ -104,9 +101,7 @@ Custom Checkpoint IO Plugin
 Asynchronous Checkpointing
 **************************
 
-.. warning::
-
-    This is currently an experimental plugin/feature and API changes are to be expected.
+.. warning::  This is an experimental feature.
 
 To enable saving the checkpoints asynchronously without blocking your training, you can configure
 :class:`~lightning.pytorch.plugins.io.async_plugin.AsyncCheckpointIO` plugin to ``Trainer``.

--- a/docs/source-pytorch/common/precision_intermediate.rst
+++ b/docs/source-pytorch/common/precision_intermediate.rst
@@ -76,8 +76,7 @@ BFloat16 Mixed Precision
 
 .. warning::
 
-    BFloat16 is also experimental and may not provide significant speedups or memory improvements, offering better numerical stability.
-
+    BFloat16 may not provide significant speedups or memory improvements or offer better numerical stability.
     Do note for GPUs, the most significant benefits require `Ampere <https://en.wikipedia.org/wiki/Ampere_(microarchitecture)>`__ based GPUs, such as A100s or 3090s.
 
 BFloat16 Mixed precision is similar to FP16 mixed precision, however, it maintains more of the "dynamic range" that FP32 offers. This means it is able to improve numerical stability than FP16 mixed precision. For more information, see `this TPU performance blogpost <https://cloud.google.com/blog/products/ai-machine-learning/bfloat16-the-secret-to-high-performance-on-cloud-tpus>`__.

--- a/docs/source-pytorch/deploy/production_advanced.rst
+++ b/docs/source-pytorch/deploy/production_advanced.rst
@@ -65,7 +65,7 @@ Once you have the exported model, you can run it on your ONNX runtime in the fol
 Validate a Model Is Servable
 ****************************
 
-.. warning::  This is an experimental feature.
+.. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
 Production ML Engineers would argue that a model shouldn't be trained if it can't be deployed reliably and in a fully automated manner.
 

--- a/docs/source-pytorch/deploy/production_advanced.rst
+++ b/docs/source-pytorch/deploy/production_advanced.rst
@@ -65,6 +65,8 @@ Once you have the exported model, you can run it on your ONNX runtime in the fol
 Validate a Model Is Servable
 ****************************
 
+.. warning::  This is an experimental feature.
+
 Production ML Engineers would argue that a model shouldn't be trained if it can't be deployed reliably and in a fully automated manner.
 
 In order to ease transition from training to production, PyTorch Lightning provides a way for you to validate a model can be served even before starting training.

--- a/docs/source-pytorch/extensions/accelerator.rst
+++ b/docs/source-pytorch/extensions/accelerator.rst
@@ -29,6 +29,8 @@ hardware and distributed training or clusters.
 Create a Custom Accelerator
 ---------------------------
 
+.. warning::  This is an experimental feature.
+
 Here is how you create a new Accelerator.
 Let's pretend we want to integrate the fictional XPU accelerator and we have access to its hardware through a library
 ``xpulib``.

--- a/docs/source-pytorch/extensions/accelerator.rst
+++ b/docs/source-pytorch/extensions/accelerator.rst
@@ -39,7 +39,7 @@ Let's pretend we want to integrate the fictional XPU accelerator and we have acc
 
 
     class XPUAccelerator(Accelerator):
-        """Experimental support for XPU, optimized for large-scale machine learning."""
+        """Support for an hypothetical XPU, optimized for large-scale machine learning."""
 
         @staticmethod
         def parse_devices(devices: Any) -> Any:

--- a/docs/source-pytorch/extensions/accelerator.rst
+++ b/docs/source-pytorch/extensions/accelerator.rst
@@ -29,7 +29,7 @@ hardware and distributed training or clusters.
 Create a Custom Accelerator
 ---------------------------
 
-.. warning::  This is an experimental feature.
+.. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
 Here is how you create a new Accelerator.
 Let's pretend we want to integrate the fictional XPU accelerator and we have access to its hardware through a library
@@ -41,7 +41,7 @@ Let's pretend we want to integrate the fictional XPU accelerator and we have acc
 
 
     class XPUAccelerator(Accelerator):
-        """Support for an hypothetical XPU, optimized for large-scale machine learning."""
+        """Support for a hypothetical XPU, optimized for large-scale machine learning."""
 
         @staticmethod
         def parse_devices(devices: Any) -> Any:

--- a/docs/source-pytorch/versioning.rst
+++ b/docs/source-pytorch/versioning.rst
@@ -24,18 +24,6 @@ API Stability
 In Lightning, all public APIs are considered stable unless explicitly marked as experimental in their documentation or docstrings.
 Modules, functions, classes, and methods that are protected (have a leading underscore, see https://peps.python.org/pep-0008/ for more information) may be changed or removed at any time.
 
-Experimental API
-----------------
-
-Experimental APIs are labelled as experimental in their documentation or docstrings and are considered unstable and are discouraged from use in production.
-
-For experimental features, any of the following may be true:
-
-- The feature has unstable dependencies.
-- The API may change without notice in future versions.
-- The performance of the feature has not been verified.
-- The docs for this feature are under active development.
-
 Stable API
 ----------
 
@@ -44,7 +32,20 @@ Everything not specifically labelled as experimental is stable.
 For stable APIs, all of the following are true:
 
 - The API is not expected to change.
-- If anything does change, we show a deprecation warning before applying the breaking change following the policy described below.
+- If anything does change, we show a deprecation warning before applying the breaking change following the policy described in the "API Evolution" section below.
+
+Experimental API
+----------------
+
+Experimental APIs are labelled as experimental in their documentation or docstrings and are considered unstable and are discouraged from use in production.
+For experimental features, any of the following may be true:
+
+- The feature has unstable dependencies.
+- The API may change without notice in future versions.
+- The performance of the feature has not been verified.
+- The docs for this feature are under active development.
+
+We may still add deprecation warnings for some experimental API changes, but this is not guaranteed.
 
 API Evolution
 *************

--- a/docs/source-pytorch/versioning.rst
+++ b/docs/source-pytorch/versioning.rst
@@ -37,15 +37,18 @@ For stable APIs, all of the following are true:
 Experimental API
 ----------------
 
-Experimental APIs are labelled as experimental in their documentation or docstrings and are considered unstable and are discouraged from use in production.
+Experimental APIs are labelled as experimental in their documentation or docstrings.
 For experimental features, any of the following may be true:
 
-- The feature has unstable dependencies.
+- The feature uses dependencies that are under active development and may change outside our control.
 - The API may change without notice in future versions.
 - The performance of the feature has not been verified.
-- The docs for this feature are under active development.
+- The feature has not been battle tested by the core team in production scenarios.
+- The feature is under active development.
 
-We may still add deprecation warnings for some experimental API changes, but this is not guaranteed.
+While we may still issue deprecation warnings for experimental API changes, this is not guaranteed.
+Therefore, it is important to be cautious when using experimental features and be prepared to modify your code if the
+API changes in a future release. In this case, you might want to pin your dependencies to avoid unexpected issues.
 
 API Evolution
 *************

--- a/src/lightning/fabric/accelerators/accelerator.py
+++ b/src/lightning/fabric/accelerators/accelerator.py
@@ -22,7 +22,7 @@ class Accelerator(ABC):
 
     An Accelerator is meant to deal with one type of hardware.
 
-    .. warning::  Writing your own accelerator is an experimental feature.
+    .. warning::  Writing your own accelerator is an :ref:`experimental <versioning:Experimental API>` feature.
     """
 
     @abstractmethod

--- a/src/lightning/fabric/accelerators/accelerator.py
+++ b/src/lightning/fabric/accelerators/accelerator.py
@@ -21,6 +21,8 @@ class Accelerator(ABC):
     """The Accelerator base class.
 
     An Accelerator is meant to deal with one type of hardware.
+
+    .. warning::  Writing your own accelerator is an experimental feature.
     """
 
     @abstractmethod

--- a/src/lightning/fabric/accelerators/mps.py
+++ b/src/lightning/fabric/accelerators/mps.py
@@ -22,7 +22,10 @@ from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_1_12
 
 
 class MPSAccelerator(Accelerator):
-    """Accelerator for Metal Apple Silicon GPU devices."""
+    """Accelerator for Metal Apple Silicon GPU devices.
+
+    .. warning::  Use of this accelerator beyond import and instantiation is experimental.
+    """
 
     def setup_device(self, device: torch.device) -> None:
         """

--- a/src/lightning/fabric/accelerators/tpu.py
+++ b/src/lightning/fabric/accelerators/tpu.py
@@ -25,7 +25,10 @@ from lightning.fabric.utilities.device_parser import _check_data_type
 
 
 class TPUAccelerator(Accelerator):
-    """Accelerator for TPU devices."""
+    """Accelerator for TPU devices.
+
+    .. warning::  Use of this accelerator beyond import and instantiation is experimental.
+    """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         if not _XLA_AVAILABLE:

--- a/src/lightning/fabric/plugins/collectives/collective.py
+++ b/src/lightning/fabric/plugins/collectives/collective.py
@@ -12,8 +12,7 @@ class Collective(ABC):
 
     Supports communications between multiple processes and multiple nodes. A collective owns a group.
 
-    .. warning::
-        This API is experimental and subject to change
+    .. warning:: This is an experimental feature which is still in development.
     """
 
     def __init__(self) -> None:

--- a/src/lightning/fabric/plugins/collectives/collective.py
+++ b/src/lightning/fabric/plugins/collectives/collective.py
@@ -12,7 +12,7 @@ class Collective(ABC):
 
     Supports communications between multiple processes and multiple nodes. A collective owns a group.
 
-    .. warning:: This is an experimental feature which is still in development.
+    .. warning:: This is an :ref:`experimental <versioning:Experimental API>` feature which is still in development.
     """
 
     def __init__(self) -> None:

--- a/src/lightning/fabric/plugins/collectives/single_device.py
+++ b/src/lightning/fabric/plugins/collectives/single_device.py
@@ -7,6 +7,11 @@ from lightning.fabric.utilities.types import CollectibleGroup
 
 
 class SingleDeviceCollective(Collective):
+    """Support for collective operations on a single device (no-op).
+
+    .. warning:: This is an experimental feature which is still in development.
+    """
+
     @property
     def rank(self) -> int:
         return 0

--- a/src/lightning/fabric/plugins/collectives/single_device.py
+++ b/src/lightning/fabric/plugins/collectives/single_device.py
@@ -9,7 +9,7 @@ from lightning.fabric.utilities.types import CollectibleGroup
 class SingleDeviceCollective(Collective):
     """Support for collective operations on a single device (no-op).
 
-    .. warning:: This is an experimental feature which is still in development.
+    .. warning:: This is an :ref:`experimental <versioning:Experimental API>` feature which is still in development.
     """
 
     @property

--- a/src/lightning/fabric/plugins/collectives/torch_collective.py
+++ b/src/lightning/fabric/plugins/collectives/torch_collective.py
@@ -18,6 +18,11 @@ else:
 
 
 class TorchCollective(Collective):
+    """Collective operations using `torch.distributed <https://pytorch.org/docs/stable/distributed.html>`__.
+
+    .. warning:: This is an experimental feature which is still in development.
+    """
+
     manages_default_group = False
 
     def __init__(self) -> None:

--- a/src/lightning/fabric/plugins/collectives/torch_collective.py
+++ b/src/lightning/fabric/plugins/collectives/torch_collective.py
@@ -20,7 +20,7 @@ else:
 class TorchCollective(Collective):
     """Collective operations using `torch.distributed <https://pytorch.org/docs/stable/distributed.html>`__.
 
-    .. warning:: This is an experimental feature which is still in development.
+    .. warning:: This is an :ref:`experimental <versioning:Experimental API>` feature which is still in development.
     """
 
     manages_default_group = False

--- a/src/lightning/fabric/plugins/io/checkpoint_io.py
+++ b/src/lightning/fabric/plugins/io/checkpoint_io.py
@@ -20,6 +20,8 @@ from lightning.fabric.utilities.types import _PATH
 class CheckpointIO(ABC):
     """Interface to save/load checkpoints as they are saved through the ``Strategy``.
 
+    .. warning::  This is an experimental feature.
+
     Typically most plugins either use the Torch based IO Plugin; ``TorchCheckpointIO`` but may
     require particular handling depending on the plugin.
 

--- a/src/lightning/fabric/plugins/io/checkpoint_io.py
+++ b/src/lightning/fabric/plugins/io/checkpoint_io.py
@@ -20,7 +20,7 @@ from lightning.fabric.utilities.types import _PATH
 class CheckpointIO(ABC):
     """Interface to save/load checkpoints as they are saved through the ``Strategy``.
 
-    .. warning::  This is an experimental feature.
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
     Typically most plugins either use the Torch based IO Plugin; ``TorchCheckpointIO`` but may
     require particular handling depending on the plugin.

--- a/src/lightning/fabric/plugins/io/torch_io.py
+++ b/src/lightning/fabric/plugins/io/torch_io.py
@@ -29,7 +29,7 @@ class TorchCheckpointIO(CheckpointIO):
     """CheckpointIO that utilizes :func:`torch.save` and :func:`torch.load` to save and load checkpoints
     respectively, common for most use cases.
 
-    .. warning::  This is an experimental feature.
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
     """
 
     def save_checkpoint(self, checkpoint: Dict[str, Any], path: _PATH, storage_options: Optional[Any] = None) -> None:

--- a/src/lightning/fabric/plugins/io/torch_io.py
+++ b/src/lightning/fabric/plugins/io/torch_io.py
@@ -27,7 +27,10 @@ log = logging.getLogger(__name__)
 
 class TorchCheckpointIO(CheckpointIO):
     """CheckpointIO that utilizes :func:`torch.save` and :func:`torch.load` to save and load checkpoints
-    respectively, common for most use cases."""
+    respectively, common for most use cases.
+
+    .. warning::  This is an experimental feature.
+    """
 
     def save_checkpoint(self, checkpoint: Dict[str, Any], path: _PATH, storage_options: Optional[Any] = None) -> None:
         """Save model/training states as a checkpoint file through state-dump and file-write.

--- a/src/lightning/fabric/plugins/io/xla.py
+++ b/src/lightning/fabric/plugins/io/xla.py
@@ -24,7 +24,10 @@ from lightning.fabric.utilities.types import _PATH
 
 
 class XLACheckpointIO(TorchCheckpointIO):
-    """CheckpointIO that utilizes :func:`xm.save` to save checkpoints for TPU training strategies."""
+    """CheckpointIO that utilizes :func:`xm.save` to save checkpoints for TPU training strategies.
+
+    .. warning::  This is an experimental feature.
+    """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         if not _XLA_AVAILABLE:

--- a/src/lightning/fabric/plugins/io/xla.py
+++ b/src/lightning/fabric/plugins/io/xla.py
@@ -26,7 +26,7 @@ from lightning.fabric.utilities.types import _PATH
 class XLACheckpointIO(TorchCheckpointIO):
     """CheckpointIO that utilizes :func:`xm.save` to save checkpoints for TPU training strategies.
 
-    .. warning::  This is an experimental feature.
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:

--- a/src/lightning/fabric/plugins/precision/fsdp.py
+++ b/src/lightning/fabric/plugins/precision/fsdp.py
@@ -24,7 +24,10 @@ if TYPE_CHECKING:
 
 
 class FSDPPrecision(MixedPrecision):
-    """AMP for Fully Sharded Data Parallel training."""
+    """AMP for Fully Sharded Data Parallel training.
+
+    .. warning::  This is an experimental feature.
+    """
 
     def __init__(
         self, precision: Literal["16-mixed", "bf16-mixed"], device: str, scaler: Optional["ShardedGradScaler"] = None

--- a/src/lightning/fabric/plugins/precision/fsdp.py
+++ b/src/lightning/fabric/plugins/precision/fsdp.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 class FSDPPrecision(MixedPrecision):
     """AMP for Fully Sharded Data Parallel training.
 
-    .. warning::  This is an experimental feature.
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
     """
 
     def __init__(

--- a/src/lightning/fabric/strategies/deepspeed.py
+++ b/src/lightning/fabric/strategies/deepspeed.py
@@ -105,7 +105,7 @@ class DeepSpeedStrategy(DDPStrategy, _Sharded):
         billion parameter models. `For more information: https://pytorch-
         lightning.readthedocs.io/en/stable/advanced/model_parallel.html#deepspeed`.
 
-        .. warning::  This is an experimental feature.
+        .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
         Defaults have been set to enable ZeRO-Offload and some have been taken from the link below.
         These defaults have been set generally, but may require tuning for optimum performance based on your model size.

--- a/src/lightning/fabric/strategies/deepspeed.py
+++ b/src/lightning/fabric/strategies/deepspeed.py
@@ -105,7 +105,7 @@ class DeepSpeedStrategy(DDPStrategy, _Sharded):
         billion parameter models. `For more information: https://pytorch-
         lightning.readthedocs.io/en/stable/advanced/model_parallel.html#deepspeed`.
 
-        .. warning:: ``DeepSpeedStrategy`` is in beta and subject to change.
+        .. warning::  This is an experimental feature.
 
         Defaults have been set to enable ZeRO-Offload and some have been taken from the link below.
         These defaults have been set generally, but may require tuning for optimum performance based on your model size.

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -54,7 +54,7 @@ _FSDP_ALIASES = ("fsdp", "fsdp_cpu_offload")
 class FSDPStrategy(ParallelStrategy, _Sharded):
     r"""Strategy for Fully Sharded Data Parallel provided by torch.distributed.
 
-    .. warning::  This is an experimental feature.
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
     Fully Sharded Training shards the entire model across all available GPUs, allowing you to scale model
     size, whilst using efficient communication to reduce overhead. In practice, this means we can remain

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -54,8 +54,7 @@ _FSDP_ALIASES = ("fsdp", "fsdp_cpu_offload")
 class FSDPStrategy(ParallelStrategy, _Sharded):
     r"""Strategy for Fully Sharded Data Parallel provided by torch.distributed.
 
-    .. warning:: ``FSDPStrategy`` is in BETA and subject to change. The interface can
-        bring breaking changes and new features with the next release of PyTorch.
+    .. warning::  This is an experimental feature.
 
     Fully Sharded Training shards the entire model across all available GPUs, allowing you to scale model
     size, whilst using efficient communication to reduce overhead. In practice, this means we can remain

--- a/src/lightning/pytorch/accelerators/accelerator.py
+++ b/src/lightning/pytorch/accelerators/accelerator.py
@@ -22,7 +22,7 @@ from lightning.fabric.utilities.types import _DEVICE
 class Accelerator(_Accelerator, ABC):
     """The Accelerator base class for Lightning PyTorch.
 
-    .. warning::  Writing your own accelerator is an experimental feature.
+    .. warning::  Writing your own accelerator is an :ref:`experimental <versioning:Experimental API>` feature.
     """
 
     def setup(self, trainer: "pl.Trainer") -> None:

--- a/src/lightning/pytorch/accelerators/accelerator.py
+++ b/src/lightning/pytorch/accelerators/accelerator.py
@@ -22,7 +22,7 @@ from lightning.fabric.utilities.types import _DEVICE
 class Accelerator(_Accelerator, ABC):
     """The Accelerator base class for Lightning PyTorch.
 
-    An Accelerator is meant to deal with one type of hardware.
+    .. warning::  Writing your own accelerator is an experimental feature.
     """
 
     def setup(self, trainer: "pl.Trainer") -> None:

--- a/src/lightning/pytorch/accelerators/hpu.py
+++ b/src/lightning/pytorch/accelerators/hpu.py
@@ -35,7 +35,10 @@ if _HPU_AVAILABLE:
 
 
 class HPUAccelerator(Accelerator):
-    """Accelerator for HPU devices."""
+    """Accelerator for HPU devices.
+
+    .. warning::  Use of this accelerator beyond import and instantiation is experimental.
+    """
 
     def setup_device(self, device: torch.device) -> None:
         """

--- a/src/lightning/pytorch/accelerators/ipu.py
+++ b/src/lightning/pytorch/accelerators/ipu.py
@@ -31,7 +31,10 @@ else:
 
 
 class IPUAccelerator(Accelerator):
-    """Accelerator for IPUs."""
+    """Accelerator for IPUs.
+
+    .. warning::  Use of this accelerator beyond import and instantiation is experimental.
+    """
 
     def setup_device(self, device: torch.device) -> None:
         pass

--- a/src/lightning/pytorch/accelerators/mps.py
+++ b/src/lightning/pytorch/accelerators/mps.py
@@ -24,7 +24,10 @@ from lightning.pytorch.utilities.imports import _PSUTIL_AVAILABLE
 
 
 class MPSAccelerator(Accelerator):
-    """Accelerator for Metal Apple Silicon GPU devices."""
+    """Accelerator for Metal Apple Silicon GPU devices.
+
+    .. warning::  Use of this accelerator beyond import and instantiation is experimental.
+    """
 
     def setup_device(self, device: torch.device) -> None:
         """

--- a/src/lightning/pytorch/accelerators/tpu.py
+++ b/src/lightning/pytorch/accelerators/tpu.py
@@ -22,7 +22,10 @@ from lightning.pytorch.accelerators.accelerator import Accelerator
 
 
 class TPUAccelerator(Accelerator):
-    """Accelerator for TPU devices."""
+    """Accelerator for TPU devices.
+
+    .. warning::  Use of this accelerator beyond import and instantiation is experimental.
+    """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         if not _XLA_AVAILABLE:

--- a/src/lightning/pytorch/callbacks/batch_size_finder.py
+++ b/src/lightning/pytorch/callbacks/batch_size_finder.py
@@ -34,7 +34,7 @@ class BatchSizeFinder(Callback):
     ``trainer.{fit,validate,test,predict}``. Internally it calls the respective step function ``steps_per_trial``
     times for each batch size until one of the batch sizes generates an OOM error.
 
-    .. warning::  This is an experimental feature.
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
     Args:
         mode: search strategy to update the batch size:

--- a/src/lightning/pytorch/callbacks/batch_size_finder.py
+++ b/src/lightning/pytorch/callbacks/batch_size_finder.py
@@ -34,6 +34,8 @@ class BatchSizeFinder(Callback):
     ``trainer.{fit,validate,test,predict}``. Internally it calls the respective step function ``steps_per_trial``
     times for each batch size until one of the batch sizes generates an OOM error.
 
+    .. warning::  This is an experimental feature.
+
     Args:
         mode: search strategy to update the batch size:
 

--- a/src/lightning/pytorch/callbacks/finetuning.py
+++ b/src/lightning/pytorch/callbacks/finetuning.py
@@ -40,7 +40,7 @@ class BaseFinetuning(Callback):
     r"""
     This class implements the base logic for writing your own Finetuning Callback.
 
-    .. warning::  This is an experimental feature.
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
     Override ``freeze_before_training`` and ``finetune_function`` methods with your own logic.
 

--- a/src/lightning/pytorch/callbacks/finetuning.py
+++ b/src/lightning/pytorch/callbacks/finetuning.py
@@ -40,6 +40,8 @@ class BaseFinetuning(Callback):
     r"""
     This class implements the base logic for writing your own Finetuning Callback.
 
+    .. warning::  This is an experimental feature.
+
     Override ``freeze_before_training`` and ``finetune_function`` methods with your own logic.
 
     ``freeze_before_training``: This method is called before ``configure_optimizers``

--- a/src/lightning/pytorch/callbacks/lr_finder.py
+++ b/src/lightning/pytorch/callbacks/lr_finder.py
@@ -30,7 +30,7 @@ class LearningRateFinder(Callback):
     """The ``LearningRateFinder`` callback enables the user to do a range test of good initial learning rates, to
     reduce the amount of guesswork in picking a good starting learning rate.
 
-    .. warning::  This is an experimental feature.
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
     Args:
         min_lr: Minimum learning rate to investigate

--- a/src/lightning/pytorch/callbacks/lr_finder.py
+++ b/src/lightning/pytorch/callbacks/lr_finder.py
@@ -30,6 +30,8 @@ class LearningRateFinder(Callback):
     """The ``LearningRateFinder`` callback enables the user to do a range test of good initial learning rates, to
     reduce the amount of guesswork in picking a good starting learning rate.
 
+    .. warning::  This is an experimental feature.
+
     Args:
         min_lr: Minimum learning rate to investigate
         max_lr: Maximum learning rate to investigate

--- a/src/lightning/pytorch/callbacks/pruning.py
+++ b/src/lightning/pytorch/callbacks/pruning.py
@@ -83,7 +83,7 @@ class ModelPruning(Callback):
         To learn more about pruning with PyTorch, please take a look at
         `this tutorial <https://pytorch.org/tutorials/intermediate/pruning_tutorial.html>`_.
 
-        .. warning::  This is an experimental feature.
+        .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
         .. code-block:: python
 

--- a/src/lightning/pytorch/callbacks/pruning.py
+++ b/src/lightning/pytorch/callbacks/pruning.py
@@ -83,7 +83,7 @@ class ModelPruning(Callback):
         To learn more about pruning with PyTorch, please take a look at
         `this tutorial <https://pytorch.org/tutorials/intermediate/pruning_tutorial.html>`_.
 
-        .. warning:: ``ModelPruning`` is in beta and subject to change.
+        .. warning::  This is an experimental feature.
 
         .. code-block:: python
 

--- a/src/lightning/pytorch/callbacks/stochastic_weight_avg.py
+++ b/src/lightning/pytorch/callbacks/stochastic_weight_avg.py
@@ -59,7 +59,7 @@ class StochasticWeightAveraging(Callback):
         For a SWA explanation, please take a look
         `here <https://pytorch.org/blog/pytorch-1.6-now-includes-stochastic-weight-averaging>`_.
 
-        .. warning::  This is an experimental feature.
+        .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
         .. warning:: ``StochasticWeightAveraging`` is currently not supported for multiple optimizers/schedulers.
 

--- a/src/lightning/pytorch/callbacks/stochastic_weight_avg.py
+++ b/src/lightning/pytorch/callbacks/stochastic_weight_avg.py
@@ -59,7 +59,7 @@ class StochasticWeightAveraging(Callback):
         For a SWA explanation, please take a look
         `here <https://pytorch.org/blog/pytorch-1.6-now-includes-stochastic-weight-averaging>`_.
 
-        .. warning:: ``StochasticWeightAveraging`` is in beta and subject to change.
+        .. warning::  This is an experimental feature.
 
         .. warning:: ``StochasticWeightAveraging`` is currently not supported for multiple optimizers/schedulers.
 

--- a/src/lightning/pytorch/cli.py
+++ b/src/lightning/pytorch/cli.py
@@ -289,8 +289,6 @@ class LightningCLI:
 
         For more info, read :ref:`the CLI docs <lightning-cli>`.
 
-        .. warning:: ``LightningCLI`` is in beta and subject to change.
-
         Args:
             model_class: An optional :class:`~lightning.pytorch.core.module.LightningModule` class to train on or a
                 callable which returns a :class:`~lightning.pytorch.core.module.LightningModule` instance when

--- a/src/lightning/pytorch/demos/boring_classes.py
+++ b/src/lightning/pytorch/demos/boring_classes.py
@@ -27,6 +27,10 @@ from lightning.pytorch.utilities.types import STEP_OUTPUT
 
 
 class RandomDictDataset(Dataset):
+    """
+    .. warning::  This is meant for testing/debugging and is experimental.
+    """
+
     def __init__(self, size: int, length: int):
         self.len = length
         self.data = torch.randn(length, size)
@@ -41,6 +45,10 @@ class RandomDictDataset(Dataset):
 
 
 class RandomDataset(Dataset):
+    """
+    .. warning::  This is meant for testing/debugging and is experimental.
+    """
+
     def __init__(self, size: int, length: int):
         self.len = length
         self.data = torch.randn(length, size)
@@ -53,6 +61,10 @@ class RandomDataset(Dataset):
 
 
 class RandomIterableDataset(IterableDataset):
+    """
+    .. warning::  This is meant for testing/debugging and is experimental.
+    """
+
     def __init__(self, size: int, count: int):
         self.count = count
         self.size = size
@@ -63,6 +75,10 @@ class RandomIterableDataset(IterableDataset):
 
 
 class RandomIterableDatasetWithLen(IterableDataset):
+    """
+    .. warning::  This is meant for testing/debugging and is experimental.
+    """
+
     def __init__(self, size: int, count: int):
         self.count = count
         self.size = size
@@ -76,19 +92,22 @@ class RandomIterableDatasetWithLen(IterableDataset):
 
 
 class BoringModel(LightningModule):
+    """Testing PL Module.
+
+    Use as follows:
+    - subclass
+    - modify the behavior for what you want
+
+    .. warning::  This is meant for testing/debugging and is experimental.
+
+    Example::
+
+        class TestModel(BoringModel):
+            def training_step(self, ...):
+                ...  # do your own thing
+    """
+
     def __init__(self) -> None:
-        """Testing PL Module.
-
-        Use as follows:
-        - subclass
-        - modify the behavior for what you want
-
-        Example::
-
-            class TestModel(BoringModel):
-                def training_step(self, ...):
-                    ...  # do your own thing
-        """
         super().__init__()
         self.layer = torch.nn.Linear(32, 2)
 
@@ -133,6 +152,10 @@ class BoringModel(LightningModule):
 
 
 class BoringDataModule(LightningDataModule):
+    """
+    .. warning::  This is meant for testing/debugging and is experimental.
+    """
+
     def __init__(self) -> None:
         super().__init__()
         self.random_full = RandomDataset(32, 64 * 4)
@@ -164,6 +187,10 @@ class BoringDataModule(LightningDataModule):
 
 
 class ManualOptimBoringModel(BoringModel):
+    """
+    .. warning::  This is meant for testing/debugging and is experimental.
+    """
+
     def __init__(self) -> None:
         super().__init__()
         self.automatic_optimization = False
@@ -179,6 +206,10 @@ class ManualOptimBoringModel(BoringModel):
 
 
 class DemoModel(LightningModule):
+    """
+    .. warning::  This is meant for testing/debugging and is experimental.
+    """
+
     def __init__(self, out_dim: int = 10, learning_rate: float = 0.02):
         super().__init__()
         self.l1 = torch.nn.Linear(32, out_dim)
@@ -198,6 +229,10 @@ class DemoModel(LightningModule):
 
 
 class Net(nn.Module):
+    """
+    .. warning::  This is meant for testing/debugging and is experimental.
+    """
+
     def __init__(self) -> None:
         super().__init__()
         self.conv1 = nn.Conv2d(1, 32, 3, 1)

--- a/src/lightning/pytorch/demos/mnist_datamodule.py
+++ b/src/lightning/pytorch/demos/mnist_datamodule.py
@@ -39,6 +39,8 @@ class _MNIST(Dataset):
 
     We cannot import the tests as they are not distributed with the package.
     See https://github.com/Lightning-AI/lightning/pull/7614#discussion_r671183652 for more context.
+
+    .. warning::  This is meant for testing/debugging and is experimental.
     """
 
     RESOURCES = (

--- a/src/lightning/pytorch/plugins/io/async_plugin.py
+++ b/src/lightning/pytorch/plugins/io/async_plugin.py
@@ -22,9 +22,7 @@ from lightning.pytorch.plugins.io.wrapper import _WrappingCheckpointIO
 class AsyncCheckpointIO(_WrappingCheckpointIO):
     """``AsyncCheckpointIO`` enables saving the checkpoints asynchronously in a thread.
 
-    .. warning::
-
-        This is currently an experimental plugin/feature and API changes are to be expected.
+    .. warning::  This is an experimental feature.
 
     Args:
         checkpoint_io: A checkpoint IO plugin that is used as the basis for async checkpointing.

--- a/src/lightning/pytorch/plugins/io/async_plugin.py
+++ b/src/lightning/pytorch/plugins/io/async_plugin.py
@@ -22,7 +22,7 @@ from lightning.pytorch.plugins.io.wrapper import _WrappingCheckpointIO
 class AsyncCheckpointIO(_WrappingCheckpointIO):
     """``AsyncCheckpointIO`` enables saving the checkpoints asynchronously in a thread.
 
-    .. warning::  This is an experimental feature.
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
     Args:
         checkpoint_io: A checkpoint IO plugin that is used as the basis for async checkpointing.

--- a/src/lightning/pytorch/plugins/io/hpu_plugin.py
+++ b/src/lightning/pytorch/plugins/io/hpu_plugin.py
@@ -24,7 +24,10 @@ from lightning.fabric.utilities.types import _PATH
 
 
 class HPUCheckpointIO(TorchCheckpointIO):
-    """CheckpointIO to save checkpoints for HPU training strategies."""
+    """CheckpointIO to save checkpoints for HPU training strategies.
+
+    .. warning::  This is an experimental feature.
+    """
 
     def save_checkpoint(self, checkpoint: Dict[str, Any], path: _PATH, storage_options: Optional[Any] = None) -> None:
         """Save model/training states as a checkpoint file through state-dump and file-write.

--- a/src/lightning/pytorch/plugins/io/hpu_plugin.py
+++ b/src/lightning/pytorch/plugins/io/hpu_plugin.py
@@ -26,7 +26,7 @@ from lightning.fabric.utilities.types import _PATH
 class HPUCheckpointIO(TorchCheckpointIO):
     """CheckpointIO to save checkpoints for HPU training strategies.
 
-    .. warning::  This is an experimental feature.
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
     """
 
     def save_checkpoint(self, checkpoint: Dict[str, Any], path: _PATH, storage_options: Optional[Any] = None) -> None:

--- a/src/lightning/pytorch/plugins/precision/deepspeed.py
+++ b/src/lightning/pytorch/plugins/precision/deepspeed.py
@@ -37,6 +37,8 @@ _PRECISION_INPUT = Literal["32-true", "16-mixed", "bf16-mixed"]
 class DeepSpeedPrecisionPlugin(PrecisionPlugin):
     """Precision plugin for DeepSpeed integration.
 
+    .. warning::  This is an experimental feature.
+
     Args:
         precision: Full precision (32), half precision (16) or bfloat16 precision (bf16).
     Raises:

--- a/src/lightning/pytorch/plugins/precision/deepspeed.py
+++ b/src/lightning/pytorch/plugins/precision/deepspeed.py
@@ -37,7 +37,7 @@ _PRECISION_INPUT = Literal["32-true", "16-mixed", "bf16-mixed"]
 class DeepSpeedPrecisionPlugin(PrecisionPlugin):
     """Precision plugin for DeepSpeed integration.
 
-    .. warning::  This is an experimental feature.
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
     Args:
         precision: Full precision (32), half precision (16) or bfloat16 precision (bf16).

--- a/src/lightning/pytorch/plugins/precision/fsdp.py
+++ b/src/lightning/pytorch/plugins/precision/fsdp.py
@@ -30,7 +30,7 @@ else:
 class FSDPMixedPrecisionPlugin(MixedPrecisionPlugin):
     """AMP for Fully Sharded Data Parallel (FSDP) Training.
 
-    .. warning::  This is an experimental feature.
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
     """
 
     def __init__(

--- a/src/lightning/pytorch/plugins/precision/fsdp.py
+++ b/src/lightning/pytorch/plugins/precision/fsdp.py
@@ -28,7 +28,10 @@ else:
 
 
 class FSDPMixedPrecisionPlugin(MixedPrecisionPlugin):
-    """AMP for Fully Sharded Data Parallel (FSDP) Training."""
+    """AMP for Fully Sharded Data Parallel (FSDP) Training.
+
+    .. warning::  This is an experimental feature.
+    """
 
     def __init__(
         self, precision: Literal["16-mixed", "bf16-mixed"], device: str, scaler: Optional[ShardedGradScaler] = None

--- a/src/lightning/pytorch/plugins/precision/hpu.py
+++ b/src/lightning/pytorch/plugins/precision/hpu.py
@@ -28,7 +28,7 @@ _PRECISION_INPUT = Literal["32-true", "16-mixed", "bf16-mixed"]
 class HPUPrecisionPlugin(PrecisionPlugin):
     """Plugin that enables bfloat/half support on HPUs.
 
-    .. warning::  This is an experimental feature.
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
     Args:
         precision: The precision to use.

--- a/src/lightning/pytorch/plugins/precision/hpu.py
+++ b/src/lightning/pytorch/plugins/precision/hpu.py
@@ -28,6 +28,8 @@ _PRECISION_INPUT = Literal["32-true", "16-mixed", "bf16-mixed"]
 class HPUPrecisionPlugin(PrecisionPlugin):
     """Plugin that enables bfloat/half support on HPUs.
 
+    .. warning::  This is an experimental feature.
+
     Args:
         precision: The precision to use.
         opt_level: Choose optimization level for hmp.

--- a/src/lightning/pytorch/plugins/precision/ipu.py
+++ b/src/lightning/pytorch/plugins/precision/ipu.py
@@ -33,7 +33,7 @@ _PRECISION_INPUT = Literal["32-true", "16-mixed"]
 class IPUPrecisionPlugin(PrecisionPlugin):
     """Precision plugin for IPU integration.
 
-    .. warning::  This is an experimental feature.
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
     Raises:
         ValueError:

--- a/src/lightning/pytorch/plugins/precision/ipu.py
+++ b/src/lightning/pytorch/plugins/precision/ipu.py
@@ -33,6 +33,8 @@ _PRECISION_INPUT = Literal["32-true", "16-mixed"]
 class IPUPrecisionPlugin(PrecisionPlugin):
     """Precision plugin for IPU integration.
 
+    .. warning::  This is an experimental feature.
+
     Raises:
         ValueError:
             If the precision is neither 16-mixed nor 32-true.

--- a/src/lightning/pytorch/serve/servable_module.py
+++ b/src/lightning/pytorch/serve/servable_module.py
@@ -9,9 +9,7 @@ class ServableModule(ABC, torch.nn.Module):
 
     """The ServableModule provides a simple API to make your model servable.
 
-    .. warning::
-
-        This is currently an experimental feature and API changes are to be expected.
+    .. warning::  This is an experimental feature.
 
     Here is an example of how to use the ``ServableModule`` module.
 

--- a/src/lightning/pytorch/serve/servable_module.py
+++ b/src/lightning/pytorch/serve/servable_module.py
@@ -9,7 +9,7 @@ class ServableModule(ABC, torch.nn.Module):
 
     """The ServableModule provides a simple API to make your model servable.
 
-    .. warning::  This is an experimental feature.
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
     Here is an example of how to use the ``ServableModule`` module.
 

--- a/src/lightning/pytorch/serve/servable_module_validator.py
+++ b/src/lightning/pytorch/serve/servable_module_validator.py
@@ -26,9 +26,7 @@ _logger = logging.getLogger(__name__)
 class ServableModuleValidator(Callback):
     """The ServableModuleValidator validates to validate a model correctly implement the ServableModule API.
 
-    .. warning::
-
-        This is currently an experimental feature and API changes are to be expected.
+    .. warning::  This is an experimental feature.
 
     Arguments:
         optimization: The format in which the model should be tested while being served.

--- a/src/lightning/pytorch/serve/servable_module_validator.py
+++ b/src/lightning/pytorch/serve/servable_module_validator.py
@@ -26,7 +26,7 @@ _logger = logging.getLogger(__name__)
 class ServableModuleValidator(Callback):
     """The ServableModuleValidator validates to validate a model correctly implement the ServableModule API.
 
-    .. warning::  This is an experimental feature.
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
     Arguments:
         optimization: The format in which the model should be tested while being served.

--- a/src/lightning/pytorch/strategies/deepspeed.py
+++ b/src/lightning/pytorch/strategies/deepspeed.py
@@ -119,7 +119,7 @@ class DeepSpeedStrategy(DDPStrategy):
         billion parameter models. `For more information: https://pytorch-
         lightning.readthedocs.io/en/stable/advanced/model_parallel.html#deepspeed`.
 
-        .. warning::  This is an experimental feature.
+        .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
         Defaults have been set to enable ZeRO-Offload and some have been taken from the link below.
         These defaults have been set generally, but may require tuning for optimum performance based on your model size.

--- a/src/lightning/pytorch/strategies/deepspeed.py
+++ b/src/lightning/pytorch/strategies/deepspeed.py
@@ -119,7 +119,7 @@ class DeepSpeedStrategy(DDPStrategy):
         billion parameter models. `For more information: https://pytorch-
         lightning.readthedocs.io/en/stable/advanced/model_parallel.html#deepspeed`.
 
-        .. warning:: ``DeepSpeedStrategy`` is in beta and subject to change.
+        .. warning::  This is an experimental feature.
 
         Defaults have been set to enable ZeRO-Offload and some have been taken from the link below.
         These defaults have been set generally, but may require tuning for optimum performance based on your model size.

--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -74,8 +74,7 @@ log = logging.getLogger(__name__)
 class FSDPStrategy(ParallelStrategy):
     r"""Strategy for Fully Sharded Data Parallel provided by torch.distributed.
 
-    .. warning:: ``FSDPStrategy`` is in BETA and subject to change. The interface can
-        bring breaking changes and new features with the next release of PyTorch.
+    .. warning::  This is an experimental feature.
 
     Fully Sharded Training shards the entire model across all available GPUs, allowing you to scale model
     size, whilst using efficient communication to reduce overhead. In practice, this means we can remain

--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -74,7 +74,7 @@ log = logging.getLogger(__name__)
 class FSDPStrategy(ParallelStrategy):
     r"""Strategy for Fully Sharded Data Parallel provided by torch.distributed.
 
-    .. warning::  This is an experimental feature.
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
     Fully Sharded Training shards the entire model across all available GPUs, allowing you to scale model
     size, whilst using efficient communication to reduce overhead. In practice, this means we can remain

--- a/src/lightning/pytorch/strategies/hpu_parallel.py
+++ b/src/lightning/pytorch/strategies/hpu_parallel.py
@@ -38,7 +38,10 @@ log = logging.getLogger(__name__)
 
 
 class HPUParallelStrategy(DDPStrategy):
-    """Strategy for distributed training on multiple HPU devices."""
+    """Strategy for distributed training on multiple HPU devices.
+
+    .. warning::  This is an experimental feature.
+    """
 
     strategy_name = "hpu_parallel"
 

--- a/src/lightning/pytorch/strategies/hpu_parallel.py
+++ b/src/lightning/pytorch/strategies/hpu_parallel.py
@@ -40,7 +40,7 @@ log = logging.getLogger(__name__)
 class HPUParallelStrategy(DDPStrategy):
     """Strategy for distributed training on multiple HPU devices.
 
-    .. warning::  This is an experimental feature.
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
     """
 
     strategy_name = "hpu_parallel"

--- a/src/lightning/pytorch/strategies/ipu.py
+++ b/src/lightning/pytorch/strategies/ipu.py
@@ -43,7 +43,10 @@ else:
 
 
 class IPUStrategy(ParallelStrategy):
-    """Plugin for training on IPU devices."""
+    """Plugin for training on IPU devices.
+
+    .. warning::  This is an experimental feature.
+    """
 
     strategy_name = "ipu_strategy"
 

--- a/src/lightning/pytorch/strategies/ipu.py
+++ b/src/lightning/pytorch/strategies/ipu.py
@@ -45,7 +45,7 @@ else:
 class IPUStrategy(ParallelStrategy):
     """Plugin for training on IPU devices.
 
-    .. warning::  This is an experimental feature.
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
     """
 
     strategy_name = "ipu_strategy"

--- a/src/lightning/pytorch/strategies/single_hpu.py
+++ b/src/lightning/pytorch/strategies/single_hpu.py
@@ -34,7 +34,7 @@ if _HPU_AVAILABLE:
 class SingleHPUStrategy(SingleDeviceStrategy):
     """Strategy for training on single HPU device.
 
-    .. warning::  This is an experimental feature.
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
     """
 
     strategy_name = "hpu_single"

--- a/src/lightning/pytorch/strategies/single_hpu.py
+++ b/src/lightning/pytorch/strategies/single_hpu.py
@@ -32,7 +32,10 @@ if _HPU_AVAILABLE:
 
 
 class SingleHPUStrategy(SingleDeviceStrategy):
-    """Strategy for training on single HPU device."""
+    """Strategy for training on single HPU device.
+
+    .. warning::  This is an experimental feature.
+    """
 
     strategy_name = "hpu_single"
 

--- a/src/lightning/pytorch/utilities/compile.py
+++ b/src/lightning/pytorch/utilities/compile.py
@@ -23,7 +23,7 @@ from lightning.pytorch.strategies import DDPStrategy, FSDPStrategy, SingleDevice
 def from_compiled(model: "torch._dynamo.OptimizedModule") -> "pl.LightningModule":
     """Returns an instance LightningModule from the output of ``torch.compile``.
 
-    .. warning::  This is an experimental feature.
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
     The ``torch.compile`` function returns a ``torch._dynamo.OptimizedModule``, which wraps the LightningModule
     passed in as an argument, but doesn't inherit from it. This means that the output of ``torch.compile`` behaves
@@ -71,7 +71,7 @@ def from_compiled(model: "torch._dynamo.OptimizedModule") -> "pl.LightningModule
 def to_uncompiled(model: Union["pl.LightningModule", "torch._dynamo.OptimizedModule"]) -> "pl.LightningModule":
     """Returns an instance of LightningModule without any compilation optimizations from a compiled model.
 
-    .. warning::  This is an experimental feature.
+    .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 
     This takes either a ``torch._dynamo.OptimizedModule`` returned by ``torch.compile()`` or a ``LightningModule``
     returned by ``from_compiled``.

--- a/src/lightning/pytorch/utilities/compile.py
+++ b/src/lightning/pytorch/utilities/compile.py
@@ -23,6 +23,8 @@ from lightning.pytorch.strategies import DDPStrategy, FSDPStrategy, SingleDevice
 def from_compiled(model: "torch._dynamo.OptimizedModule") -> "pl.LightningModule":
     """Returns an instance LightningModule from the output of ``torch.compile``.
 
+    .. warning::  This is an experimental feature.
+
     The ``torch.compile`` function returns a ``torch._dynamo.OptimizedModule``, which wraps the LightningModule
     passed in as an argument, but doesn't inherit from it. This means that the output of ``torch.compile`` behaves
     like a LightningModule, but it doesn't inherit from it (i.e. `isinstance` will fail).
@@ -68,6 +70,8 @@ def from_compiled(model: "torch._dynamo.OptimizedModule") -> "pl.LightningModule
 
 def to_uncompiled(model: Union["pl.LightningModule", "torch._dynamo.OptimizedModule"]) -> "pl.LightningModule":
     """Returns an instance of LightningModule without any compilation optimizations from a compiled model.
+
+    .. warning::  This is an experimental feature.
 
     This takes either a ``torch._dynamo.OptimizedModule`` returned by ``torch.compile()`` or a ``LightningModule``
     returned by ``from_compiled``.


### PR DESCRIPTION
## What does this PR do?

Adds "experimental" markers to docs and docstrings that need it. This complies with https://pytorch-lightning.readthedocs.io/en/latest/versioning.html#experimental-api

List of changes

Promoted to stable
- Strategy registry
- LightningCLI

PyTorch Lightning experimental
- Accelerator API
- MPS internals
- TPU internals
- FSDP integration
- DeepSpeed integration
- HPU integration
- IPU integration
- BatchSizeFinder callback
- LRFinder callback
- Finetuning callback
- SWA callback
- Pruning callback
- Demos
- Async checkpoint plugin
- Servable module
- torch.compile integration

Fabric experimental:
- Accelerator API
- MPS internals
- TPU internals
- FSDP integration
- DeepSpeed integration
- Collectives
- CheckpointIO


cc @borda @carmocca @justusschock @awaelchli