### PR TITLE
Fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ ______________________________________________________________________
 
 The lightning community is maintained by
 
-- [10+ core contributors](https://lightning.ai/docs/pytorch/latest/governance.html) who are all a mix of professional engineers, Research Scientists, and Ph.D. students from top AI labs.
+- [10+ core contributors](https://lightning.ai/docs/pytorch/latest/community/governance.html) who are all a mix of professional engineers, Research Scientists, and Ph.D. students from top AI labs.
 - 800+ community contributors.
 
 Want to help us build Lightning and reduce boilerplate for thousands of researchers? [Learn how to make your first contribution here](https://lightning.ai/docs/pytorch/stable/generated/CONTRIBUTING.html)

--- a/docs/source-fabric/_templates/theme_variables.jinja
+++ b/docs/source-fabric/_templates/theme_variables.jinja
@@ -2,7 +2,7 @@
   'github': 'https://github.com/Lightning-AI/lightning',
   'github_issues': 'https://github.com/Lightning-AI/lightning/issues',
   'contributing': 'https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md',
-  'governance': 'https://lightning.ai/docs/pytorch/latest/governance.html',
+  'governance': 'https://lightning.ai/docs/pytorch/latest/community/governance.html',
   'docs': 'https://lightning.ai/docs/fabric/',
   'twitter': 'https://twitter.com/LightningAI',
   'home': 'https://lightning.ai/docs/fabric/',

--- a/docs/source-pytorch/_templates/theme_variables.jinja
+++ b/docs/source-pytorch/_templates/theme_variables.jinja
@@ -2,7 +2,7 @@
   'github': 'https://github.com/Lightning-AI/lightning',
   'github_issues': 'https://github.com/Lightning-AI/lightning/issues',
   'contributing': 'https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md',
-  'governance': 'https://lightning.ai/docs/pytorch/latest/governance.html',
+  'governance': 'https://lightning.ai/docs/pytorch/latest/community/governance.html',
   'docs': 'https://lightning.ai/docs/pytorch/latest/',
   'twitter': 'https://twitter.com/LightningAI',
   'discuss': 'https://www.pytorchlightning.ai/community',

--- a/src/pytorch_lightning/README.md
+++ b/src/pytorch_lightning/README.md
@@ -369,7 +369,7 @@ ______________________________________________________________________
 
 The PyTorch Lightning community is maintained by
 
-- [10+ core contributors](https://lightning.ai/docs/pytorch/latest/governance.html) who are all a mix of professional engineers, Research Scientists, and Ph.D. students from top AI labs.
+- [10+ core contributors](https://lightning.ai/docs/pytorch/latest/community/governance.html) who are all a mix of professional engineers, Research Scientists, and Ph.D. students from top AI labs.
 - 680+ active community contributors.
 
 Want to help us build Lightning and reduce boilerplate for thousands of researchers? [Learn how to make your first contribution here](https://devblog.pytorchlightning.ai/quick-contribution-guide-86d977171b3a)


### PR DESCRIPTION
## What does this PR do?

Unblocks the failing markdown link check on master that's holding back from PRs merging.
The location of the documents was changed in #17246 


cc @borda @carmocca @justusschock @awaelchli