### PR TITLE
Improve the error message for installing tensorboardx

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -73,6 +73,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed issue where the wrapped dataloader `iter()` would be called twice ([#16841](https://github.com/Lightning-AI/lightning/pull/16841))
 
+- Improved the error message for installing tensorboard or tensorboardx ([#17053](https://github.com/Lightning-AI/lightning/pull/17053))
+
 
 ## [1.9.4] - 2023-03-01
 

--- a/src/lightning/fabric/loggers/tensorboard.py
+++ b/src/lightning/fabric/loggers/tensorboard.py
@@ -91,7 +91,8 @@ class TensorBoardLogger(Logger):
     ):
         if not _TENSORBOARD_AVAILABLE and not _TENSORBOARDX_AVAILABLE:
             raise ModuleNotFoundError(
-                "Neither `tensorboard` nor `tensorboardX` is available. Try `pip install`ing either."
+                "Neither `tensorboard` nor `tensorboardX` is available. Try `pip install`ing either.\n"
+                f"{str(_TENSORBOARDX_AVAILABLE)}\n{str(_TENSORBOARD_AVAILABLE)}"
             )
         super().__init__()
         root_dir = os.fspath(root_dir)

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -433,6 +433,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed an issue where `DistributedSampler.set_epoch` wasn't getting called during `trainer.predict` ([#16785](https://github.com/Lightning-AI/lightning/pull/16785), [#16826](https://github.com/Lightning-AI/lightning/pull/16826))
 
 
+- Improved the error message for installing tensorboard or tensorboardx ([#17053](https://github.com/Lightning-AI/lightning/pull/17053))
+
+
 ## [1.9.4] - 2023-03-01
 
 ### Added

--- a/src/lightning/pytorch/loggers/tensorboard.py
+++ b/src/lightning/pytorch/loggers/tensorboard.py
@@ -117,7 +117,10 @@ class TensorBoardLogger(Logger, FabricTensorBoardLogger):
             **kwargs,
         )
         if log_graph and not _TENSORBOARD_AVAILABLE:
-            rank_zero_warn("You set `TensorBoardLogger(log_graph=True)` but `tensorboard` is not available.")
+            rank_zero_warn(
+                "You set `TensorBoardLogger(log_graph=True)` but `tensorboard` is not available.\n"
+                f"{str(_TENSORBOARD_AVAILABLE)}"
+            )
         self._log_graph = log_graph and _TENSORBOARD_AVAILABLE
         self.hparams: Union[Dict[str, Any], Namespace] = {}
 


### PR DESCRIPTION
## What does this PR do?

Fixes #16810

Adds information to the error message that helps the user determine why tensorboard or tensorboardx can't be imported.


cc @borda @awaelchli @carmocca @justusschock