### PR TITLE
Remove redundant install info in CLI

### DIFF
--- a/src/lightning/pytorch/cli.py
+++ b/src/lightning/pytorch/cli.py
@@ -90,9 +90,7 @@ class LightningArgumentParser(ArgumentParser):
             default_env: Whether to parse environment variables.
         """
         if not _JSONARGPARSE_SIGNATURES_AVAILABLE:
-            raise ModuleNotFoundError(
-                f"{_JSONARGPARSE_SIGNATURES_AVAILABLE}. Try `pip install -U 'jsonargparse[signatures]'`."
-            )
+            raise ModuleNotFoundError(f"{_JSONARGPARSE_SIGNATURES_AVAILABLE}")
         super().__init__(*args, description=description, env_prefix=env_prefix, default_env=default_env, **kwargs)
         self.callback_keys: List[str] = []
         # separate optimizers and lr schedulers to know which were added


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

I was using LightningCli without having `jsonargparse` installed in the current enviroment, which gives the following traceback:
```
Traceback (most recent call last):
  File "C:\Users\nsde\Documents\pytorch-lightning\examples\pytorch\basics\backbone_image_classifier.py", line 140, in <module>
    cli_main()
  File "C:\Users\nsde\Documents\pytorch-lightning\examples\pytorch\basics\backbone_image_classifier.py", line 129, in cli_main
    cli = LightningCLI(
          ^^^^^^^^^^^^^
  File "C:\Users\nsde\Documents\pytorch-lightning\src\lightning\pytorch\cli.py", line 342, in __init__
    self.setup_parser(run, main_kwargs, subparser_kwargs)
  File "C:\Users\nsde\Documents\pytorch-lightning\src\lightning\pytorch\cli.py", line 374, in setup_parser
    self.parser = self.init_parser(**main_kwargs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\nsde\Documents\pytorch-lightning\src\lightning\pytorch\cli.py", line 364, in init_parser
    parser = LightningArgumentParser(**kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\nsde\Documents\pytorch-lightning\src\lightning\pytorch\cli.py", line 93, in __init__
    raise ModuleNotFoundError(
ModuleNotFoundError: DistributionNotFound: The 'jsonargparse[signatures]>=4.17.0' distribution was not found and is required by the application. HINT: Try running `pip install -U 'jsonargparse[signatures]>=4.17.0'`. Try `pip install -U 'jsonargparse[signatures]'`.
```

The last line states redundant install instructions
```
HINT: Try running `pip install -U 'jsonargparse[signatures]>=4.17.0'`. Try `pip install -U 'jsonargparse[signatures]'`.
```

This is due to the first error being created by lightning utilities here:
https://github.com/Lightning-AI/utilities/blob/8541e129b0ecbee5d6ec092a7d04386911d08685/src/lightning_utilities/core/imports.py#L120-L121
and the second being added here:
https://github.com/Lightning-AI/lightning/blob/4413e98e4e5e2ac59ebe662529822a86fcca912e/src/lightning/pytorch/cli.py#L93-L95

PR simply removes the latter.



<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
