### PR TITLE
Add test for compiling FSDP model in Fabric

### DIFF
--- a/tests/tests_fabric/helpers/runif.py
+++ b/tests/tests_fabric/helpers/runif.py
@@ -25,6 +25,7 @@ from lightning.fabric.accelerators import TPUAccelerator
 from lightning.fabric.accelerators.cuda import num_cuda_devices
 from lightning.fabric.accelerators.mps import MPSAccelerator
 from lightning.fabric.strategies.deepspeed import _DEEPSPEED_AVAILABLE
+from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 
 
 class RunIf:
@@ -139,6 +140,16 @@ class RunIf:
         return pytest.mark.skipif(
             *args, condition=any(conditions), reason=f"Requires: [{' + '.join(reasons)}]", **kwargs
         )
+
+
+def skip_if_dynamo_unsupported():
+    if _TORCH_GREATER_EQUAL_2_1:
+        from torch._dynamo.eval_frame import is_dynamo_supported
+
+        if not is_dynamo_supported():
+            pytest.skip("TorchDynamo unsupported")
+    elif sys.platform == "win32" or sys.version_info >= (3, 11):
+        pytest.skip("TorchDynamo unsupported")
 
 
 @RunIf(min_torch="99")

--- a/tests/tests_fabric/strategies/test_fsdp_integration.py
+++ b/tests/tests_fabric/strategies/test_fsdp_integration.py
@@ -25,7 +25,7 @@ from lightning.fabric.strategies import FSDPStrategy
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_1_12, _TORCH_GREATER_EQUAL_2_0
 from lightning.fabric.wrappers import _FabricOptimizer
 from tests_fabric.helpers.models import BoringFabric
-from tests_fabric.helpers.runif import RunIf
+from tests_fabric.helpers.runif import RunIf, skip_if_dynamo_unsupported
 from tests_fabric.test_fabric import BoringModel
 
 if _TORCH_GREATER_EQUAL_1_12:
@@ -173,6 +173,8 @@ def test_setup_with_orig_params_and_multiple_param_groups():
 @pytest.mark.parametrize("compile_after_setup", [False, True])
 def test_compile(compile_after_setup):
     """Test that the model can be compiled before and after the model is wrapped in FSDP."""
+    skip_if_dynamo_unsupported()
+
     model = BoringModel()
     strategy = FSDPStrategy(auto_wrap_policy=always_wrap_policy)
     fabric = Fabric(accelerator="cuda", devices=2, strategy=strategy)

--- a/tests/tests_fabric/strategies/test_fsdp_integration.py
+++ b/tests/tests_fabric/strategies/test_fsdp_integration.py
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 import tempfile
 from unittest import mock
-import os
 
 import pytest
 import torch
@@ -180,9 +180,9 @@ def test_compile(compile_after_setup):
 
     if not compile_after_setup:
         model = torch.compile(model)
-    
+
     model = fabric.setup(model)
-    
+
     if compile_after_setup:
         model = torch.compile(model)
 

--- a/tests/tests_fabric/strategies/test_fsdp_integration.py
+++ b/tests/tests_fabric/strategies/test_fsdp_integration.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import tempfile
 from unittest import mock
+import os
 
 import pytest
 import torch
@@ -25,6 +26,7 @@ from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_1_12, _TORCH
 from lightning.fabric.wrappers import _FabricOptimizer
 from tests_fabric.helpers.models import BoringFabric
 from tests_fabric.helpers.runif import RunIf
+from tests_fabric.test_fabric import BoringModel
 
 if _TORCH_GREATER_EQUAL_1_12:
     from torch.distributed.fsdp import FlatParameter, FullyShardedDataParallel
@@ -164,3 +166,25 @@ def test_setup_with_orig_params_and_multiple_param_groups():
         # A regular parameter as a view into the flattened parameters
         assert isinstance(layer.weight, torch.nn.Parameter)
         assert not isinstance(layer.weight, FlatParameter)
+
+
+@RunIf(min_cuda_gpus=2, skip_windows=True, standalone=True, min_torch="2.0.0")
+@mock.patch.dict(os.environ, {})
+@pytest.mark.parametrize("compile_after_setup", [False, True])
+def test_compile(compile_after_setup):
+    """Test that the model can be compiled before and after the model is wrapped in FSDP."""
+    model = BoringModel()
+    strategy = FSDPStrategy(auto_wrap_policy=always_wrap_policy)
+    fabric = Fabric(accelerator="cuda", devices=2, strategy=strategy)
+    fabric.launch()
+
+    if not compile_after_setup:
+        model = torch.compile(model)
+    
+    model = fabric.setup(model)
+    
+    if compile_after_setup:
+        model = torch.compile(model)
+
+    for _ in range(3):
+        model(torch.rand(2, 32, device=fabric.device)).sum().backward()

--- a/tests/tests_fabric/test_fabric.py
+++ b/tests/tests_fabric/test_fabric.py
@@ -39,7 +39,7 @@ from lightning.fabric.utilities.exceptions import MisconfigurationException
 from lightning.fabric.utilities.seed import pl_worker_init_function, seed_everything
 from lightning.fabric.utilities.warnings import PossibleUserWarning
 from lightning.fabric.wrappers import _FabricDataLoader, _FabricModule, _FabricOptimizer
-from tests_fabric.helpers.runif import RunIf
+from tests_fabric.helpers.runif import RunIf, skip_if_dynamo_unsupported
 
 
 class BoringModel(nn.Module):
@@ -90,6 +90,8 @@ def test_setup_module(ddp_mock, setup_method):
 @pytest.mark.parametrize("setup_method", ["setup", "setup_module"])
 def test_setup_compiled_module(setup_method):
     """Test that an `OptimizedModule` can be passed to the setup method."""
+    skip_if_dynamo_unsupported()
+
     from torch._dynamo.eval_frame import OptimizedModule
 
     fabric = Fabric()


### PR DESCRIPTION
## What does this PR do?

Adds an end-to-end test for compiling a model wrapped by FSDP. 


cc @carmocca @justusschock @awaelchli @borda