### PR TITLE
Replace codecov pip package with codecov uploader

### DIFF
--- a/.azure/gpu-tests-fabric.yml
+++ b/.azure/gpu-tests-fabric.yml
@@ -142,7 +142,11 @@ jobs:
         python -m coverage report
         python -m coverage xml
         python -m coverage html
-        python -m codecov --token=$(CODECOV_TOKEN) --commit=$(Build.SourceVersion) \
+
+        # https://docs.codecov.com/docs/codecov-uploader
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        chmod +x codecov
+        ./codecov --token=$(CODECOV_TOKEN) --commit=$(Build.SourceVersion) \
           --flags=gpu,pytest,${COVERAGE_SOURCE} --name="GPU-coverage" --env=linux,azure
         ls -l
       workingDirectory: tests/tests_fabric

--- a/.azure/gpu-tests-pytorch.yml
+++ b/.azure/gpu-tests-pytorch.yml
@@ -181,7 +181,11 @@ jobs:
         python -m coverage report
         python -m coverage xml
         python -m coverage html
-        python -m codecov --token=$(CODECOV_TOKEN) --commit=$(Build.SourceVersion) \
+
+        # https://docs.codecov.com/docs/codecov-uploader
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        chmod +x codecov
+        ./codecov --token=$(CODECOV_TOKEN) --commit=$(Build.SourceVersion) \
           --flags=gpu,pytest,${COVERAGE_SOURCE} --name="GPU-coverage" --env=linux,azure
         ls -l
       workingDirectory: tests/tests_pytorch

--- a/requirements/app/test.txt
+++ b/requirements/app/test.txt
@@ -1,5 +1,4 @@
 coverage==6.5.0
-codecov==2.1.12
 pytest==7.2.2
 pytest-timeout==2.1.0
 pytest-cov==4.0.0

--- a/requirements/fabric/test.txt
+++ b/requirements/fabric/test.txt
@@ -1,5 +1,4 @@
 coverage==6.5.0
-codecov==2.1.12
 pytest==7.2.2
 pytest-cov==4.0.0
 pytest-rerunfailures==10.3

--- a/requirements/pytorch/test.txt
+++ b/requirements/pytorch/test.txt
@@ -1,5 +1,4 @@
 coverage==6.5.0
-codecov==2.1.12
 pytest==7.2.2
 pytest-cov==4.0.0
 pytest-forked==1.4.0


### PR DESCRIPTION
## What does this PR do?

The `codecov` package has been removed from PyPI: https://pypi.org/project/codecov/

Looks like we missed a deprecation for it. Discussions online:
https://twitter.com/sovietfish/status/1646155087717318657?s=20
https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259/3

cc @carmocca @borda