### PR TITLE
Make WandbLogger run initialization lazy for non-spawn distributed operation

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -72,6 +72,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - `self.log`ed tensors are now kept in the original device to reduce unnecessary host-to-device synchronizations ([#17334](https://github.com/Lightning-AI/lightning/pull/17334))
 
+
+- Made the run initialization in `WandbLogger` lazy to avoid creating artifacts when the CLI is used ([#17573](https://github.com/Lightning-AI/lightning/pull/17573))
+
+
 ### Deprecated
 
 - Deprecated the `SingleTPUStrategy` (`strategy="single_tpu"`) in favor of `SingleDeviceXLAStrategy` (`strategy="single_xla"`) ([#17383](https://github.com/Lightning-AI/lightning/pull/17383))

--- a/tests/tests_pytorch/loggers/test_wandb.py
+++ b/tests/tests_pytorch/loggers/test_wandb.py
@@ -83,9 +83,10 @@ def test_wandb_logger_init(wandb, monkeypatch):
     wandb.init.reset_mock()
     wandb.run = wandb.init()
 
-    monkeypatch.setattr(lightning.pytorch.loggers.wandb, "_WANDB_GREATER_EQUAL_0_12_10", True)
+    logger = WandbLogger()
     with pytest.warns(UserWarning, match="There is a wandb run already in progress"):
-        logger = WandbLogger()
+        _ = logger.experiment
+
     # check that no new run is created
     with no_warning_call(UserWarning, match="There is a wandb run already in progress"):
         _ = logger.experiment
@@ -113,6 +114,21 @@ def test_wandb_logger_init(wandb, monkeypatch):
     wandb.init().watch.assert_called_once_with("model", log="log", log_freq=10, log_graph=False)
 
     assert logger.version == wandb.init().id
+
+
+@mock.patch("lightning.pytorch.loggers.wandb.Run", new=mock.Mock)
+@mock.patch("lightning.pytorch.loggers.wandb.wandb")
+def test_wandb_logger_init_before_spawn(_, monkeypatch):
+    monkeypatch.setattr(lightning.pytorch.loggers.wandb, "_WANDB_GREATER_EQUAL_0_12_10", False)
+    logger = WandbLogger()
+    assert logger._experiment is None
+    logger.__getstate__()
+    assert logger._experiment is None
+
+    monkeypatch.setattr(lightning.pytorch.loggers.wandb, "_WANDB_GREATER_EQUAL_0_12_10", True)
+    logger = WandbLogger()
+    logger.__getstate__()
+    assert logger._experiment is not None
 
 
 @mock.patch("lightning.pytorch.loggers.wandb.wandb")
@@ -161,8 +177,6 @@ def test_wandb_logger_dirs_creation(wandb, monkeypatch, tmpdir):
     monkeypatch.setattr(lightning.pytorch.loggers.wandb, "_WANDB_GREATER_EQUAL_0_12_10", True)
     wandb.run = None
     logger = WandbLogger(project="project", save_dir=str(tmpdir), offline=True)
-    # the logger get initialized
-    assert logger.version == wandb.init().id
 
     # mock return values of experiment
     wandb.run = None


### PR DESCRIPTION
## What does this PR do?

Fixes #17487

Prior to 2.0, when strategy="ddp_spawn" was the default distributed strategy, the wandb logger had to solve the following problem:
- Avoid creating empty duplicate runs in main process and rank-0 worker process
- Avoid creating multiple runs when repeatedly calling fit/validate/test.

These were addressed by enabling the wandb-service feature (#11650), which would re-attach subprocesses to the one run created by the main process. This would avoid creating duplicated runs under different circumstances. However, the drawback to the solution is that the experiment had to be created in the main process for the service to reattach properly. This is inconsistent with other loggers who create their runs lazily, and leads to inconveniences like in #17487. 

This PR removes the run initialization in `WandbLogger.__init__` to make it truly lazy. The justification is that today in 2.0, the default strategy is ddp proper, with which the above issues never existed. To not break the usage with ddp_spawn, for users who still use that strategy, I "hacked" the `__getstate__` so that when `mp.spawn` is called, the special wandb-service still gets enabled (and the run gets initialized in the main process). 


cc @borda @awaelchli @morganmcg1 @borisdayma @scottire @parambharat