### PR TITLE
Ignore README in pre-commit rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,8 @@ repos:
                 docs/source-pytorch/_static/images/general/pl_overview_flat.jpg|
                 docs/source-pytorch/_static/images/general/pl_overview.gif|
                 src/lightning/fabric/CHANGELOG.md|
-                src/lightning/pytorch/CHANGELOG.md
+                src/lightning/pytorch/CHANGELOG.md|
+                README.md
             )$
       - id: detect-private-key
 
@@ -99,7 +100,8 @@ repos:
           (?x)^(
               src/lightning/app/CHANGELOG.md|
               src/lightning/fabric/CHANGELOG.md|
-              src/lightning/pytorch/CHANGELOG.md
+              src/lightning/pytorch/CHANGELOG.md|
+              README.md
           )$
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,7 +95,7 @@ repos:
       - id: mdformat
         additional_dependencies:
           - mdformat-gfm
-          - mdformat-black
+          #- mdformat-black
           - mdformat_frontmatter
         exclude: |
           (?x)^(

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,8 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
+        # ignoring Wills's wild changes
+        exclude: README.md
       - id: check-yaml
       - id: check-docstring-first
       - id: check-executables-have-shebangs
@@ -43,8 +45,7 @@ repos:
                 docs/source-pytorch/_static/images/general/pl_overview_flat.jpg|
                 docs/source-pytorch/_static/images/general/pl_overview.gif|
                 src/lightning/fabric/CHANGELOG.md|
-                src/lightning/pytorch/CHANGELOG.md|
-                README.md
+                src/lightning/pytorch/CHANGELOG.md
             )$
       - id: detect-private-key
 
@@ -94,7 +95,7 @@ repos:
       - id: mdformat
         additional_dependencies:
           - mdformat-gfm
-          #- mdformat-black
+          - mdformat-black
           - mdformat_frontmatter
         exclude: |
           (?x)^(

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ ______________________________________________________________________
 
 ## Lightning has 3 core packages
 
-[PyTorch Lightning: Train and deploy PyTorch at scale](#pytorch-lightning-train-and-deploy-pytorch-at-scale).    
-[Lightning Fabric: Expert control](#lightning-fabric-expert-control).    
+[PyTorch Lightning: Train and deploy PyTorch at scale](#pytorch-lightning-train-and-deploy-pytorch-at-scale).
+[Lightning Fabric: Expert control](#lightning-fabric-expert-control).
 [Lightning Apps: Build AI products and ML workflows](#lightning-apps-build-ai-products-and-ml-workflows).
 
 Lightning gives you granular control over how much abstraction you want to add over PyTorch.

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ ______________________________________________________________________
 
 ## Lightning has 3 core packages
 
-[PyTorch Lightning: Train and deploy PyTorch at scale](#pytorch-lightning-train-and-deploy-pytorch-at-scale).
-[Lightning Fabric: Expert control](#lightning-fabric-expert-control).
+[PyTorch Lightning: Train and deploy PyTorch at scale](#pytorch-lightning-train-and-deploy-pytorch-at-scale).    
+[Lightning Fabric: Expert control](#lightning-fabric-expert-control).    
 [Lightning Apps: Build AI products and ML workflows](#lightning-apps-build-ai-products-and-ml-workflows).
 
 Lightning gives you granular control over how much abstraction you want to add over PyTorch.


### PR DESCRIPTION
## What does this PR do?

Recent edits to the README, e.g. in https://github.com/Lightning-AI/lightning/commit/1156eb74aef23fa1a43069d20e652ba5a9dfd77e, blocked our development. This PR makes it so that updates to the README.md do no longer need to follow the precommit rules. This should unblock master from merging PRs.

closes #17132
