### PR TITLE
[TPU] Do not delete jobs with "keepalive" in the name 

### DIFF
--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -62,6 +62,12 @@ jobs:
 
         jobs_deleted=false
         while read -r job_name created_at; do
+          # Skip jobs with "keepalive" in the name
+          if [[ "$job_name" == *"keepalive"* ]]; then
+            echo "Skipping $job_name, has keepalive in name"
+            continue
+          fi
+
           # Convert the creation time to Unix timestamp
           created_timestamp=$(date -d "${created_at}" +%s)
 


### PR DESCRIPTION
## What does this PR do?

We use the same gcloud project in testing than regular usage

This means that CI can turn off your machine if it has been running for longer than 35 minutes

This PR avoids this if the name contains `keepalive`

cc @carmocca @borda