### PR TITLE
Return the correct IPU root_device

### DIFF
--- a/src/lightning/pytorch/accelerators/ipu.py
+++ b/src/lightning/pytorch/accelerators/ipu.py
@@ -52,9 +52,9 @@ class IPUAccelerator(Accelerator):
         return devices
 
     @staticmethod
-    def get_parallel_devices(devices: int) -> List[int]:
+    def get_parallel_devices(devices: int) -> List[torch.device]:
         """Gets parallel devices for the Accelerator."""
-        return list(range(devices))
+        return [torch.device("ipu", i) for i in range(devices)]
 
     @staticmethod
     def auto_device_count() -> int:

--- a/src/lightning/pytorch/strategies/ipu.py
+++ b/src/lightning/pytorch/strategies/ipu.py
@@ -347,9 +347,9 @@ class IPUStrategy(ParallelStrategy):
         self.poptorch_models[RunningStage.TRAINING].setOptimizer(optimizer)
 
     @property
-    def root_device(self) -> torch.device:  # type: ignore[empty-body]
-        # TODO: this should return `self.parallel_devices[self.local_rank]`
-        pass
+    def root_device(self) -> torch.device:
+        assert self.parallel_devices is not None
+        return self.parallel_devices[self.local_rank]
 
     def model_to_device(self) -> None:
         pass


### PR DESCRIPTION
## What does this PR do?

All accelerators should return a list of `torch.device`s, which is what the strategy expects to get as `strategy.parallel_devices`

Otherwise, there can be silent errors where the wrong device type is used.