### PR TITLE
Add current count and total count to standalone test output

### DIFF
--- a/tests/tests_pytorch/run_standalone_tests.sh
+++ b/tests/tests_pytorch/run_standalone_tests.sh
@@ -63,14 +63,15 @@ trap show_batched_output EXIT  # show the output on exit
 
 for i in "${!parametrizations_arr[@]}"; do
   parametrization=${parametrizations_arr[$i]}
+  prefix="$((i+1))/${#parametrizations_arr[@]}"
 
   # check blocklist
   if [[ "${parametrization}" == *"test_pytorch_profiler_nested_emit_nvtx"* ]]; then
-    echo "Skipping $parametrization"
+    echo "$prefix: Skipping $parametrization"
     report+="Skipped\t$parametrization\n"
     # do not continue the loop because we might need to wait for batched jobs
   else
-    echo "Running $parametrization"
+    echo "$prefix: Running $parametrization"
     # execute the test in the background
     # redirect to a log file that buffers test output. since the tests will run in the background, we cannot let them
     # output to std{out,err} because the outputs would be garbled together


### PR DESCRIPTION
## What does this PR do?

Minor improvement to know how many tests are left

```shell
1/41: Running parity/test_parity_ddp.py::test_parity_ddp[cpu-2-0.02]
2/41: Running parity/test_parity_ddp.py::test_parity_ddp[cuda-2-0.01]
3/41: Running strategies/launchers/test_multiprocessing.py::test_multiprocessing_launcher_start_method[fork]
4/41: Running strategies/launchers/test_multiprocessing.py::test_multiprocessing_launcher_restore_globals[fork]
5/41: Running strategies/test_ddp.py::test_ddp_grad_clipping[norm-cpu-32-true]
6/41: Running strategies/test_ddp.py::test_ddp_grad_clipping[val-cpu-32-true]
```


cc @carmocca @borda