### PR TITLE
Improve CLI output

### DIFF
--- a/src/lightning/app/cli/connect/app.py
+++ b/src/lightning/app/cli/connect/app.py
@@ -77,7 +77,7 @@ def connect_app(app_name_or_id: str):
             if app_name_or_id == "localhost":
                 click.echo("You are connected to the local Lightning App.")
             else:
-                click.echo(f"You are already connected to the cloud Lightning App: {app_name_or_id}.")
+                click.echo(f"You are already connected to the cloud Lightning App: {app_name_or_id}. If it isn't running. Either restart it or disconnect to access lightning main cli.")
         else:
             disconnect_app()
             connect_app(app_name_or_id)

--- a/src/lightning/app/cli/connect/app.py
+++ b/src/lightning/app/cli/connect/app.py
@@ -77,7 +77,7 @@ def connect_app(app_name_or_id: str):
             if app_name_or_id == "localhost":
                 click.echo("You are connected to the local Lightning App.")
             else:
-                click.echo(f"You are already connected to the cloud Lightning App: {app_name_or_id}. If it isn't running. Either restart it or disconnect to access lightning main cli.")
+                click.echo(f"You are already connected to the cloud Lightning App: {app_name_or_id}. If it isn't running. Either restart it or reconnect to access lightning main cli.")
         else:
             disconnect_app()
             connect_app(app_name_or_id)


### PR DESCRIPTION
When connected to a lightning app via lightning connect .. you remain connected despite uninstalling/reinstalling the lightning package. This can get confusing if you step away from keyboard for a few days and you come back and you don't see the regular lightning commands.

I improve the output of lightning CLI on every command to show:
You are connected to the localhost App but it isn't running. Either restart it or reconnect to access lightning main cli.

It solve the issue #14661