### PR TITLE
Update gradient clipping docs in Fabric

### DIFF
--- a/docs/source-fabric/api/fabric_methods.rst
+++ b/docs/source-fabric/api/fabric_methods.rst
@@ -95,27 +95,17 @@ This is useful if your model experiences *exploding gradients* during training.
 .. code-block:: python
 
     # Clip gradients to a max value of +/- 0.5
-    fabric.clip_gradients(model, clip_val=0.5)
+    fabric.clip_gradients(model, optimizer, clip_val=0.5)
 
     # Clip gradients such that their total norm is no bigger than 2.0
-    fabric.clip_gradients(model, clip_norm=2.0)
+    fabric.clip_gradients(model, optimizer, clip_norm=2.0)
 
     # By default, clipping by norm uses the 2-norm
-    fabric.clip_gradients(model, clip_norm=2.0, norm_type=2)
+    fabric.clip_gradients(model, optimizer, clip_norm=2.0, norm_type=2)
 
     # You can also choose the infinity-norm, which clips the largest
     # element among all
-    fabric.clip_gradients(model, clip_norm=2.0, norm_type="inf")
-
-You can also reduce the gradient clipping to just one layer or to the parameters a particular optimizer is referencing (if using multiple optimizers):
-
-.. code-block:: python
-
-    # Clip gradients on a specific layer of your model
-    fabric.clip_gradients(model.fc3, clip_val=1.0)
-
-    # Clip gradients for a specific optimizer if using multiple optimizers
-    fabric.clip_gradients(model, optimizer1, clip_val=1.0)
+    fabric.clip_gradients(model, optimizer, clip_norm=2.0, norm_type="inf")
 
 The :meth:`~lightning.fabric.fabric.Fabric.clip_gradients` method is agnostic to the precision and strategy being used.
 Note: Gradient clipping with FSDP is not yet fully supported.

--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -382,9 +382,8 @@ class Fabric:
         """Clip the gradients of the model to a given max value or max norm.
 
         Args:
-            module: The module whose parameters should be clipped. This can also be just one submodule of your model.
-            optimizer: Optional optimizer. If passed, clipping will be applied to only the parameters that the
-                optimizer is referencing.
+            module: The module whose parameters should be clipped.
+            optimizer: The optimizer referencing the parameters to be clipped.
             clip_val: If passed, gradients will be clipped to this value.
             max_norm: If passed, clips the gradients in such a way that the p-norm of the resulting parameters is
                 no larger than the given value.


### PR DESCRIPTION
## What does this PR do?

Addresses https://github.com/Lightning-AI/lightning/issues/17358#issuecomment-1521044866

It is required to pass in the optimizer in `Fabric.clip_gradients()` because AMP needs it to unscale the gradients. Furthermore, the docs said that it is supported to pass in only a submodule, but this is not implemented (yet). 


cc @borda @carmocca @justusschock @awaelchli