### PR TITLE
Fix `*_batch_end` typos

### DIFF
--- a/docs/source-pytorch/upgrade/sections/1_9_advanced.rst
+++ b/docs/source-pytorch/upgrade/sections/1_9_advanced.rst
@@ -239,7 +239,7 @@
      - `PR16791`_
 
    * - had any logic except reducing the DP outputs in  ``LightningModule.test_step_end`` hook
-     - port it to ``LightningModule.test_batch_end`` hook
+     - port it to ``LightningModule.on_test_batch_end`` hook
      - `PR16791`_
 
    * - used ``pl.strategies.DDPSpawnStrategy``

--- a/docs/source-pytorch/upgrade/sections/1_9_advanced.rst
+++ b/docs/source-pytorch/upgrade/sections/1_9_advanced.rst
@@ -231,11 +231,11 @@
      - `PR16750`_
 
    * - had any logic except reducing the DP outputs in  ``LightningModule.training_step_end`` hook
-     - port it to ``LightningModule.training_batch_end`` hook
+     - port it to ``LightningModule.on_train_batch_end`` hook
      - `PR16791`_
 
    * - had any logic except reducing the DP outputs in  ``LightningModule.validation_step_end`` hook
-     - port it to ``LightningModule.validation_batch_end`` hook
+     - port it to ``LightningModule.on_validation_batch_end`` hook
      - `PR16791`_
 
    * - had any logic except reducing the DP outputs in  ``LightningModule.test_step_end`` hook


### PR DESCRIPTION
## What does this PR do?

There is a typo in the documentation -- train_batch_end/validation_batch_end should be on_train_batch_end/on_validation_batch_end for lightning 2.0

Fixes #17187