### PR TITLE
Rename `SingleTPUStrategy`

### DIFF
--- a/src/lightning/fabric/strategies/__init__.py
+++ b/src/lightning/fabric/strategies/__init__.py
@@ -19,6 +19,7 @@ from lightning.fabric.strategies.parallel import ParallelStrategy  # noqa: F401
 from lightning.fabric.strategies.registry import _call_register_strategies, _StrategyRegistry
 from lightning.fabric.strategies.single_device import SingleDeviceStrategy  # noqa: F401
 from lightning.fabric.strategies.single_tpu import SingleTPUStrategy  # noqa: F401
+from lightning.fabric.strategies.single_xla import SingleDeviceXLAStrategy  # noqa: F401
 from lightning.fabric.strategies.strategy import Strategy  # noqa: F401
 from lightning.fabric.strategies.xla import XLAStrategy  # noqa: F401
 

--- a/src/lightning/fabric/strategies/single_tpu.py
+++ b/src/lightning/fabric/strategies/single_tpu.py
@@ -11,54 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Dict, Optional
+from typing import Dict
 
-import torch
-
-from lightning.fabric.accelerators import Accelerator
-from lightning.fabric.accelerators.tpu import _XLA_AVAILABLE
-from lightning.fabric.plugins.io.checkpoint_io import CheckpointIO
-from lightning.fabric.plugins.io.xla import XLACheckpointIO
-from lightning.fabric.plugins.precision import Precision
-from lightning.fabric.strategies.single_device import SingleDeviceStrategy
-from lightning.fabric.utilities.types import _DEVICE
+from lightning.fabric.strategies.single_xla import SingleDeviceXLAStrategy
 
 
-class SingleTPUStrategy(SingleDeviceStrategy):
-    """Strategy for training on a single TPU device."""
+class SingleTPUStrategy(SingleDeviceXLAStrategy):
+    """Legacy class.
 
-    def __init__(
-        self,
-        device: _DEVICE,
-        accelerator: Optional[Accelerator] = None,
-        checkpoint_io: Optional[CheckpointIO] = None,
-        precision: Optional[Precision] = None,
-    ):
-        if not _XLA_AVAILABLE:
-            raise ModuleNotFoundError(str(_XLA_AVAILABLE))
-        if isinstance(device, torch.device):
-            # unwrap the `torch.device` in favor of `xla_device`
-            device = device.index
+    Use `SingleDeviceXLAStrategy` instead.
+    """
 
-        import torch_xla.core.xla_model as xm
-
-        super().__init__(
-            accelerator=accelerator,
-            device=xm.xla_device(device),
-            checkpoint_io=checkpoint_io,
-            precision=precision,
-        )
-
-    @property
-    def checkpoint_io(self) -> CheckpointIO:
-        if self._checkpoint_io is None:
-            self._checkpoint_io = XLACheckpointIO()
-        return self._checkpoint_io
-
-    @checkpoint_io.setter
-    def checkpoint_io(self, io: Optional[CheckpointIO]) -> None:
-        self._checkpoint_io = io
-
-    @classmethod
     def register_strategies(cls, strategy_registry: Dict) -> None:
-        strategy_registry.register("single_tpu", cls, description=f"{cls.__class__.__name__}")
+        # legacy
+        strategy_registry.register("single_tpu", cls, description="Legacy class. Use `single_xla` instead.")

--- a/src/lightning/fabric/strategies/single_xla.py
+++ b/src/lightning/fabric/strategies/single_xla.py
@@ -1,0 +1,64 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Dict, Optional
+
+import torch
+
+from lightning.fabric.accelerators import Accelerator
+from lightning.fabric.accelerators.tpu import _XLA_AVAILABLE
+from lightning.fabric.plugins.io.checkpoint_io import CheckpointIO
+from lightning.fabric.plugins.io.xla import XLACheckpointIO
+from lightning.fabric.plugins.precision import Precision
+from lightning.fabric.strategies.single_device import SingleDeviceStrategy
+from lightning.fabric.utilities.types import _DEVICE
+
+
+class SingleDeviceXLAStrategy(SingleDeviceStrategy):
+    """Strategy for training on a single XLA device."""
+
+    def __init__(
+        self,
+        device: _DEVICE,
+        accelerator: Optional[Accelerator] = None,
+        checkpoint_io: Optional[CheckpointIO] = None,
+        precision: Optional[Precision] = None,
+    ):
+        if not _XLA_AVAILABLE:
+            raise ModuleNotFoundError(str(_XLA_AVAILABLE))
+        if isinstance(device, torch.device):
+            # unwrap the `torch.device` in favor of `xla_device`
+            device = device.index
+
+        import torch_xla.core.xla_model as xm
+
+        super().__init__(
+            accelerator=accelerator,
+            device=xm.xla_device(device),
+            checkpoint_io=checkpoint_io,
+            precision=precision,
+        )
+
+    @property
+    def checkpoint_io(self) -> CheckpointIO:
+        if self._checkpoint_io is None:
+            self._checkpoint_io = XLACheckpointIO()
+        return self._checkpoint_io
+
+    @checkpoint_io.setter
+    def checkpoint_io(self, io: Optional[CheckpointIO]) -> None:
+        self._checkpoint_io = io
+
+    @classmethod
+    def register_strategies(cls, strategy_registry: Dict) -> None:
+        strategy_registry.register("single_xla", cls, description=cls.__class__.__name__)

--- a/src/lightning/pytorch/strategies/__init__.py
+++ b/src/lightning/pytorch/strategies/__init__.py
@@ -19,6 +19,7 @@ from lightning.pytorch.strategies.ipu import IPUStrategy  # noqa: F401
 from lightning.pytorch.strategies.parallel import ParallelStrategy  # noqa: F401
 from lightning.pytorch.strategies.single_device import SingleDeviceStrategy  # noqa: F401
 from lightning.pytorch.strategies.single_tpu import SingleTPUStrategy  # noqa: F401
+from lightning.pytorch.strategies.single_xla import SingleDeviceXLAStrategy  # noqa: F401
 from lightning.pytorch.strategies.strategy import Strategy  # noqa: F401
 from lightning.pytorch.strategies.utils import _call_register_strategies
 from lightning.pytorch.strategies.xla import XLAStrategy  # noqa: F401

--- a/src/lightning/pytorch/strategies/single_xla.py
+++ b/src/lightning/pytorch/strategies/single_xla.py
@@ -1,0 +1,88 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+from typing import Dict, Optional
+
+import torch
+
+import lightning.pytorch as pl
+from lightning.fabric.accelerators.tpu import _XLA_AVAILABLE
+from lightning.fabric.plugins import CheckpointIO, XLACheckpointIO
+from lightning.fabric.utilities.types import _DEVICE
+from lightning.pytorch.plugins.io.wrapper import _WrappingCheckpointIO
+from lightning.pytorch.plugins.precision import PrecisionPlugin
+from lightning.pytorch.strategies.single_device import SingleDeviceStrategy
+from lightning.pytorch.utilities import find_shared_parameters, set_shared_parameters
+
+
+class SingleDeviceXLAStrategy(SingleDeviceStrategy):
+    """Strategy for training on a single XLA device."""
+
+    def __init__(
+        self,
+        device: _DEVICE,
+        accelerator: Optional["pl.accelerators.Accelerator"] = None,
+        checkpoint_io: Optional[CheckpointIO] = None,
+        precision_plugin: Optional[PrecisionPlugin] = None,
+        debug: bool = False,
+    ):
+        if not _XLA_AVAILABLE:
+            raise ModuleNotFoundError(str(_XLA_AVAILABLE))
+        if isinstance(device, torch.device):
+            # unwrap the `torch.device` in favor of `xla_device`
+            device = device.index
+        import torch_xla.core.xla_model as xm
+
+        super().__init__(
+            accelerator=accelerator,
+            device=xm.xla_device(device),
+            checkpoint_io=checkpoint_io,
+            precision_plugin=precision_plugin,
+        )
+        self.debug = debug
+
+    @property
+    def checkpoint_io(self) -> CheckpointIO:
+        if self._checkpoint_io is None:
+            self._checkpoint_io = XLACheckpointIO()
+        elif isinstance(self._checkpoint_io, _WrappingCheckpointIO):
+            self._checkpoint_io.checkpoint_io = XLACheckpointIO()
+
+        return self._checkpoint_io
+
+    @checkpoint_io.setter
+    def checkpoint_io(self, io: Optional[CheckpointIO]) -> None:
+        self._checkpoint_io = io
+
+    @property
+    def is_distributed(self) -> bool:
+        return False
+
+    def setup(self, trainer: "pl.Trainer") -> None:
+        assert self.model, "self.model must be set before find_shared_parameters(self.model)"
+        shared_params = find_shared_parameters(self.model)
+        self.model_to_device()
+        set_shared_parameters(self.model, shared_params)
+        super().setup(trainer)
+
+        if self.debug:
+            os.environ["PT_XLA_DEBUG"] = str(1)
+
+    @classmethod
+    def register_strategies(cls, strategy_registry: Dict) -> None:
+        strategy_registry.register("single_xla", cls, description=cls.__class__.__name__)
+
+    def teardown(self) -> None:
+        super().teardown()
+        os.environ.pop("PT_XLA_DEBUG", None)


### PR DESCRIPTION
## What does this PR do?

`SingleTPUStrategy` is a misnomer, because not only TPUs can be XLA devices (see #16130)

This PR renames it to `SingleDeviceXLAStrategy` to rhyme with `XLAStrategy`.

Decisions:
- We could move the legacy implementations to the graveyard if we consider the files annoying to have in the regular strategy directory.
- It doesn't add a deprecation as there's no plans to remove it. Should I add a deprecation regardless?
