### PR TITLE
fix typo in docs migration 1_6_regular

### DIFF
--- a/docs/source-pytorch/upgrade/sections/1_6_regular.rst
+++ b/docs/source-pytorch/upgrade/sections/1_6_regular.rst
@@ -50,7 +50,7 @@
      - use the utility function ``pl.utilities.memory.get_model_size_mb(model)``
      - `PR8495`_
 
-   * - relied on the ``on_trai_dataloader()`` hooks in  ``LightningModule`` and ``LightningDataModule``
+   * - relied on the ``on_train_dataloader()`` hooks in  ``LightningModule`` and ``LightningDataModule``
      - use ``train_dataloader``
      - `PR9098`_
 


### PR DESCRIPTION
## What does this PR do?
Fixes small typo in docs/source-pytorch/upgrade/sections/1_6_regular.rst. Did not create an issue because the typo is small. Clean version of closed PR #17185 (accidentally PR out of date branch rather than master).

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [X] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [X] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
