### PR TITLE
Typo fix: on_training_epoch_end -> on_train_epoch_end

### DIFF
--- a/docs/source-pytorch/common/lightning_module.rst
+++ b/docs/source-pytorch/common/lightning_module.rst
@@ -226,7 +226,7 @@ Train Epoch-level Operations
 ============================
 
 In the case that you need to make use of all the outputs from each :meth:`~lightning.pytorch.LightningModule.training_step`,
-override the :meth:`~lightning.pytorch.LightningModule.on_training_epoch_end` method.
+override the :meth:`~lightning.pytorch.LightningModule.on_train_epoch_end` method.
 
 .. code-block:: python
 

--- a/docs/source-pytorch/upgrade/sections/1_4_regular.rst
+++ b/docs/source-pytorch/upgrade/sections/1_4_regular.rst
@@ -7,7 +7,7 @@
      - Ref
 
    * - relied on the ``outputs`` in your  ``LightningModule.on_train_epoch_end`` or ``Callback.on_train_epoch_end`` hooks
-     - rely on either ``on_training_epoch_end`` or set outputs as attributes in your ``LightningModule`` instances and access them from the hook
+     - rely on either ``on_train_epoch_end`` or set outputs as attributes in your ``LightningModule`` instances and access them from the hook
      - #7339
 
    * - accessed ``Trainer.truncated_bptt_steps``

--- a/docs/source-pytorch/upgrade/sections/1_9_advanced.rst
+++ b/docs/source-pytorch/upgrade/sections/1_9_advanced.rst
@@ -15,7 +15,7 @@
      - #16748
 
    * - implemented ``LightningModule.training_epoch_end`` hooks
-     - port your logic to  ``LightningModule.on_training_epoch_end`` hook
+     - port your logic to  ``LightningModule.on_train_epoch_end`` hook
      - #16520
 
    * - implemented ``LightningModule.validation_epoch_end`` hook

--- a/tests/tests_pytorch/trainer/logging_/test_eval_loop_logging.py
+++ b/tests/tests_pytorch/trainer/logging_/test_eval_loop_logging.py
@@ -597,7 +597,7 @@ def test_multiple_dataloaders_reset(val_check_interval, tmpdir):
             self.log("batch_idx", value, on_step=True, on_epoch=True, prog_bar=True)
             return out
 
-        def on_training_epoch_end(self):
+        def on_train_epoch_end(self):
             metrics = self.trainer.progress_bar_metrics
             v = 15 if self.current_epoch == 0 else 150
             assert metrics["batch_idx_epoch"] == (v / 5.0)


### PR DESCRIPTION
## What does this PR do?

There are several typos in the documentation that refer to `on_training_epoch_end`. The correct name of the step is `on_train_epoch_end`. This PR fixes those typos.

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>