### PR TITLE
Trigger TPU tests if '[TPU]' is in the PR title

### DIFF
--- a/.github/checkgroup.yml
+++ b/.github/checkgroup.yml
@@ -104,25 +104,6 @@ subprojects:
   #  checks:
   #    - "pytorch-lightning (IPUs)"
 
-  # TODO: since this job has intermittent availability, it cannot be required
-  #- id: "pytorch-lightning: TPU workflow"
-  #  paths:
-  #    - ".actions/**"
-  #    - ".github/workflows/tpu-tests.yml"
-  #    - "dockers/base-xla/*"
-  #    - "requirements/fabric/**"
-  #    - "src/lightning_fabric/**"
-  #    - "tests/tests_fabric/**"
-  #    - "requirements/pytorch/**"
-  #    - "src/pytorch_lightning/**"
-  #    - "tests/tests_pytorch/**"
-  #    - "pyproject.toml"  # includes pytest config
-  #    - "!requirements/*/docs.txt"
-  #    - "!*.md"
-  #    - "!**/*.md"
-  #  checks:
-  #    - "test-on-tpus"
-
   - id: "fabric: Docs"
     paths:
       - "src/lightning/fabric/**"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,7 +10,7 @@
 | .azure-pipelines/ipu-tests.yml         | Run only IPU-specific tests.                                                                                                                                                | IPU           |
 | .azure-pipelines/gpu-tests-pytorch.yml | Run all CPU and GPU-specific tests, standalone, and examples. Each standalone test needs to be run in separate processes to avoid unwanted interactions between test cases. | GPU           |
 | .azure-pipelines/gpu-benchmark.yml     | Run speed/memory benchmarks for parity with pure PyTorch.                                                                                                                   | GPU           |
-| .github/workflows/tpu-tests.yml        | Run only TPU-specific tests.                                                                                                                                                | TPU           |
+| .github/workflows/tpu-tests.yml        | Run only TPU-specific tests. Requires that the PR title contains '\[TPU\]'                                                                                                  | TPU           |
 
 - \*Accelerators used in CI
 

--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -3,25 +3,8 @@ name: Test PyTorch - TPU
 on:
   push:
     branches: [master, "release/*"]
-  pull_request_target:
+  pull_request:  # TODO: set to target later
     branches: [master, "release/*"]
-    types: [opened, reopened, ready_for_review, synchronize]  # added `ready_for_review` since draft is skipped
-    paths:
-      - ".actions/**"
-      - ".github/workflows/tpu-tests.yml"
-      - "dockers/base-xla/*"
-      - "requirements/fabric/**"
-      - "src/lightning/fabric/**"
-      - "src/lightning_fabric/*"
-      - "tests/tests_fabric/**"
-      - "requirements/pytorch/**"
-      - "src/lightning/pytorch/**"
-      - "src/pytorch_lightning/*"
-      - "tests/tests_pytorch/**"
-      - "pyproject.toml"  # includes pytest config
-      - "!requirements/*/docs.txt"
-      - "!*.md"
-      - "!**/*.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref }}
@@ -39,12 +22,12 @@ defaults:
 jobs:
   test-on-tpus:
     runs-on: ubuntu-22.04
-    if: github.event.pull_request.draft == false
+    # run only when merged to master or the PR title contains '[TPU]'
+    if: ${{ github.event.pull_request.merged == true || contains(github.event.pull_request.title, '[TPU]') }}
     env:
       PYTHON_VER: 3.8
     strategy:
-      fail-fast: true
-      max-parallel: 1  # run sequential
+      fail-fast: false
       matrix:
         # TODO: add also lightning
         pkg-name: ["fabric", "pytorch"]


### PR DESCRIPTION
## What does this PR do?

See title.

This is meant to reduce the TPU CI load. Not even [keras](https://github.com/keras-team/keras-nlp/blob/1dfed906faf6523c09fc3c2095d2070aa41774c5/.cloudbuild/README.md#run-tpu-testing) can get capacity
