### PR TITLE
Simplified setup of optimizers in FSDP

### DIFF
--- a/docs/source-pytorch/advanced/model_parallel.rst
+++ b/docs/source-pytorch/advanced/model_parallel.rst
@@ -88,9 +88,9 @@ simplest way to do it is auto wrapping, which can serve as a drop-in replacement
 have to ``wrap`` layers manually as in the case of manual wrapping.
 
 .. note::
-    While initializing the optimizers inside ``configure_optimizers`` hook, make sure to use ``self.trainer.model.parameters()``, else
+    For users of PyTorch < 2.0: While initializing the optimizers inside ``configure_optimizers`` hook, make sure to use ``self.trainer.model.parameters()``, else
     PyTorch will raise an error. This is required because when you use auto-wrap, the model layers are sharded and your
-    ``lightning_module.parameters()`` will return a generator with no params. This inconvenience will be addressed in the future.
+    ``lightning_module.parameters()`` will return a generator with no params. This is only necessary in PyTorch < 2.0.
 
 
 .. code-block:: python

--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -253,6 +253,9 @@ class FSDPStrategy(ParallelStrategy):
         self.setup_precision_plugin()
 
     def setup_optimizers(self, trainer: "pl.Trainer") -> None:
+        if _TORCH_GREATER_EQUAL_2_0:
+            return super().setup_optimizers(trainer)
+
         invalid_params_error = False
         try:
             super().setup_optimizers(trainer)
@@ -261,7 +264,7 @@ class FSDPStrategy(ParallelStrategy):
                 raise
             invalid_params_error = True
 
-        if invalid_params_error or (not _TORCH_GREATER_EQUAL_2_0 and any(not _optimizer_has_flat_params(optimizer) for optimizer in self.optimizers)):
+        if invalid_params_error or any(not _optimizer_has_flat_params(optimizer) for optimizer in self.optimizers):
             # We avoid this limitation in PyTorch >= 2.0 by setting `use_orig_params=True`
             raise ValueError(
                 "The optimizer does not seem to reference any FSDP parameters. HINT: Make sure to create the"

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 import torch.nn as nn
 
+import lightning
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_1_12, _TORCH_GREATER_EQUAL_2_0
 from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks import ModelCheckpoint
@@ -370,3 +371,16 @@ def test_fsdp_strategy_cpu_offload():
     config = CPUOffload()
     strategy = FSDPStrategy(cpu_offload=config)
     assert strategy.cpu_offload == config
+
+
+def test_fsdp_use_orig_params(monkeypatch):
+    """Test that Lightning enables `use_orig_params` in PyTorch >= 2.0"""
+    monkeypatch.setattr(lightning.pytorch.strategies.fsdp, "_TORCH_GREATER_EQUAL_2_0", False)
+    strategy = FSDPStrategy()
+    assert "use_orig_params" not in strategy.kwargs
+
+    monkeypatch.setattr(lightning.pytorch.strategies.fsdp, "_TORCH_GREATER_EQUAL_2_0", True)
+    strategy = FSDPStrategy()
+    assert strategy.kwargs["use_orig_params"]
+    strategy = FSDPStrategy(use_orig_params=False)
+    assert not strategy.kwargs["use_orig_params"]


### PR DESCRIPTION
## What does this PR do?

Resolves a limitation in FSDP for users of PyTorch 2.0+. Previously, to use FSDP you had to make code modifications. In particular, you had to write `optimizer = Adam(self.trainer.model.parameters)` instead of just `optimizer = Adam(self.parameters)`. This can be avoided by enabling `use_orig_params` in the FSDP wrapper. This PR enables this for users of PyTorch >= 2.0 automatically. This also enables multiple parameter groups which was previously not possible. 

This PR goes alongside the equivalent change in Fabric: #17305