### PR TITLE
Support compiling a module after it was set up by Fabric

### DIFF
--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -48,7 +48,7 @@ from lightning.fabric.utilities.distributed import DistributedSamplerWrapper
 from lightning.fabric.utilities.seed import seed_everything
 from lightning.fabric.utilities.types import ReduceOp
 from lightning.fabric.utilities.warnings import PossibleUserWarning
-from lightning.fabric.wrappers import _FabricDataLoader, _FabricModule, _FabricOptimizer, _unwrap_objects
+from lightning.fabric.wrappers import _FabricDataLoader, _FabricModule, _FabricOptimizer, _unwrap_objects, _unwrap_compiled
 
 
 def _do_nothing(*_: Any) -> None:
@@ -547,6 +547,7 @@ class Fabric:
             enabled: Whether the context manager is enabled or not. ``True`` means skip the sync, ``False`` means do not
                 skip.
         """
+        module = _unwrap_compiled(module)
         if not isinstance(module, _FabricModule):
             raise TypeError(
                 "You need to set up the model first before you can call `self.no_backward_sync()`:"
@@ -638,7 +639,8 @@ class Fabric:
             # We need to unwrap objects (see above) but this creates a new dictionary. In-place updates
             # (for user metadata) wouldn't show up in the original dict, so we need to copy the data back.
             for k in list(unwrapped_state.keys()):
-                if isinstance(state[k], (_FabricModule, _FabricOptimizer, _FabricDataLoader)):
+                obj = _unwrap_compiled(state[k])
+                if isinstance(obj, (_FabricModule, _FabricOptimizer, _FabricDataLoader)):
                     continue
                 state[k] = unwrapped_state[k]
         return remainder

--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -48,7 +48,13 @@ from lightning.fabric.utilities.distributed import DistributedSamplerWrapper
 from lightning.fabric.utilities.seed import seed_everything
 from lightning.fabric.utilities.types import ReduceOp
 from lightning.fabric.utilities.warnings import PossibleUserWarning
-from lightning.fabric.wrappers import _FabricDataLoader, _FabricModule, _FabricOptimizer, _unwrap_objects, _unwrap_compiled
+from lightning.fabric.wrappers import (
+    _FabricDataLoader,
+    _FabricModule,
+    _FabricOptimizer,
+    _unwrap_compiled,
+    _unwrap_objects,
+)
 
 
 def _do_nothing(*_: Any) -> None:

--- a/src/lightning/fabric/wrappers.py
+++ b/src/lightning/fabric/wrappers.py
@@ -27,8 +27,8 @@ from lightning.fabric.plugins import Precision
 from lightning.fabric.strategies import Strategy
 from lightning.fabric.utilities import move_data_to_device
 from lightning.fabric.utilities.data import _set_sampler_epoch
-from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_0
 from lightning.fabric.utilities.device_dtype_mixin import _DeviceDtypeModuleMixin
+from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_0
 from lightning.fabric.utilities.types import Optimizable
 from lightning.fabric.utilities.warnings import PossibleUserWarning
 
@@ -232,8 +232,9 @@ def _unwrap_objects(collection: Any) -> Any:
 
 
 def _unwrap_compiled(obj: Any) -> Any:
-    """Removes the :class:`torch._dynamo.OptimizedModule` around the object if it is wrapped. Use this function
-    before instance checks against e.g. :class:`_FabricModule`.
+    """Removes the :class:`torch._dynamo.OptimizedModule` around the object if it is wrapped.
+
+    Use this function before instance checks against e.g. :class:`_FabricModule`.
     """
     if not _TORCH_GREATER_EQUAL_2_0:
         return obj

--- a/src/lightning/fabric/wrappers.py
+++ b/src/lightning/fabric/wrappers.py
@@ -220,7 +220,7 @@ def _unwrap_objects(collection: Any) -> Any:
         obj: Union[_FabricModule, _FabricOptimizer, _FabricDataLoader]
     ) -> Union[nn.Module, Optimizer, DataLoader]:
         if isinstance(_unwrap_compiled(obj), _FabricModule):
-            return obj._forward_module
+            return obj._forward_module  # type: ignore[union-attr]
         if isinstance(obj, _FabricOptimizer):
             return obj.optimizer
         if isinstance(obj, _FabricDataLoader):

--- a/src/lightning/fabric/wrappers.py
+++ b/src/lightning/fabric/wrappers.py
@@ -219,8 +219,8 @@ def _unwrap_objects(collection: Any) -> Any:
     def _unwrap(
         obj: Union[_FabricModule, _FabricOptimizer, _FabricDataLoader]
     ) -> Union[nn.Module, Optimizer, DataLoader]:
-        if isinstance(_unwrap_compiled(obj), _FabricModule):
-            return obj._forward_module  # type: ignore[union-attr]
+        if isinstance(unwrapped := _unwrap_compiled(obj), _FabricModule):
+            return unwrapped._forward_module
         if isinstance(obj, _FabricOptimizer):
             return obj.optimizer
         if isinstance(obj, _FabricDataLoader):

--- a/tests/tests_fabric/test_wrappers.py
+++ b/tests/tests_fabric/test_wrappers.py
@@ -359,7 +359,8 @@ def test_fabric_optimizer_zero_grad_kwargs():
     custom_zero_grad.assert_called_with(set_grads_to_None=False)
 
 
-def test_is_wrapped():
+@pytest.mark.parametrize("compile", [False, pytest.param(True, marks=RunIf(dynamo=True))])
+def test_is_wrapped(compile):
     """Test that the `is_wrapped` utility recognizes when an object was wrapped by Fabric."""
     assert not is_wrapped(None)
 
@@ -370,7 +371,7 @@ def test_is_wrapped():
     assert is_wrapped(wrapped)
 
     # _FabricModule inside an OptimizedModule
-    if _TORCH_GREATER_EQUAL_2_0:
+    if compile:
         from torch._dynamo import OptimizedModule
 
         module = torch.nn.Linear(2, 2)

--- a/tests/tests_fabric/test_wrappers.py
+++ b/tests/tests_fabric/test_wrappers.py
@@ -413,7 +413,7 @@ def test_unwrap_objects(compile):
         "wrapped_optimizer": wrapped_optimizer,
         "dataloader": dataloader,
         "wrapped_dataloader": wrapped_dataloader,
-        # "nested": [module, wrapped_module, optimizer, wrapped_optimizer, dataloader, wrapped_dataloader],
+        "nested": [module, wrapped_module, optimizer, wrapped_optimizer, dataloader, wrapped_dataloader],
     }
     expected = {
         "int": 1,
@@ -423,7 +423,7 @@ def test_unwrap_objects(compile):
         "wrapped_optimizer": optimizer,
         "dataloader": dataloader,
         "wrapped_dataloader": dataloader,
-        # "nested": [module, wrapped_module._forward_module, optimizer, optimizer, dataloader, dataloader],
+        "nested": [module, wrapped_module._forward_module, optimizer, optimizer, dataloader, dataloader],
     }
     assert _unwrap_objects(container) == expected
 

--- a/tests/tests_fabric/test_wrappers.py
+++ b/tests/tests_fabric/test_wrappers.py
@@ -23,7 +23,6 @@ from torch.utils.data.dataloader import DataLoader
 from lightning.fabric.fabric import Fabric
 from lightning.fabric.plugins import Precision
 from lightning.fabric.utilities.device_dtype_mixin import _DeviceDtypeModuleMixin
-from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_0
 from lightning.fabric.wrappers import _FabricDataLoader, _FabricModule, _FabricOptimizer, _unwrap_objects, is_wrapped
 from tests_fabric.helpers.runif import RunIf
 

--- a/tests/tests_fabric/test_wrappers.py
+++ b/tests/tests_fabric/test_wrappers.py
@@ -24,6 +24,7 @@ from lightning.fabric.fabric import Fabric
 from lightning.fabric.plugins import Precision
 from lightning.fabric.utilities.device_dtype_mixin import _DeviceDtypeModuleMixin
 from lightning.fabric.wrappers import _FabricDataLoader, _FabricModule, _FabricOptimizer, is_wrapped
+from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_0
 from tests_fabric.helpers.runif import RunIf
 
 
@@ -367,6 +368,15 @@ def test_is_wrapped():
     assert not is_wrapped(module)
     wrapped = _FabricModule(module, Mock())
     assert is_wrapped(wrapped)
+
+    # _FabricModule inside an OptimizedModule
+    if _TORCH_GREATER_EQUAL_2_0:
+        from torch._dynamo import OptimizedModule
+
+        module = torch.nn.Linear(2, 2)
+        wrapped = torch.compile(_FabricModule(module, Mock()))
+        assert isinstance(wrapped, OptimizedModule)
+        assert is_wrapped(wrapped)
 
     # _FabricOptimizer
     optimizer = torch.optim.Adam(module.parameters())

--- a/tests/tests_fabric/test_wrappers.py
+++ b/tests/tests_fabric/test_wrappers.py
@@ -23,8 +23,8 @@ from torch.utils.data.dataloader import DataLoader
 from lightning.fabric.fabric import Fabric
 from lightning.fabric.plugins import Precision
 from lightning.fabric.utilities.device_dtype_mixin import _DeviceDtypeModuleMixin
-from lightning.fabric.wrappers import _FabricDataLoader, _FabricModule, _FabricOptimizer, is_wrapped
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_0
+from lightning.fabric.wrappers import _FabricDataLoader, _FabricModule, _FabricOptimizer, is_wrapped
 from tests_fabric.helpers.runif import RunIf
 
 


### PR DESCRIPTION
## What does this PR do?

Fabric supports working with models output by `torch.compile` because the `torch._dynamo.OptimizedModule` wrapper is a subtype of `nn.Module`. So to Fabric, a compiled module will look just like any other `nn.Module`. This works fine:

```py
model = torch.compile(model)
model = fabric.setup(model)
```

However, it is also possible for the user to compile their model *after* they called `fabric.setup()` like so:

```py
model = fabric.setup(model)
model = torch.compile(model)
```
This also works without issues in most cases, but some fabric methods expect a _FabricModule or have instance checks against it (e.g., fabric.save, fabric.load, fabric.no_backward_sync). These would fail because what we are passing in is a OptimizedModule. This PR makes sure we unwrap the optimized module in the methods that require the original unwrapped module.


Part of #16971 




cc @borda @carmocca @justusschock @awaelchli