### PR TITLE
Remove `pip install pytorch-lightning` warning in docs

### DIFF
--- a/docs/source-pytorch/starter/installation.rst
+++ b/docs/source-pytorch/starter/installation.rst
@@ -6,9 +6,6 @@
 Installation
 ############
 
-.. warning:: pip install pytorch-lightning has been deprecated and will stop being updated June 2023. Use pip install lightning instead.
-
-----
 
 *****************************
 Apple Silicon (M1/M2/M3) Macs


### PR DESCRIPTION
## What does this PR do?

As discussed with @lantiga, the warning was added in the past but we are going to keep the pytorch-lightning package up for longer. The warning will be added back in the future when it becomes appropriate. 