### PR TITLE
add note in LightningCLI docs that `--optimizer` must be given for `--lr_scheduler` to work

### DIFF
--- a/docs/source-pytorch/cli/lightning_cli_intermediate_2.rst
+++ b/docs/source-pytorch/cli/lightning_cli_intermediate_2.rst
@@ -193,13 +193,15 @@ Standard learning rate schedulers from ``torch.optim.lr_scheduler``  work out of
 
 .. code:: bash
 
-    python main.py fit --lr_scheduler CosineAnnealingLR
+    python main.py fit --optimizer=Adam --lr_scheduler CosineAnnealingLR
+
+Please note that ``--optimizer`` must be added for ``--lr_scheduler`` to have an effect.
 
 If the scheduler you want needs other arguments, add them via the CLI (no need to change your code)!
 
 .. code:: bash
 
-    python main.py fit --lr_scheduler=ReduceLROnPlateau --lr_scheduler.monitor=epoch
+    python main.py fit --optimizer=Adam --lr_scheduler=ReduceLROnPlateau --lr_scheduler.monitor=epoch
 
 Furthermore, any custom subclass of ``torch.optim.lr_scheduler.LRScheduler`` can be used as learning rate scheduler:
 
@@ -224,7 +226,7 @@ Now you can choose between any learning rate scheduler at runtime:
 .. code:: bash
 
     # LitLRScheduler
-    python main.py fit --lr_scheduler LitLRScheduler
+    python main.py fit --optimizer=Adam --lr_scheduler LitLRScheduler
 
 
 ----


### PR DESCRIPTION
## What does this PR do?

This PR clarifies the documentation for `LightningCLI` regarding `--lr_scheduler`. Specifically, it adds the following:

> Please note that `--optimizer` must be added for `--lr_scheduler` to have an effect.

 It also adds `--optimizer=Adam` to examples of `--lr_scheduler` to reinforce the notion that both options must be provided.

Fixes #17547 

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs) -- Yes
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary) -- Yes
- Did you write any **new necessary tests**? (not for typos and docs) -- NA
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request? -- NA
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors) -- NA

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
