### PR TITLE
Add map location option to checkpoint upgrade utility

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -39,6 +39,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added the process group timeout argument `FSDPStrategy(timeout=...)` for the FSDP strategy ([#17274](https://github.com/Lightning-AI/lightning/pull/17274))
 
 
+- Added CLI option `--map-to-cpu` to the checkpoint upgrade script to enable converting GPU checkpoints on a CPU-only machine ([#17527](https://github.com/Lightning-AI/lightning/pull/17527))
+
+
 ### Changed
 
 - Removed the limitation to call `self.trainer.model.parameters()` in `LightningModule.configure_optimizers()` ([#17309](https://github.com/Lightning-AI/lightning/pull/17309))

--- a/src/lightning/pytorch/utilities/upgrade_checkpoint.py
+++ b/src/lightning/pytorch/utilities/upgrade_checkpoint.py
@@ -88,7 +88,6 @@ def main() -> None:
     )
     parser.add_argument(
         "--map-to-cpu",
-        type=bool,
         action="store_true",
         help=(
             "Map all tensors in the checkpoint to CPU. Enable this option if you are converting a GPU checkpoint"

--- a/src/lightning/pytorch/utilities/upgrade_checkpoint.py
+++ b/src/lightning/pytorch/utilities/upgrade_checkpoint.py
@@ -60,7 +60,7 @@ def _upgrade(args: Namespace) -> None:
     _log.info("Upgrading checkpoints ...")
     for file in tqdm(files):
         with pl_legacy_patch():
-            checkpoint = torch.load(file)
+            checkpoint = torch.load(file, map_location=(torch.device("cpu") if args.map_to_cpu else None))
         migrate_checkpoint(checkpoint)
         torch.save(checkpoint, file)
 
@@ -81,6 +81,15 @@ def main() -> None:
         type=str,
         default=".ckpt",
         help="The file extension to look for when searching for checkpoint files in a directory.",
+    )
+    parser.add_argument(
+        "--map-to-cpu",
+        type=bool,
+        action="store_true",
+        help=(
+            "Map all tensors in the checkpoint to CPU. Enable this option if you are converting a GPU checkpoint"
+            " on a machine without GPUs."
+        ),
     )
     args = parser.parse_args()
     _upgrade(args)

--- a/src/lightning/pytorch/utilities/upgrade_checkpoint.py
+++ b/src/lightning/pytorch/utilities/upgrade_checkpoint.py
@@ -74,7 +74,11 @@ def main() -> None:
             " This will also save a backup of the original files."
         )
     )
-    parser.add_argument("path", type=str, help="Path to a checkpoint file or a directory with checkpoints to upgrade")
+    parser.add_argument(
+        "path",
+        type=str,
+        help="Path to a checkpoint file or a directory with checkpoints to upgrade",
+    )
     parser.add_argument(
         "--extension",
         "-e",

--- a/tests/tests_pytorch/utilities/test_upgrade_checkpoint.py
+++ b/tests/tests_pytorch/utilities/test_upgrade_checkpoint.py
@@ -51,7 +51,7 @@ def test_upgrade_checkpoint_single_file(migrate_mock, load_mock, save_mock, tmp_
     with mock.patch("sys.argv", ["upgrade_checkpoint.py", str(file)]):
         upgrade_main()
 
-    load_mock.assert_called_once_with(Path(file))
+    load_mock.assert_called_once_with(Path(file), map_location=None)
     migrate_mock.assert_called_once()
     save_mock.assert_called_once_with(ANY, Path(file))
 


### PR DESCRIPTION
## What does this PR do?

Fixes #17481

Allows to convert/upgrade checkpoints on a machine without GPUs, when a checkpoint was saved witch CUDA tensors. 


cc @borda @awaelchli