### PR TITLE
Update pip upgrade command in CI

### DIFF
--- a/.github/workflows/ci-tests-fabric.yml
+++ b/.github/workflows/ci-tests-fabric.yml
@@ -108,6 +108,7 @@ jobs:
 
     - name: Install package & dependencies
       run: |
+        python -m pip install -q pip -U
         pip install -e .[test] "pytest-timeout" -U -f ${TORCH_URL} ${TORCH_PREINSTALL} -f ${PYPI_CACHE_DIR} --prefer-binary
         pip install -r requirements/fabric/strategies.txt -f ${PYPI_CACHE_DIR} --prefer-binary
         pip list

--- a/.github/workflows/ci-tests-pytorch.yml
+++ b/.github/workflows/ci-tests-pytorch.yml
@@ -115,7 +115,7 @@ jobs:
 
     - name: Install package & dependencies
       run: |
-        pip install -q pip -U
+        python -m pip install -q pip -U
         pip install .[extra,test] -U \
           "pytest-timeout" -r requirements/_integrations/accelerators.txt \
           -f ${TORCH_URL} ${TORCH_PREINSTALL} -f ${PYPI_CACHE_DIR} --prefer-binary


### PR DESCRIPTION
## What does this PR do?

We are getting [this error in the CI](https://github.com/Lightning-AI/lightning/actions/runs/4711703341/jobs/8356232336?pr=17323):

```
Run pip install -q pip -U
ERROR: To modify pip, please run the following command:
c:\hostedtoolcache\windows\python\3.8.10\x64\python.exe -m pip install -q pip -U

Notice:  A new release of pip is available: [23](https://github.com/Lightning-AI/lightning/actions/runs/4711703341/jobs/8356232336?pr=17323#step:11:24).0.1 -> 23.1
Notice:  To update, run: python.exe -m pip install --upgrade pip
Error: Process completed with exit code 1.
```

The error suggests to change it to:

```
python -m pip install -q pip -U
```

cc @carmocca @borda