### PR TITLE
improve cli output

### DIFF
--- a/src/lightning/app/cli/connect/app.py
+++ b/src/lightning/app/cli/connect/app.py
@@ -77,7 +77,8 @@ def connect_app(app_name_or_id: str):
             if app_name_or_id == "localhost":
                 click.echo("You are connected to the local Lightning App.")
             else:
-                click.echo(f"You are already connected to the cloud Lightning App: {app_name_or_id}.")
+                click.echo(f"""You are already connected to the cloud Lightning App: {app_name_or_id}.
+                        If it isn't running, either restart it or reconnect to access the lightning cli""")
         else:
             disconnect_app()
             connect_app(app_name_or_id)

--- a/src/lightning/app/cli/connect/app.py
+++ b/src/lightning/app/cli/connect/app.py
@@ -77,8 +77,10 @@ def connect_app(app_name_or_id: str):
             if app_name_or_id == "localhost":
                 click.echo("You are connected to the local Lightning App.")
             else:
-                click.echo(f"""You are already connected to the cloud Lightning App: {app_name_or_id}.
-                        If it isn't running, either restart it or reconnect to access the lightning cli""")
+                click.echo(
+                    f"""You are already connected to the cloud Lightning App: {app_name_or_id}.
+                        If it isn't running, either restart it or reconnect to access the lightning cli"""
+                )
         else:
             disconnect_app()
             connect_app(app_name_or_id)


### PR DESCRIPTION

When connected to a lightning app via lightning connect .. you remain connected despite uninstalling/reinstalling the lightning package. This can get confusing if you step away from keyboard for a few days and you come back and you don't see the regular lightning commands.

 I improve the output of lightning CLI on every command to show:
`You are connected to the localhost App if it isn't running, either, restart it or reconnect to access lightning  cli.`

Fixes #14661