### PR TITLE
Force keyword-only usage to init Fabric

### DIFF
--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -78,6 +78,7 @@ class Fabric:
 
     def __init__(
         self,
+        *,
         accelerator: Union[str, Accelerator] = "auto",
         strategy: Union[str, Strategy] = "auto",
         devices: Union[List[int], str, int] = "auto",


### PR DESCRIPTION
## What does this PR do?

Passing Fabric arguments positionally is error-prone. We should force it to be keyword-only.


cc @borda @carmocca @justusschock @awaelchli