### PR TITLE
Restructure Fabric docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **NEW- Lightning 2.0 is featuring a clean and stable API!!**
 
-----
+______________________________________________________________________
 
 <p align="center">
   <a href="https://www.lightning.ai/">Lightning.ai</a> •
@@ -39,7 +39,6 @@
 -->
 
 </div>
-
 
 ## Install Lightning
 
@@ -92,31 +91,31 @@ pip install -iU https://test.pypi.org/simple/ pytorch-lightning
 </details>
 <!-- end skipping PyPI description -->
 
-----
+______________________________________________________________________
 
 ## Lightning has 3 core packages
 
-[PyTorch Lightning: Train and deploy PyTorch at scale](#pytorch-lightning-train-and-deploy-pytorch-at-scale).   
-[Lightning Fabric: Expert control](#lightning-fabric-expert-control).   
-[Lightning Apps: Build AI products and ML workflows](#lightning-apps-build-ai-products-and-ml-workflows).    
+[PyTorch Lightning: Train and deploy PyTorch at scale](#pytorch-lightning-train-and-deploy-pytorch-at-scale).
+[Lightning Fabric: Expert control](#lightning-fabric-expert-control).
+[Lightning Apps: Build AI products and ML workflows](#lightning-apps-build-ai-products-and-ml-workflows).
 
-Lightning gives you granular control over how much abstraction you want to add over PyTorch.   
+Lightning gives you granular control over how much abstraction you want to add over PyTorch.
 
 <div align="center">
     <img src="https://pl-public-data.s3.amazonaws.com/assets_lightning/continuum.png" width="80%">
 </div>
 
-----
+______________________________________________________________________
 
 # PyTorch Lightning: Train and Deploy PyTorch at Scale
 
-PyTorch Lightning is just organized PyTorch - Lightning disentangles PyTorch code to decouple the science from the engineering.    
+PyTorch Lightning is just organized PyTorch - Lightning disentangles PyTorch code to decouple the science from the engineering.
 
 ![PT to PL](docs/source-pytorch/_static/images/general/pl_quick_start_full_compressed.gif)
 
-----
+______________________________________________________________________
 
-### Hello simple model 
+### Hello simple model
 
 ```python
 # main.py
@@ -125,10 +124,11 @@ import os, torch, torch.nn as nn, torch.utils.data as data, torchvision as tv, t
 import lightning as L
 
 # --------------------------------
-# Step 1: Define a LightningModule 
+# Step 1: Define a LightningModule
 # --------------------------------
-# A LightningModule (nn.Module subclass) defines a full *system* 
+# A LightningModule (nn.Module subclass) defines a full *system*
 # (ie: an LLM, difussion model, autoencoder, or simple image classifier).
+
 
 class LitAutoEncoder(L.LightningModule):
     def __init__(self):
@@ -155,6 +155,7 @@ class LitAutoEncoder(L.LightningModule):
         optimizer = torch.optim.Adam(self.parameters(), lr=1e-3)
         return optimizer
 
+
 # -------------------
 # Step 2: Define data
 # -------------------
@@ -170,11 +171,13 @@ trainer.fit(autoencoder, data.DataLoader(train), data.DataLoader(val))
 ```
 
 Run the model on your terminal
-``` bash
+
+```bash
 pip install torchvision
 python main.py
 ```
-----
+
+______________________________________________________________________
 
 ## Advanced features
 
@@ -197,6 +200,7 @@ trainer = Trainer(accelerator="gpu", devices=8)
 # 256 GPUs
 trainer = Trainer(accelerator="gpu", devices=8, num_nodes=32)
 ```
+
 </details>
 
 <details>
@@ -206,6 +210,7 @@ trainer = Trainer(accelerator="gpu", devices=8, num_nodes=32)
 # no code changes needed
 trainer = Trainer(accelerator="tpu", devices=8)
 ```
+
 </details>
 
 <details>
@@ -246,12 +251,13 @@ trainer = Trainer(logger=loggers.NeptuneLogger())
 
 <details>
 
-  <summary>Early Stopping</summary>
+<summary>Early Stopping</summary>
 
 ```python
 es = EarlyStopping(monitor="val_loss")
 trainer = Trainer(callbacks=[es])
 ```
+
 </details>
 
 <details>
@@ -261,6 +267,7 @@ trainer = Trainer(callbacks=[es])
 checkpointing = ModelCheckpoint(monitor="val_loss")
 trainer = Trainer(callbacks=[checkpointing])
 ```
+
 </details>
 
 <details>
@@ -271,6 +278,7 @@ trainer = Trainer(callbacks=[checkpointing])
 autoencoder = LitAutoEncoder()
 torch.jit.save(autoencoder.to_torchscript(), "model.pt")
 ```
+
 </details>
 
 <details>
@@ -287,7 +295,7 @@ with tempfile.NamedTemporaryFile(suffix=".onnx", delete=False) as tmpfile:
 
 </details>
 
-----
+______________________________________________________________________
 
 ## Advantages over unstructured PyTorch
 
@@ -300,20 +308,19 @@ with tempfile.NamedTemporaryFile(suffix=".onnx", delete=False) as tmpfile:
 - [Tested rigorously with every new PR](https://github.com/Lightning-AI/lightning/tree/master/tests). We test every combination of PyTorch and Python supported versions, every OS, multi GPUs and even TPUs.
 - Minimal running speed overhead (about 300 ms per epoch compared with pure PyTorch).
 
-----
+______________________________________________________________________
 
 <div align="center">
     <a href="https://lightning.ai/docs/pytorch/stable/">Read the PyTorch Lightning docs</a>
 </div>
 
-----
+______________________________________________________________________
 
 # Lightning Fabric: Expert control.
 
 Run on any device at any scale with expert-level control over PyTorch training loop and scaling strategy. You can even write your own Trainer.
 
 Fabric is designed for the most complex models like foundation model scaling, LLMs, diffussion, transformers, reinforcement learning, active learning.
-
 
 ```diff
 + import lightning as L
@@ -354,13 +361,13 @@ Fabric is designed for the most complex models like foundation model scaling, LL
 - Designed with multi-billion parameter models in mind
 - Build your own custom Trainer using Fabric primitives for training checkpointing, logging, and more
 
-----
+______________________________________________________________________
 
 <div align="center">
     <a href="https://lightning.ai/docs/fabric/stable/">Read the Lightning Fabric docs</a>
 </div>
 
-----
+______________________________________________________________________
 
 # Lightning Apps: Build AI products and ML workflows
 
@@ -376,23 +383,27 @@ Lightning Apps remove the cloud infrastructure boilerplate so you can focus on s
 # app.py
 import lightning as L
 
+
 class TrainComponent(L.LightningWork):
     def run(self, x):
-        print(f'train a model on {x}')
+        print(f"train a model on {x}")
+
 
 class AnalyzeComponent(L.LightningWork):
     def run(self, x):
-        print(f'analyze model on {x}')
+        print(f"analyze model on {x}")
+
 
 class WorkflowOrchestrator(L.LightningFlow):
     def __init__(self) -> None:
         super().__init__()
-        self.train = TrainComponent(cloud_compute=L.CloudCompute('cpu'))
-        self.analyze = AnalyzeComponent(cloud_compute=L.CloudCompute('gpu'))
+        self.train = TrainComponent(cloud_compute=L.CloudCompute("cpu"))
+        self.analyze = AnalyzeComponent(cloud_compute=L.CloudCompute("gpu"))
 
     def run(self):
         self.train.run("CPU machine 1")
         self.analyze.run("GPU machine 2")
+
 
 app = L.LightningApp(WorkflowOrchestrator())
 ```
@@ -407,13 +418,13 @@ lightning run app app.py --setup --cloud
 lightning run app app.py
 ```
 
-----
+______________________________________________________________________
 
 <div align="center">
     <a href="https://lightning.ai/docs/app/stable/">Read the Lightning Apps docs</a>
 </div>
 
----- 
+______________________________________________________________________
 
 ## Examples
 
@@ -444,7 +455,7 @@ lightning run app app.py
 - [Logistic Regression](https://lightning-bolts.readthedocs.io/en/stable/models/classic_ml.html#logistic-regression)
 - [Linear Regression](https://lightning-bolts.readthedocs.io/en/stable/models/classic_ml.html#linear-regression)
 
-----
+______________________________________________________________________
 
 ## Continuous Integration
 
@@ -470,7 +481,7 @@ Lightning is rigorously tested across multiple CPUs, GPUs, TPUs, IPUs, and HPUs 
 </center>
 </details>
 
-----
+______________________________________________________________________
 
 ## Community
 

--- a/docs/source-fabric/fundamentals/convert.rst
+++ b/docs/source-fabric/fundamentals/convert.rst
@@ -119,13 +119,13 @@ Next steps
     :button_link: accelerators.html
     :col_css: col-md-4
     :height: 150
-    :tag: intermediate
+    :tag: basic
 
 .. displayitem::
     :header: Build your own Trainer
     :description: Learn how to build a trainer tailored for you
     :col_css: col-md-4
-    :button_link: ../index.html#build-your-own-trainer
+    :button_link: ../levels/intermediate
     :height: 150
     :tag: intermediate
 

--- a/docs/source-fabric/fundamentals/launch.rst
+++ b/docs/source-fabric/fundamentals/launch.rst
@@ -226,7 +226,7 @@ Next steps
     :col_css: col-md-4
     :button_link: ../fundamentals/precision.html
     :height: 160
-    :tag: intermediate
+    :tag: basic
 
 .. displayitem::
     :header: Distributed Communication

--- a/docs/source-fabric/index.rst
+++ b/docs/source-fabric/index.rst
@@ -1,8 +1,8 @@
 .. include:: links.rst
 
-################
-Lightning Fabric
-################
+####################
+Welcome to ⚡ Fabric
+####################
 
 Fabric is the fast and lightweight way to scale PyTorch models without boilerplate code.
 
@@ -102,173 +102,6 @@ Fabric ships directly with Lightning. Install it with
 
 For alternative ways to install, read the :doc:`installation guide <fundamentals/installation>`.
 
-----
-
-
-************
-Fundamentals
-************
-
-.. raw:: html
-
-    <div class="display-card-container">
-        <div class="row">
-
-.. displayitem::
-    :header: Getting Started
-    :description: Learn how to add Fabric to your PyTorch code
-    :button_link: fundamentals/convert.html
-    :col_css: col-md-4
-    :height: 150
-    :tag: basic
-
-.. displayitem::
-    :header: Accelerators
-    :description: Take advantage of your hardware with a switch of a flag
-    :button_link: fundamentals/accelerators.html
-    :col_css: col-md-4
-    :height: 150
-    :tag: intermediate
-
-.. displayitem::
-    :header: Code Structure
-    :description: Best practices for setting up your training script with Fabric
-    :button_link: fundamentals/code_structure.html
-    :col_css: col-md-4
-    :height: 150
-    :tag: basic
-
-.. displayitem::
-    :header: Launch Distributed Training
-    :description: Launch a Python script on multiple devices and machines
-    :button_link: fundamentals/launch.html
-    :col_css: col-md-4
-    :height: 150
-    :tag: intermediate
-
-.. displayitem::
-    :header: Fabric in Notebooks
-    :description: Launch on multiple devices from within a Jupyter notebook
-    :button_link: fundamentals/notebooks.html
-    :col_css: col-md-4
-    :height: 150
-    :tag: basic
-
-.. displayitem::
-    :header: Mixed Precision Training
-    :description: Save memory and speed up training using mixed precision
-    :button_link: fundamentals/precision.html
-    :col_css: col-md-4
-    :height: 150
-    :tag: intermediate
-
-.. raw:: html
-
-        </div>
-    </div>
-
-
-----
-
-
-**********************
-Build Your Own Trainer
-**********************
-
-.. raw:: html
-
-    <div class="display-card-container">
-        <div class="row">
-
-.. displayitem::
-    :header: The LightningModule
-    :description: Organize your code in a LightningModule and use it with Fabric
-    :button_link: guide/lightning_module.html
-    :col_css: col-md-4
-    :height: 150
-    :tag: basic
-
-.. displayitem::
-    :header: Callbacks
-    :description: Make use of the Callback system in Fabric
-    :button_link: guide/callbacks.html
-    :col_css: col-md-4
-    :height: 150
-    :tag: basic
-
-.. displayitem::
-    :header: Logging
-    :description: Learn how Fabric helps you remove boilerplate code for tracking metrics with a logger
-    :button_link: guide/logging.html
-    :col_css: col-md-4
-    :height: 150
-    :tag: basic
-
-.. displayitem::
-    :header: Checkpoints
-    :description: Efficient saving and loading of model weights, training state, hyperparameters and more.
-    :button_link: guide/checkpoint.html
-    :col_css: col-md-4
-    :height: 150
-    :tag: basic
-
-.. displayitem::
-    :header: Trainer Template
-    :description: Take our Fabric Trainer template and customize it for your needs
-    :button_link: https://github.com/Lightning-AI/lightning/tree/master/examples/fabric/build_your_own_trainer
-    :col_css: col-md-4
-    :height: 150
-    :tag: intermediate
-
-.. raw:: html
-
-        </div>
-    </div>
-
-
-----
-
-
-***************
-Advanced Topics
-***************
-
-.. raw:: html
-
-    <div class="display-card-container">
-        <div class="row">
-
-.. displayitem::
-    :header: Efficient Gradient Accumulation
-    :description: Learn how to perform efficient gradient accumulation in distributed settings
-    :button_link: advanced/gradient_accumulation.html
-    :col_css: col-md-4
-    :height: 160
-    :tag: advanced
-
-.. displayitem::
-    :header: Distributed Communication
-    :description: Learn all about communication primitives for distributed operation. Gather, reduce, broadcast, etc.
-    :button_link: advanced/distributed_communication.html
-    :col_css: col-md-4
-    :height: 160
-    :tag: advanced
-
-.. displayitem::
-    :header: Multiple Models and Optimizers
-    :description: See how flexible Fabric is to work with multiple models and optimizers!
-    :button_link: advanced/multiple_setup.html
-    :col_css: col-md-4
-    :height: 160
-    :tag: advanced
-
-.. raw:: html
-
-        </div>
-    </div>
-
-
-----
 
 
 .. raw:: html
@@ -278,58 +111,38 @@ Advanced Topics
 .. toctree::
     :maxdepth: 1
     :name: start
-    :caption: Get Started
+    :caption: Home
 
-    Fabric in 5 minutes <fundamentals/convert>
-    Installation <fundamentals/installation>
+    self
+    Install <fundamentals/installation>
 
-.. toctree::
-    :maxdepth: 1
-    :name: fundamentals
-    :caption: Fundamentals
-
-    Accelerators <fundamentals/accelerators>
-    Code Structure <fundamentals/code_structure>
-    Launch Distributed Training <fundamentals/launch>
-    Fabric in Notebooks <fundamentals/notebooks>
-    Mixed Precision Training <fundamentals/precision>
 
 .. toctree::
-    :maxdepth: 1
-    :name: byot
-    :caption: Build Your Own Trainer
+   :maxdepth: 1
+   :caption: Get started in steps
 
-    The LightningModule <guide/lightning_module>
-    Callbacks <guide/callbacks>
-    Logging <guide/logging>
-    Checkpoints <guide/checkpoint>
-    Trainer Template <https://github.com/Lightning-AI/lightning/tree/master/examples/fabric/build_your_own_trainer>
+   Basic <levels/basic>
+   Intermediate <levels/intermediate>
+   Advanced <levels/advanced>
 
-.. toctree::
-    :maxdepth: 1
-    :name: advanced
-    :caption: Advanced Topics
-
-    Efficient Gradient Accumulation <advanced/gradient_accumulation>
-    Distributed Communication <advanced/distributed_communication>
-    Multiple Models and Optimizers <advanced/multiple_setup>
-
-.. toctree::
-    :maxdepth: 1
-    :name: examples
-    :caption: Examples
-
-    Examples <examples/index>
 
 .. toctree::
     :maxdepth: 1
     :name: api
-    :caption: API Reference
+    :caption: Core API Reference
 
     Fabric Arguments <api/fabric_args>
     Fabric Methods <api/fabric_methods>
     Utilities <api/utilities>
     Full API Reference <api_reference>
+
+
+.. toctree::
+    :maxdepth: 1
+    :name: more
+    :caption: More
+
+    Examples <examples/index>
 
 
 .. raw:: html

--- a/docs/source-fabric/levels/advanced.rst
+++ b/docs/source-fabric/levels/advanced.rst
@@ -1,0 +1,46 @@
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+    <../advanced/gradient_accumulation>
+    <../advanced/distributed_communication>
+    <../advanced/multiple_setup>
+
+
+###############
+Advanced skills
+###############
+
+.. raw:: html
+
+    <div class="display-card-container">
+        <div class="row">
+
+.. displayitem::
+    :header: Efficient Gradient Accumulation
+    :description: Learn how to perform efficient gradient accumulation in distributed settings
+    :button_link: ../advanced/gradient_accumulation.html
+    :col_css: col-md-4
+    :height: 160
+    :tag: advanced
+
+.. displayitem::
+    :header: Distributed Communication
+    :description: Learn all about communication primitives for distributed operation. Gather, reduce, broadcast, etc.
+    :button_link: ../advanced/distributed_communication.html
+    :col_css: col-md-4
+    :height: 160
+    :tag: advanced
+
+.. displayitem::
+    :header: Multiple Models and Optimizers
+    :description: See how flexible Fabric is to work with multiple models and optimizers!
+    :button_link: ../advanced/multiple_setup.html
+    :col_css: col-md-4
+    :height: 160
+    :tag: advanced
+
+.. raw:: html
+
+        </div>
+    </div>

--- a/docs/source-fabric/levels/basic.rst
+++ b/docs/source-fabric/levels/basic.rst
@@ -1,0 +1,74 @@
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+    <../fundamentals/convert>
+    <../fundamentals/accelerators>
+    <../fundamentals/code_structure>
+    <../fundamentals/launch>
+    <../fundamentals/notebooks>
+    <../fundamentals/precision>
+
+
+############
+Basic skills
+############
+
+
+.. raw:: html
+
+    <div class="display-card-container">
+        <div class="row">
+
+.. displayitem::
+    :header: Convert to Fabric in 5 minutes
+    :description: Learn how to add Fabric to your PyTorch code
+    :button_link: ../fundamentals/convert.html
+    :col_css: col-md-4
+    :height: 150
+    :tag: basic
+
+.. displayitem::
+    :header: Accelerators
+    :description: Take advantage of your hardware with a switch of a flag
+    :button_link: ../fundamentals/accelerators.html
+    :col_css: col-md-4
+    :height: 150
+    :tag: basic
+
+.. displayitem::
+    :header: Code Structure
+    :description: Best practices for setting up your training script with Fabric
+    :button_link: ../fundamentals/code_structure.html
+    :col_css: col-md-4
+    :height: 150
+    :tag: basic
+
+.. displayitem::
+    :header: Launch Distributed Training
+    :description: Launch a Python script on multiple devices and machines
+    :button_link: ../fundamentals/launch.html
+    :col_css: col-md-4
+    :height: 150
+    :tag: basic
+
+.. displayitem::
+    :header: Fabric in Notebooks
+    :description: Launch on multiple devices from within a Jupyter notebook
+    :button_link: ../fundamentals/notebooks.html
+    :col_css: col-md-4
+    :height: 150
+    :tag: basic
+
+.. displayitem::
+    :header: Mixed Precision Training
+    :description: Save memory and speed up training using mixed precision
+    :button_link: ../fundamentals/precision.html
+    :col_css: col-md-4
+    :height: 150
+    :tag: basic
+
+.. raw:: html
+
+        </div>
+    </div>

--- a/docs/source-fabric/levels/intermediate.rst
+++ b/docs/source-fabric/levels/intermediate.rst
@@ -1,0 +1,64 @@
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+    <../guide/lightning_module>
+    <../guide/callbacks>
+    <../guide/logging>
+    <../guide/checkpoint>
+    <../guide/trainer_template>
+
+
+###################
+Intermediate skills
+###################
+
+.. raw:: html
+
+    <div class="display-card-container">
+        <div class="row">
+
+.. displayitem::
+    :header: The LightningModule
+    :description: Organize your code in a LightningModule and use it with Fabric
+    :button_link: ../guide/lightning_module.html
+    :col_css: col-md-4
+    :height: 150
+    :tag: intermediate
+
+.. displayitem::
+    :header: Callbacks
+    :description: Make use of the Callback system in Fabric
+    :button_link: ../guide/callbacks.html
+    :col_css: col-md-4
+    :height: 150
+    :tag: intermediate
+
+.. displayitem::
+    :header: Logging
+    :description: Learn how Fabric helps you remove boilerplate code for tracking metrics with a logger
+    :button_link: ../guide/logging.html
+    :col_css: col-md-4
+    :height: 150
+    :tag: intermediate
+
+.. displayitem::
+    :header: Checkpoints
+    :description: Efficient saving and loading of model weights, training state, hyperparameters and more.
+    :button_link: ../guide/checkpoint.html
+    :col_css: col-md-4
+    :height: 150
+    :tag: intermediate
+
+.. displayitem::
+    :header: Trainer Template
+    :description: Take our Fabric Trainer template and customize it for your needs
+    :button_link: https://github.com/Lightning-AI/lightning/tree/master/examples/fabric/build_your_own_trainer
+    :col_css: col-md-4
+    :height: 150
+    :tag: intermediate
+
+.. raw:: html
+
+        </div>
+    </div>


### PR DESCRIPTION
## What does this PR do?

It was requested that the Fabric docs be completely restructured. The top-level navigation is now exactly the same as in https://lightning.ai/docs/app/latest. 
