### PR TITLE
Fix `load_from_checkpoint` to return model on correct device

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -46,7 +46,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
--
+- Fixed issue where `Model.load_from_checkpoint("checkpoint.ckpt", map_location=map_location)` would always return model on CPU ([#17308](https://github.com/Lightning-AI/lightning/pull/17308))
+
 
 
 ## [2.0.1.post0] - 2023-04-11
@@ -72,8 +73,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed the availability check for `rich` that prevented Lightning to be imported in Google Colab ([#17156](https://github.com/Lightning-AI/lightning/pull/17156))
 - Fixed parsing the precision config for inference in `DeepSpeedStrategy` ([#16973](https://github.com/Lightning-AI/lightning/pull/16973))
 - Fixed issue where `torch.compile` would fail when logging to WandB ([#17216](https://github.com/Lightning-AI/lightning/pull/17216))
-
-- Fixed issue where `Model.load_from_checkpoint("checkpoint.ckpt", map_location=map_location)` would always return model on CPU ([#17308](https://github.com/Lightning-AI/lightning/pull/17308))
 
 
 ## [2.0.0] - 2023-03-15

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -73,6 +73,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed parsing the precision config for inference in `DeepSpeedStrategy` ([#16973](https://github.com/Lightning-AI/lightning/pull/16973))
 - Fixed issue where `torch.compile` would fail when logging to WandB ([#17216](https://github.com/Lightning-AI/lightning/pull/17216))
 
+- Fixed issue where `Model.load_from_checkpoint("checkpoint.ckpt", map_location=map_location)` would always return model on CPU ([#17308](https://github.com/Lightning-AI/lightning/pull/17308))
+
 
 ## [2.0.0] - 2023-03-15
 

--- a/src/lightning/pytorch/core/saving.py
+++ b/src/lightning/pytorch/core/saving.py
@@ -87,14 +87,12 @@ def _load_from_checkpoint(
         return _load_state(cls, checkpoint, **kwargs)
     if issubclass(cls, pl.LightningModule):
         if map_location is None:
-            loaded_location = list(checkpoint["state_dict"].values())[0].device
-            map_location = loaded_location
-
+            map_location = list(checkpoint["state_dict"].values())[0].device
         storage = _load_state(cls, checkpoint, strict=strict, **kwargs)
+        assert isinstance(storage, pl.LightningModule)
         restore_location = torch.serialization._get_restore_location(map_location)
-        if isinstance(map_location, dict) and isinstance(storage, pl.LightningModule):
-            return restore_location(storage, str(storage.device))
-
+        if isinstance(map_location, dict):
+            map_location = str(storage.device)
         return restore_location(storage, map_location)
 
     raise NotImplementedError(f"Unsupported {cls}")

--- a/src/lightning/pytorch/core/saving.py
+++ b/src/lightning/pytorch/core/saving.py
@@ -86,8 +86,8 @@ def _load_from_checkpoint(
     if issubclass(cls, pl.LightningDataModule):
         return _load_state(cls, checkpoint, **kwargs)
     if issubclass(cls, pl.LightningModule):
-        loaded_location = list(checkpoint["state_dict"].items())[0][1].device
         if map_location is None:
+            loaded_location = list(checkpoint["state_dict"].items())[0][1].device
             map_location = loaded_location
 
         storage = _load_state(cls, checkpoint, strict=strict, **kwargs)

--- a/src/lightning/pytorch/core/saving.py
+++ b/src/lightning/pytorch/core/saving.py
@@ -86,9 +86,11 @@ def _load_from_checkpoint(
         return _load_state(cls, checkpoint, **kwargs)
     if issubclass(cls, pl.LightningModule):
         storage = _load_state(cls, checkpoint, strict=strict, **kwargs)
-        assert len(checkpoint["state_dict"]) > 0
+        state_dict = checkpoint["state_dict"]
+        if not state_dict:
+            raise ValueError(f"The state dict in {checkpoint_path!r} contains no parameters.")
+        map_location = list(state_dict.values())[0].device
         assert isinstance(storage, pl.LightningModule)
-        map_location = list(checkpoint["state_dict"].values())[0].device
         return storage.to(map_location)
 
     raise NotImplementedError(f"Unsupported {cls}")

--- a/src/lightning/pytorch/core/saving.py
+++ b/src/lightning/pytorch/core/saving.py
@@ -88,7 +88,7 @@ def _load_from_checkpoint(
     if issubclass(cls, pl.LightningDataModule):
         return _load_state(cls, checkpoint, **kwargs)
     if issubclass(cls, pl.LightningModule):
-        storage = _load_state(cls, checkpoint, strict=strict, **kwargs)
+        storage: pl.LightningModule = _load_state(cls, checkpoint, strict=strict, **kwargs)
         restore_location = torch.serialization._get_restore_location(map_location)
 
         if isinstance(map_location, dict):

--- a/src/lightning/pytorch/core/saving.py
+++ b/src/lightning/pytorch/core/saving.py
@@ -85,9 +85,11 @@ def _load_from_checkpoint(
     if issubclass(cls, pl.LightningDataModule):
         return _load_state(cls, checkpoint, **kwargs)
     if issubclass(cls, pl.LightningModule):
+        storage = _load_state(cls, checkpoint, strict=strict, **kwargs)
         assert len(checkpoint["state_dict"]) > 0
+        assert isinstance(storage, pl.LightningModule)
         map_location = list(checkpoint["state_dict"].values())[0].device
-        return _load_state(cls, checkpoint, strict=strict, **kwargs).to(map_location)
+        return storage.to(map_location)
 
     raise NotImplementedError(f"Unsupported {cls}")
 

--- a/src/lightning/pytorch/core/saving.py
+++ b/src/lightning/pytorch/core/saving.py
@@ -92,7 +92,7 @@ def _load_from_checkpoint(
         restore_location = torch.serialization._get_restore_location(map_location)
 
         if isinstance(map_location, dict):
-            return restore_location(storage, map_location.get(str(storage.device)))
+            return restore_location(storage, str(storage.device))
 
         return restore_location(storage, map_location)
 

--- a/src/lightning/pytorch/core/saving.py
+++ b/src/lightning/pytorch/core/saving.py
@@ -88,10 +88,10 @@ def _load_from_checkpoint(
     if issubclass(cls, pl.LightningDataModule):
         return _load_state(cls, checkpoint, **kwargs)
     if issubclass(cls, pl.LightningModule):
-        storage: pl.LightningModule = _load_state(cls, checkpoint, strict=strict, **kwargs)
+        storage = _load_state(cls, checkpoint, strict=strict, **kwargs)
         restore_location = torch.serialization._get_restore_location(map_location)
 
-        if isinstance(map_location, dict):
+        if isinstance(map_location, dict) and isinstance(storage, pl.LightningModule):
             return restore_location(storage, str(storage.device))
 
         return restore_location(storage, map_location)

--- a/src/lightning/pytorch/core/saving.py
+++ b/src/lightning/pytorch/core/saving.py
@@ -87,7 +87,7 @@ def _load_from_checkpoint(
         return _load_state(cls, checkpoint, **kwargs)
     if issubclass(cls, pl.LightningModule):
         if map_location is None:
-            loaded_location = list(checkpoint["state_dict"].items())[0][1].device
+            loaded_location = list(checkpoint["state_dict"].values())[0].device
             map_location = loaded_location
 
         storage = _load_state(cls, checkpoint, strict=strict, **kwargs)

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -7,9 +7,8 @@ from lightning.pytorch.demos.boring_classes import BoringModel
 from tests_pytorch.helpers.runif import RunIf
 
 
-def create_boring_checkpoint(tmp_path, accelerator="gpu", testmodel=BoringModel):
+def create_boring_checkpoint(tmp_path, model, accelerator="cuda"):
     checkpoint_callback = ModelCheckpoint(dirpath=tmp_path, filename="checkpoint")
-    model = testmodel()
     trainer = pl.Trainer(
         devices=1,
         accelerator=accelerator,
@@ -24,9 +23,9 @@ def create_boring_checkpoint(tmp_path, accelerator="gpu", testmodel=BoringModel)
 @pytest.mark.parametrize(
     "map_location", (None, "cpu", torch.device("cpu"), lambda storage, loc: storage, {"cpu": "cpu"})
 )
-def test_load_from_checkpoint_map_location_cpu(tmp_path, map_location, testmodel=BoringModel):
-    create_boring_checkpoint(tmp_path, accelerator="cpu", testmodel=testmodel)
-    model = testmodel.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", map_location=map_location)
+def test_load_from_checkpoint_map_location_cpu(tmp_path, map_location):
+    create_boring_checkpoint(tmp_path, BoringModel(), accelerator="cpu")
+    model = BoringModel.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", map_location=map_location)
     assert model.device.type == "cpu"
 
 
@@ -34,17 +33,17 @@ def test_load_from_checkpoint_map_location_cpu(tmp_path, map_location, testmodel
 @pytest.mark.parametrize(
     "map_location", (None, "cuda", torch.device("cuda"), lambda storage, loc: storage.cuda(), {"cpu": "cuda"})
 )
-def test_load_from_checkpoint_map_location_gpu(tmp_path, map_location, testmodel=BoringModel):
-    create_boring_checkpoint(tmp_path, accelerator="gpu", testmodel=testmodel)
-    model = testmodel.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", map_location=map_location)
+def test_load_from_checkpoint_map_location_gpu(tmp_path, map_location):
+    create_boring_checkpoint(tmp_path, BoringModel(), accelerator="cuda")
+    model = BoringModel.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", map_location=map_location)
     assert model.device.type == "cuda"
 
 
 @RunIf(min_cuda_gpus=1)
 @pytest.mark.parametrize("map_location", ("cpu", torch.device("cpu"), lambda storage, loc: storage, {"cuda": "cpu"}))
-def test_load_from_checkpoint_map_location_gpu_to_cpu(tmp_path, map_location, testmodel=BoringModel):
-    create_boring_checkpoint(tmp_path, accelerator="gpu", testmodel=testmodel)
-    model = testmodel.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", map_location=map_location)
+def test_load_from_checkpoint_map_location_gpu_to_cpu(tmp_path, map_location):
+    create_boring_checkpoint(tmp_path, BoringModel(), accelerator="cpu")
+    model = BoringModel.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", map_location=map_location)
     assert model.device.type == "cpu"
 
 
@@ -52,7 +51,7 @@ def test_load_from_checkpoint_map_location_gpu_to_cpu(tmp_path, map_location, te
 @pytest.mark.parametrize(
     "map_location", ("cuda", torch.device("cuda"), lambda storage, loc: storage.cuda(), {"cpu": "cuda"})
 )
-def test_load_from_checkpoint_map_location_cpu_to_gpu(tmp_path, map_location, testmodel=BoringModel):
-    create_boring_checkpoint(tmp_path, accelerator="cpu", testmodel=testmodel)
-    model = testmodel.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", map_location=map_location)
+def test_load_from_checkpoint_map_location_cpu_to_gpu(tmp_path, map_location):
+    create_boring_checkpoint(tmp_path, BoringModel(), accelerator="cpu")
+    model = BoringModel.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", map_location=map_location)
     assert model.device.type == "cuda"

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -1,0 +1,28 @@
+import pytest
+import lightning.pytorch as pl
+
+import torch
+
+from lightning.pytorch.demos.boring_classes import BoringModel
+from tests_pytorch.helpers.runif import RunIf
+
+
+def create_boring_checkpoint():
+    model = BoringModel()
+    trainer = pl.Trainer(accelerator='auto', max_epochs=1)
+    trainer.fit(model)
+    trainer.save_checkpoint("./boring.ckpt")
+
+
+@pytest.mark.parametrize("map_location", ('cpu', torch.device('cpu'), lambda storage, loc: storage, {'cpu': 'cpu'}))
+def test_load_from_checkpoint_map_location_cpu(map_location):
+    create_boring_checkpoint()
+    model = BoringModel.load_from_checkpoint("./boring.ckpt", map_location=map_location)
+    assert model.device.type == 'cpu'
+
+
+@RunIf(min_cuda_gpus=1)
+@pytest.mark.parametrize("map_location", ('cuda', torch.device('cuda'), lambda storage, loc: storage.cuda(), {'cpu': 'cuda'}))
+def test_load_from_checkpoint_map_location_gpu(map_location):
+    model = BoringModel.load_from_checkpoint("./boring.ckpt", map_location=map_location)
+    assert model.device.type == 'cuda'

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -17,7 +17,7 @@ def create_boring_checkpoint():
 def test_load_from_checkpoint_map_location_cpu(map_location):
     create_boring_checkpoint()
     model = BoringModel.load_from_checkpoint("./boring.ckpt", map_location=map_location)
-    assert model.device.type == "cpu"
+    assert model.device.type == "cpu", "Model was not restored onto a cpu device"
 
 
 @RunIf(min_cuda_gpus=1)
@@ -27,4 +27,4 @@ def test_load_from_checkpoint_map_location_cpu(map_location):
 def test_load_from_checkpoint_map_location_gpu(map_location):
     create_boring_checkpoint()
     model = BoringModel.load_from_checkpoint("./boring.ckpt", map_location=map_location)
-    assert model.device.type == "cuda"
+    assert model.device.type == "cuda", "Model was not restored onto a cuda device"

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -6,17 +6,17 @@ from lightning.pytorch.demos.boring_classes import BoringModel
 from tests_pytorch.helpers.runif import RunIf
 
 
-def create_boring_checkpoint():
+def create_boring_checkpoint(tmpdir):
     model = BoringModel()
     trainer = pl.Trainer(accelerator="auto", max_epochs=1, enable_model_summary=False, enable_progress_bar=False)
     trainer.fit(model)
-    trainer.save_checkpoint("./boring.ckpt")
+    trainer.save_checkpoint(f"{tmpdir}/boring.ckpt")
 
 
 @pytest.mark.parametrize("map_location", ("cpu", torch.device("cpu"), lambda storage, loc: storage, {"cpu": "cpu"}))
-def test_load_from_checkpoint_map_location_cpu(map_location):
-    create_boring_checkpoint()
-    model = BoringModel.load_from_checkpoint("./boring.ckpt", map_location=map_location)
+def test_load_from_checkpoint_map_location_cpu(tmpdir, map_location):
+    create_boring_checkpoint(tmpdir)
+    model = BoringModel.load_from_checkpoint(f"{tmpdir}/boring.ckpt", map_location=map_location)
     assert model.device.type == "cpu"
 
 
@@ -24,7 +24,7 @@ def test_load_from_checkpoint_map_location_cpu(map_location):
 @pytest.mark.parametrize(
     "map_location", ("cuda", torch.device("cuda"), lambda storage, loc: storage.cuda(), {"cpu": "cuda"})
 )
-def test_load_from_checkpoint_map_location_gpu(map_location):
-    create_boring_checkpoint()
-    model = BoringModel.load_from_checkpoint("./boring.ckpt", map_location=map_location)
+def test_load_from_checkpoint_map_location_gpu(tmpdir, map_location):
+    create_boring_checkpoint(tmpdir)
+    model = BoringModel.load_from_checkpoint(f"{tmpdir}/boring.ckpt", map_location=map_location)
     assert model.device.type == "cuda"

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -1,28 +1,29 @@
 import pytest
-import lightning.pytorch as pl
-
 import torch
 
+import lightning.pytorch as pl
 from lightning.pytorch.demos.boring_classes import BoringModel
 from tests_pytorch.helpers.runif import RunIf
 
 
 def create_boring_checkpoint():
     model = BoringModel()
-    trainer = pl.Trainer(accelerator='auto', max_epochs=1)
+    trainer = pl.Trainer(accelerator="auto", max_epochs=1)
     trainer.fit(model)
     trainer.save_checkpoint("./boring.ckpt")
 
 
-@pytest.mark.parametrize("map_location", ('cpu', torch.device('cpu'), lambda storage, loc: storage, {'cpu': 'cpu'}))
+@pytest.mark.parametrize("map_location", ("cpu", torch.device("cpu"), lambda storage, loc: storage, {"cpu": "cpu"}))
 def test_load_from_checkpoint_map_location_cpu(map_location):
     create_boring_checkpoint()
     model = BoringModel.load_from_checkpoint("./boring.ckpt", map_location=map_location)
-    assert model.device.type == 'cpu'
+    assert model.device.type == "cpu"
 
 
 @RunIf(min_cuda_gpus=1)
-@pytest.mark.parametrize("map_location", ('cuda', torch.device('cuda'), lambda storage, loc: storage.cuda(), {'cpu': 'cuda'}))
+@pytest.mark.parametrize(
+    "map_location", ("cuda", torch.device("cuda"), lambda storage, loc: storage.cuda(), {"cpu": "cuda"})
+)
 def test_load_from_checkpoint_map_location_gpu(map_location):
     model = BoringModel.load_from_checkpoint("./boring.ckpt", map_location=map_location)
-    assert model.device.type == 'cuda'
+    assert model.device.type == "cuda"

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -25,5 +25,6 @@ def test_load_from_checkpoint_map_location_cpu(map_location):
     "map_location", ("cuda", torch.device("cuda"), lambda storage, loc: storage.cuda(), {"cpu": "cuda"})
 )
 def test_load_from_checkpoint_map_location_gpu(map_location):
+    create_boring_checkpoint()
     model = BoringModel.load_from_checkpoint("./boring.ckpt", map_location=map_location)
     assert model.device.type == "cuda"

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -8,7 +8,7 @@ from tests_pytorch.helpers.runif import RunIf
 
 def create_boring_checkpoint():
     model = BoringModel()
-    trainer = pl.Trainer(accelerator="auto", max_epochs=1)
+    trainer = pl.Trainer(accelerator="auto", max_epochs=1, enable_model_summary=False, enable_progress_bar=False)
     trainer.fit(model)
     trainer.save_checkpoint("./boring.ckpt")
 

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -7,8 +7,8 @@ from lightning.pytorch.demos.boring_classes import BoringModel
 from tests_pytorch.helpers.runif import RunIf
 
 
-def create_boring_checkpoint(tmpdir, accelerator="gpu", testmodel=BoringModel):
-    checkpoint_callback = ModelCheckpoint(dirpath=tmpdir, filename="checkpoint")
+def create_boring_checkpoint(tmp_path, accelerator="gpu", testmodel=BoringModel):
+    checkpoint_callback = ModelCheckpoint(dirpath=tmp_path, filename="checkpoint")
     model = testmodel()
     trainer = pl.Trainer(
         devices=1,
@@ -24,9 +24,9 @@ def create_boring_checkpoint(tmpdir, accelerator="gpu", testmodel=BoringModel):
 @pytest.mark.parametrize(
     "map_location", (None, "cpu", torch.device("cpu"), lambda storage, loc: storage, {"cpu": "cpu"})
 )
-def test_load_from_checkpoint_map_location_cpu(tmpdir, map_location, testmodel=BoringModel):
-    create_boring_checkpoint(tmpdir, accelerator="cpu", testmodel=testmodel)
-    model = testmodel.load_from_checkpoint(f"{tmpdir}/checkpoint.ckpt", map_location=map_location)
+def test_load_from_checkpoint_map_location_cpu(tmp_path, map_location, testmodel=BoringModel):
+    create_boring_checkpoint(tmp_path, accelerator="cpu", testmodel=testmodel)
+    model = testmodel.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", map_location=map_location)
     assert model.device.type == "cpu"
 
 
@@ -34,17 +34,17 @@ def test_load_from_checkpoint_map_location_cpu(tmpdir, map_location, testmodel=B
 @pytest.mark.parametrize(
     "map_location", (None, "cuda", torch.device("cuda"), lambda storage, loc: storage.cuda(), {"cpu": "cuda"})
 )
-def test_load_from_checkpoint_map_location_gpu(tmpdir, map_location, testmodel=BoringModel):
-    create_boring_checkpoint(tmpdir, accelerator="gpu", testmodel=testmodel)
-    model = testmodel.load_from_checkpoint(f"{tmpdir}/checkpoint.ckpt", map_location=map_location)
+def test_load_from_checkpoint_map_location_gpu(tmp_path, map_location, testmodel=BoringModel):
+    create_boring_checkpoint(tmp_path, accelerator="gpu", testmodel=testmodel)
+    model = testmodel.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", map_location=map_location)
     assert model.device.type == "cuda"
 
 
 @RunIf(min_cuda_gpus=1)
 @pytest.mark.parametrize("map_location", ("cpu", torch.device("cpu"), lambda storage, loc: storage, {"cuda": "cpu"}))
-def test_load_from_checkpoint_map_location_gpu_to_cpu(tmpdir, map_location, testmodel=BoringModel):
-    create_boring_checkpoint(tmpdir, accelerator="gpu", testmodel=testmodel)
-    model = testmodel.load_from_checkpoint(f"{tmpdir}/checkpoint.ckpt", map_location=map_location)
+def test_load_from_checkpoint_map_location_gpu_to_cpu(tmp_path, map_location, testmodel=BoringModel):
+    create_boring_checkpoint(tmp_path, accelerator="gpu", testmodel=testmodel)
+    model = testmodel.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", map_location=map_location)
     assert model.device.type == "cpu"
 
 
@@ -52,7 +52,7 @@ def test_load_from_checkpoint_map_location_gpu_to_cpu(tmpdir, map_location, test
 @pytest.mark.parametrize(
     "map_location", ("cuda", torch.device("cuda"), lambda storage, loc: storage.cuda(), {"cpu": "cuda"})
 )
-def test_load_from_checkpoint_map_location_cpu_to_gpu(tmpdir, map_location, testmodel=BoringModel):
-    create_boring_checkpoint(tmpdir, accelerator="cpu", testmodel=testmodel)
-    model = testmodel.load_from_checkpoint(f"{tmpdir}/checkpoint.ckpt", map_location=map_location)
+def test_load_from_checkpoint_map_location_cpu_to_gpu(tmp_path, map_location, testmodel=BoringModel):
+    create_boring_checkpoint(tmp_path, accelerator="cpu", testmodel=testmodel)
+    model = testmodel.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", map_location=map_location)
     assert model.device.type == "cuda"

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -8,7 +8,7 @@ from tests_pytorch.helpers.runif import RunIf
 
 def create_boring_checkpoint(tmpdir):
     model = BoringModel()
-    trainer = pl.Trainer(accelerator="auto", max_epochs=1, enable_model_summary=False, enable_progress_bar=False)
+    trainer = pl.Trainer(devices=1, max_epochs=1, enable_model_summary=False, enable_progress_bar=False)
     trainer.fit(model)
     trainer.save_checkpoint(f"{tmpdir}/boring.ckpt")
 

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -17,7 +17,7 @@ def create_boring_checkpoint():
 def test_load_from_checkpoint_map_location_cpu(map_location):
     create_boring_checkpoint()
     model = BoringModel.load_from_checkpoint("./boring.ckpt", map_location=map_location)
-    assert model.device.type == "cpu", "Model was not restored onto a cpu device"
+    assert model.device.type == "cpu"
 
 
 @RunIf(min_cuda_gpus=1)
@@ -27,4 +27,4 @@ def test_load_from_checkpoint_map_location_cpu(map_location):
 def test_load_from_checkpoint_map_location_gpu(map_location):
     create_boring_checkpoint()
     model = BoringModel.load_from_checkpoint("./boring.ckpt", map_location=map_location)
-    assert model.device.type == "cuda", "Model was not restored onto a cuda device"
+    assert model.device.type == "cuda"

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -150,7 +150,7 @@ def _assert_save_equality(trainer, ckpt_path, cls=TestFSDPModel):
 
         # Assert model parameters are identical after loading
         for ddp_param, shard_param in zip(model_state_dict.values(), saved_model.state_dict().values()):
-            assert torch.equal(ddp_param.float().cpu(), shard_param)
+            assert torch.equal(ddp_param, shard_param)
 
 
 @RunIf(min_torch="1.12")


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fixes #17304 

When using 
```python
model = BoringModel.load_from_checkpoint('path.ckpt', map_location='cuda')
``` 
the returned model is always on the CPU due to `_load_from_checkpoint` not using the map_location on the returned object.

https://github.com/Lightning-AI/lightning/blob/fd4697c62c059fc7b9946e84d91625ecb6efdbe5/src/lightning/pytorch/core/saving.py#L51-L92

This PR returns the created model with the correct mapped location.

Also create tests for checking that the model is loaded onto GPU after the checkpoint load. I have included tests for mapping to the CPU for completeness although these do not fail currently fail, only the GPU tests do. 


<details><summary>Created tests failing on master</summary>
<p>

All tests checking for model to be on `cuda` will fail on current master branch.
All tests checking for model to be on `cpu` will pass on current branch, but included for completeness.

```python
import pytest
import torch

import lightning.pytorch as pl
from lightning.pytorch.callbacks import ModelCheckpoint
from lightning.pytorch.demos.boring_classes import BoringModel
from tests_pytorch.helpers.runif import RunIf


def create_boring_checkpoint(tmpdir, accelerator="gpu", testmodel=BoringModel):
    checkpoint_callback = ModelCheckpoint(dirpath=tmpdir, filename="checkpoint")
    model = testmodel()
    trainer = pl.Trainer(
        devices=1,
        accelerator=accelerator,
        max_epochs=1,
        enable_model_summary=False,
        enable_progress_bar=False,
        callbacks=[checkpoint_callback],
    )
    trainer.fit(model)


@pytest.mark.parametrize(
    "map_location", (None, "cpu", torch.device("cpu"), lambda storage, loc: storage, {"cpu": "cpu"})
)
def test_load_from_checkpoint_map_location_cpu(tmpdir, map_location, testmodel=BoringModel):
    create_boring_checkpoint(tmpdir, accelerator="cpu", testmodel=testmodel)
    model = testmodel.load_from_checkpoint(f"{tmpdir}/checkpoint.ckpt", map_location=map_location)
    assert model.device.type == "cpu"


@RunIf(min_cuda_gpus=1)
@pytest.mark.parametrize(
    "map_location", (None, "cuda", torch.device("cuda"), lambda storage, loc: storage.cuda(), {"cpu": "cuda"})
)
def test_load_from_checkpoint_map_location_gpu(tmpdir, map_location, testmodel=BoringModel):
    create_boring_checkpoint(tmpdir, accelerator="gpu", testmodel=testmodel)
    model = testmodel.load_from_checkpoint(f"{tmpdir}/checkpoint.ckpt", map_location=map_location)
    assert model.device.type == "cuda"


@RunIf(min_cuda_gpus=1)
@pytest.mark.parametrize("map_location", ("cpu", torch.device("cpu"), lambda storage, loc: storage, {"cuda": "cpu"}))
def test_load_from_checkpoint_map_location_gpu_to_cpu(tmpdir, map_location, testmodel=BoringModel):
    create_boring_checkpoint(tmpdir, accelerator="gpu", testmodel=testmodel)
    model = testmodel.load_from_checkpoint(f"{tmpdir}/checkpoint.ckpt", map_location=map_location)
    assert model.device.type == "cpu"


@RunIf(min_cuda_gpus=1)
@pytest.mark.parametrize(
    "map_location", ("cuda", torch.device("cuda"), lambda storage, loc: storage.cuda(), {"cpu": "cuda"})
)
def test_load_from_checkpoint_map_location_cpu_to_gpu(tmpdir, map_location, testmodel=BoringModel):
    create_boring_checkpoint(tmpdir, accelerator="cpu", testmodel=testmodel)
    model = testmodel.load_from_checkpoint(f"{tmpdir}/checkpoint.ckpt", map_location=map_location)
    assert model.device.type == "cuda"

```

</p>
</details> 

### What Can be Improved

When the object is created on the GPU without setting map_location (i.e. when the model checkpoint is from the GPU, shouldn't it automatically load onto the GPU as when you use `torch.load("boring.pth")`?).
```python
import torch
import torch.nn as nn

class TestModel(nn.Module):
    def __init__(self, *args, **kwargs) -> None:
        super().__init__(*args, **kwargs)
        self.fc = nn.Linear(32, 2)

    def forward(self, x):
        return self.fc(x)

testmodel = TestModel().to("cuda")

torch.save(testmodel, "torch.pth")
testmodel = torch.load("torch.pth")
print(next(testmodel.parameters()).device)  # Prints cuda:0
```
```python
import lightning.pytorch as pl
from lightning.pytorch.callbacks import ModelCheckpoint
from lightning.pytorch.demos.boring_classes import BoringModel

checkpoint_callback = ModelCheckpoint(dirpath='', filename="boring")

model = BoringModel()
trainer = pl.Trainer(
    max_epochs=1,
    enable_progress_bar=False,
    enable_model_summary=False,
    callbacks=[checkpoint_callback],
    accelerator="gpu",
    devices=1
)
trainer.fit(model)

model = BoringModel.load_from_checkpoint("boring.ckpt") 
print(model.device.type)  # Should print cuda but prints cpu
```
So for this the issue is when the object is created in `_load_state()` it is not created on or moved to the GPU, thus when `map_location` is set to `lambda storage, loc: storage` (as it is when map_location=None) it just returns the object on the CPU.

If I try to retrieve this information from the `checkpoint['state_dict']`, it requires some ugly work that I'm not sure will work in all cases as I have only tested with the BoringModel so far
```python
...
  if issubclass(cls, pl.LightningModule):
      loaded_location = list(checkpoint["state_dict"].items())[0][1].device  # This could be done better?
      if map_location is None:
          map_location = loaded_location
  
      storage = _load_state(cls, checkpoint, strict=strict, **kwargs)
      restore_location = torch.serialization._get_restore_location(map_location)
      if isinstance(map_location, dict) and isinstance(storage, pl.LightningModule):
          return restore_location(storage, str(storage.device))
  
      return restore_location(storage, map_location)
```
This works (for the BoringModel anyways), but I'm sure it can be done much better if someone has better ideas.

### Failing tests / Breaking changes

`tests/tests_pytorch/strategies/test_fsdp.py` contains tests which are failing. It loads using checkpoints with the changed function `load_from_checkpoint`, however in the assertion, it moves one of the tensors to the `cpu` resulting in the assertion error because the loaded checkpoint is now correctly on `cuda`.

https://github.com/Lightning-AI/lightning/blob/fd4697c62c059fc7b9946e84d91625ecb6efdbe5/tests/tests_pytorch/strategies/test_fsdp.py#L142-L152

In changing this assertion to keep both state_dicts on their devices all tests pass.
```python
- assert torch.equal(ddp_param.float().cpu(), shard_param) 
+ assert torch.equal(ddp_param, shard_param) 
```

If there's other cases where users have similar conditions or rely on the current behavior this PR could break them, although it would only be unexpected for the case of `map_location=None`.

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
