### PR TITLE
WIP: Fix app dependency issues in CI

### DIFF
--- a/requirements/app/base.txt
+++ b/requirements/app/base.txt
@@ -12,7 +12,7 @@ beautifulsoup4>=4.8.0, <4.11.2
 inquirer>=2.10.0, <=3.1.2
 psutil<5.9.5
 click<=8.1.3
-fastapi<0.89.0  # strict; TODO: broken serializations
+fastapi<=0.95.0
 
 dateutils<=0.6.12
 Jinja2<=3.1.2

--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -49,6 +49,9 @@ from lightning.fabric.utilities.warnings import PossibleUserWarning
 from lightning.fabric.wrappers import _FabricDataLoader, _FabricModule, _FabricOptimizer, _unwrap_objects
 
 
+# Trigger full ci
+
+
 class Fabric:
     """Fabric accelerates your PyTorch training or inference code with minimal changes required.
 

--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -48,7 +48,6 @@ from lightning.fabric.utilities.types import ReduceOp
 from lightning.fabric.utilities.warnings import PossibleUserWarning
 from lightning.fabric.wrappers import _FabricDataLoader, _FabricModule, _FabricOptimizer, _unwrap_objects
 
-
 # Trigger full ci
 
 

--- a/src/lightning/fabric/strategies/deepspeed.py
+++ b/src/lightning/fabric/strategies/deepspeed.py
@@ -40,11 +40,13 @@ from lightning.fabric.utilities.types import _PATH
 _DEEPSPEED_AVAILABLE = (
     # DeepSpeed fails under 0.8.2 with torch 2.0: https://github.com/microsoft/DeepSpeed/pull/2863
     RequirementCache("deepspeed>=0.8.2")
-    or not _TORCH_GREATER_EQUAL_2_0
-    # check packaging because of https://github.com/microsoft/DeepSpeed/pull/2771
-    # remove the packaging check when min version is >=0.8.1
-    and RequirementCache("deepspeed")
-    and RequirementCache("packaging>=20.0")
+    or (
+        not _TORCH_GREATER_EQUAL_2_0
+        and RequirementCache("deepspeed")
+        # check packaging because of https://github.com/microsoft/DeepSpeed/pull/2771
+        # remove the packaging check when min version is >=0.8.1
+        and RequirementCache("packaging>=20.0")
+    )
 )
 if TYPE_CHECKING and _DEEPSPEED_AVAILABLE:
     import deepspeed

--- a/src/lightning/pytorch/trainer/trainer.py
+++ b/src/lightning/pytorch/trainer/trainer.py
@@ -86,6 +86,7 @@ warnings.filterwarnings(
 
 # Trigger full ci
 
+
 class Trainer:
     @_defaults_from_env_vars
     def __init__(

--- a/src/lightning/pytorch/trainer/trainer.py
+++ b/src/lightning/pytorch/trainer/trainer.py
@@ -84,6 +84,7 @@ warnings.filterwarnings(
     "ignore", message="torch.distributed.reduce_op is deprecated, please use torch.distributed.ReduceOp instead"
 )
 
+# Trigger full ci
 
 class Trainer:
     @_defaults_from_env_vars


### PR DESCRIPTION
## What does this PR do?

Attempt to fix app CI failures on master. Example:

https://github.com/Lightning-AI/lightning/actions/runs/4671606979/jobs/8273070886
```
E       trio.TrioDeprecationWarning: trio.MultiError is deprecated since Trio 0.22.0; use BaseExceptionGroup (on Python 3.11 and later) or exceptiongroup.BaseExceptionGroup (earlier versions) instead (https://github.com/python-trio/trio/issues/2211)
```
```
asynclib_name = 'trio'

    def get_asynclib(asynclib_name: Optional[str] = None) -> Any:
        if asynclib_name is None:
            asynclib_name = sniffio.current_async_library()
    
        modulename = "anyio._backends._" + asynclib_name
        try:
>           return sys.modules[modulename]
E           KeyError: 'anyio._backends._trio'

../../../../hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/anyio/_core/_eventloop.py:153: KeyError
```


Also:
Fixes #17277


cc @carmocca @borda @justusschock @awaelchli