### PR TITLE
Handle edge case in `Fabric.setup()` when model has no parameters

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -61,6 +61,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed an issue with `LightningModule.*_step` methods bypassing the DDP/FSDP wrapper ([#17424](https://github.com/Lightning-AI/lightning/pull/17424))
 
 
+- Fixed device handling in `Fabric.setup()` when the model has no parameters ([#17441](https://github.com/Lightning-AI/lightning/pull/17441))
+
+
 ## [2.0.1.post0] - 2023-04-11
 
 No changes

--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -755,7 +755,7 @@ class Fabric:
             return run_function(*args, **kwargs)
 
     def _move_model_to_device(self, model: nn.Module, optimizers: List[Optimizer]) -> nn.Module:
-        initial_device = next(model.parameters()).device
+        initial_device = next(model.parameters(), torch.tensor(0)).device
         if any(param.device != initial_device for param in model.parameters()):
             rank_zero_warn(
                 "The model passed to `Fabric.setup()` has parameters on different devices. Since `move_to_device=True`,"

--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -205,7 +205,7 @@ class Fabric:
         module = _FabricModule(module, self._precision, original_module=original_module)
 
         # Update the _DeviceDtypeModuleMixin's device parameter
-        module.to(self.device if move_to_device else next(module.parameters()).device)
+        module.to(self.device if move_to_device else next(module.parameters(), torch.tensor(0)).device)
 
         optimizers = [_FabricOptimizer(optimizer=optimizer, strategy=self._strategy) for optimizer in optimizers]
 
@@ -249,7 +249,7 @@ class Fabric:
 
         if not isinstance(self._strategy, FSDPStrategy):
             # Update the _DeviceDtypeModuleMixin's device parameter
-            module.to(self.device if move_to_device else next(module.parameters()).device)
+            module.to(self.device if move_to_device else next(module.parameters(), torch.tensor(0)).device)
 
         if hasattr(original_module, "_fabric"):  # this is probably a LightningModule
             original_module._fabric = self  # type: ignore[assignment]

--- a/tests/tests_fabric/test_fabric.py
+++ b/tests/tests_fabric/test_fabric.py
@@ -137,13 +137,10 @@ def test_setup_module_move_to_device(setup_method, move_to_device, accelerator, 
     assert fabric_model.device == expected_device
     assert fabric.device == target_device
 
-
-def test_setup_module_no_parameters():
-    """Test that setting up a model without parameters works."""
-    fabric = Fabric(devices=1)
-    model = nn.Sequential()  # has no params
-    model = fabric.setup(model)
-    assert model.device == fabric.device
+    # edge case: model has no parameters
+    model = nn.Sequential()
+    fabric_model = setup_method(model, move_to_device=move_to_device)
+    assert fabric_model.device == target_device if move_to_device else torch.device("cpu")
 
 
 @RunIf(min_cuda_gpus=1)

--- a/tests/tests_fabric/test_fabric.py
+++ b/tests/tests_fabric/test_fabric.py
@@ -138,6 +138,14 @@ def test_setup_module_move_to_device(setup_method, move_to_device, accelerator, 
     assert fabric.device == target_device
 
 
+def test_setup_module_no_parameters():
+    """Test that setting up a model without parameters works."""
+    fabric = Fabric(devices=1)
+    model = nn.Sequential()  # has no params
+    model = fabric.setup(model)
+    assert model.device == fabric.device
+
+
 @RunIf(min_cuda_gpus=1)
 @pytest.mark.parametrize("move_to_device", [True, False])
 @pytest.mark.parametrize("setup_method", ["setup", "setup_module"])


### PR DESCRIPTION
## What does this PR do?

If a model passed to `Fabric.setup()` doesn't have any parameters, we currently crash like so:

```
Traceback (most recent call last):
  File "/Users/adrian/repositories/lightning/repro.py", line 9, in <module>
    model = fabric.setup(LitModel())
  File "/Users/adrian/repositories/lightning/src/lightning/fabric/fabric.py", line 195, in setup
    module = self._move_model_to_device(model=module, optimizers=list(optimizers))
  File "/Users/adrian/repositories/lightning/src/lightning/fabric/fabric.py", line 758, in _move_model_to_device
    initial_device = next(model.parameters()).device
StopIteration
```

It is probably not useful to set up a model without parameters with a strategy in Fabric, but we should probably not fail with the error above. 



cc @carmocca @justusschock @awaelchli