### PR TITLE
[TPU] Remove CPU conversion of metrics

### DIFF
--- a/src/lightning/pytorch/trainer/connectors/logger_connector/result.py
+++ b/src/lightning/pytorch/trainer/connectors/logger_connector/result.py
@@ -364,10 +364,6 @@ class _ResultCollection(dict):
         if not enable_graph:
             value = recursive_detach(value)
 
-        # move metrics to cpu on TPU.
-        if isinstance(value, Tensor) and value.device.type == "xla":
-            value = value.cpu()
-
         # storage key
         key = f"{fx}.{name}"
         # add dataloader_suffix to both key and fx


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/Lightning-AI/lightning/issues/15884

I don't know why we move the metrics to CPU. It was added in https://github.com/Lightning-AI/lightning/pull/5743/files#diff-51f8c4fefbb7ae230000c1b9a474c8f87086a82cb4b49d9b57a3e77e7cb2ebdfR151

cc @carmocca @JackCaoG @steventk-g @Liyang90 @borda