### PR TITLE
Input validation for `Fabric.launch`

### DIFF
--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -34,6 +34,7 @@ from lightning.fabric.plugins import Precision  # avoid circular imports: # isor
 from lightning.fabric.accelerators.accelerator import Accelerator
 from lightning.fabric.connector import _Connector, _PLUGIN_INPUT, _PRECISION_INPUT
 from lightning.fabric.strategies import DeepSpeedStrategy, FSDPStrategy, SingleDeviceStrategy, Strategy, XLAStrategy
+from lightning.fabric.strategies.launchers import _MultiProcessingLauncher, _XLALauncher
 from lightning.fabric.strategies.strategy import _Sharded, TBroadcast
 from lightning.fabric.utilities import move_data_to_device
 from lightning.fabric.utilities.apply_func import convert_tensors_to_scalars, convert_to_tensors
@@ -668,10 +669,10 @@ class Fabric:
                     f"`Fabric.launch(function={function})` needs to take at least one argument. The launcher will"
                     " pass in the `Fabric` object so you can use it inside the function."
                 )
-        elif isinstance(self.strategy, XLAStrategy):
+        elif isinstance(self.strategy.launcher, (_MultiProcessingLauncher, _XLALauncher)):
             raise TypeError(
-                "When `Fabric(strategy='xla')` is used, `.launch()` needs to be called with a function that contains"
-                " the code to launch in processes."
+                f"To use the `{type(self.strategy).__name__}` strategy, `.launch()` needs to be called with a function"
+                " that contains the code to launch in processes."
             )
         function = partial(self._run_with_setup, function)
         if self._strategy.launcher is not None:

--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -660,8 +660,8 @@ class Fabric:
         if function is not _do_nothing:
             if not callable(function):
                 raise TypeError(
-                    f"`Fabric.launch(...)` needs to be a callable. Given {function}."
-                    " HINT: do `.launch(your_fn)` instead of .launch(your_fn())"
+                    f"`Fabric.launch(...)` needs to be a callable, but got {function}."
+                    " HINT: do `.launch(your_fn)` instead of `.launch(your_fn())`"
                 )
             if not inspect.signature(function).parameters:
                 raise TypeError(

--- a/tests/tests_fabric/test_fabric.py
+++ b/tests/tests_fabric/test_fabric.py
@@ -687,8 +687,9 @@ def test_launch_and_cli_not_allowed():
         fabric.launch()
 
 
-def test_launch_and_strategies_unsupported_combinations(xla_available):
-    fabric = Fabric(strategy="xla")
+@pytest.mark.parametrize("strategy", ("xla", "ddp_spawn"))
+def test_launch_and_strategies_unsupported_combinations(strategy, xla_available):
+    fabric = Fabric(strategy=strategy)
     with pytest.raises(TypeError, match=r"launch\(\)` needs to be called with a function"):
         fabric.launch()
 

--- a/tests/tests_fabric/test_fabric.py
+++ b/tests/tests_fabric/test_fabric.py
@@ -643,11 +643,10 @@ def test_no_backward_sync():
 
 def test_launch_without_function():
     """Test the various ways `Fabric.launch()` can be called."""
-
     # default: no launcher, single process
     fabric = Fabric()
-    with mock.patch("lightning.fabric.fabric._do_nothing") as nothing:
-        fabric.launch()
+    nothing = Mock()
+    fabric.launch(nothing)
     nothing.assert_called()
 
     # with a launcher on the strategy
@@ -664,7 +663,7 @@ def test_launch_with_function():
         pass
 
     fabric = Fabric()
-    with pytest.raises(TypeError, match="The function passed to .* needs to take at least one argument"):
+    with pytest.raises(TypeError, match="needs to take at least one argument"):
         fabric.launch(fn_without_args)
 
     def fn_with_one_arg(arg):
@@ -675,11 +674,22 @@ def test_launch_with_function():
     fabric.launch(fn_with_one_arg)
     assert fn_with_one_arg.called
 
+    # common user mistake
+    fabric = Fabric()
+    with pytest.raises(TypeError, match="needs to be a callable"):
+        fabric.launch(fn_with_one_arg(fabric))
+
 
 @mock.patch.dict(os.environ, {"LT_CLI_USED": "1"})  # pretend we are using the CLI
 def test_launch_and_cli_not_allowed():
     fabric = Fabric(devices=1)
     with pytest.raises(RuntimeError, match=escape("Calling  `.launch()` again is not allowed")):
+        fabric.launch()
+
+
+def test_launch_and_strategies_unsupported_combinations(xla_available):
+    fabric = Fabric(strategy="xla")
+    with pytest.raises(TypeError, match=r"launch\(\)` needs to be called with a function"):
         fabric.launch()
 
 


### PR DESCRIPTION
## What does this PR do?

Adds error validation to avoid the following confusion (from Slack)

**User:**
I have a question regarding the following code snippet (from https://lightning.ai/docs/fabric/stable/advanced/distributed_communication.html):
```py
import lightning as L
import time

fabric = L.Fabric(accelerator="tpu", devices=4)
fabric.launch()

# Simulate each process taking a different amount of time
time.sleep(2 * fabric.global_rank)
print(f"Process {fabric.global_rank} is done.")

# Wait for all processes to reach the barrier
fabric.barrier()
print("All processes reached the barrier!")
Should the expected output look something like:
Process 0 is done.
Process 1 is done.
Process 2 is done.
Process 3 is done.
All processes reached the barrier!
```
On my end when I run this (even when specifying devices=4 to fabric), the output is
```python
Process 0 is done.
All processes reached the barrier!
```

**carmocca:**
You need to put the code inside a launched function, as described in my previous message

**User:**
Hm, using
```python
import lightning as L
import time

def func(fabric):
    # Simulate each process taking a different amount of time
    time.sleep(2 * fabric.global_rank)
    print(f"Process {fabric.global_rank} is done.")

    # Wait for all processes to reach the barrier
    fabric.barrier()
    print("All processes reached the barrier!")

fabric = L.Fabric(accelerator="tpu", devices=4)
fabric.launch(func(fabric))
```
results in the same output I was getting in my previous message

**carmocca:**
It's
```py
fabric.launch(func)
```
You need to pass the callable, that is what gets "launched"

cc @borda @carmocca @justusschock @awaelchli