### PR TITLE
DOCS: Fix conda install info

### DIFF
--- a/docs/source-pytorch/starter/installation.rst
+++ b/docs/source-pytorch/starter/installation.rst
@@ -45,14 +45,14 @@ Lightning can be installed with `conda <https://anaconda.org/conda-forge/pytorch
 
 .. code-block:: bash
 
-    conda install lightning -c conda-forge
+    conda install pytorch-lightning -c conda-forge
 
 You can also use `Conda Environments <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_:
 
 .. code-block:: bash
 
     conda activate my_env
-    conda install lightning -c conda-forge
+    conda install pytorch-lightning -c conda-forge
 
 ----
 


### PR DESCRIPTION
It looks like conda should use `pytorch-lightning` (not just `lightning`): https://anaconda.org/conda-forge/pytorch-lightning