### PR TITLE
channels last callback

### DIFF
--- a/src/lightning/pytorch/callbacks/__init__.py
+++ b/src/lightning/pytorch/callbacks/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from lightning.pytorch.callbacks.batch_size_finder import BatchSizeFinder
 from lightning.pytorch.callbacks.callback import Callback
+from lightning.pytorch.callbacks.channels_last import ChannelsLast
 from lightning.pytorch.callbacks.checkpoint import Checkpoint
 from lightning.pytorch.callbacks.device_stats_monitor import DeviceStatsMonitor
 from lightning.pytorch.callbacks.early_stopping import EarlyStopping
@@ -37,6 +38,7 @@ __all__ = [
     "BasePredictionWriter",
     "BatchSizeFinder",
     "Callback",
+    "ChannelsLast",
     "Checkpoint",
     "DeviceStatsMonitor",
     "EarlyStopping",

--- a/src/lightning/pytorch/callbacks/channels_last.py
+++ b/src/lightning/pytorch/callbacks/channels_last.py
@@ -1,0 +1,39 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""
+ChannelsLast
+===============
+
+changes the model memory format to channels_last
+"""
+
+from typing import Optional
+
+import lightning.pytorch as pl
+from lightning.pytorch.callbacks.callback import Callback
+
+
+class ChannelsLast(Callback):
+    """The `ChannelsLast` callback changes the model memory format to `torch.channels_last` before training starts.
+    <https://\\pytorch.org/tutorials/intermediate/memory_format_tutorial.html>`_.
+
+    This usually improves GPU utilization.
+
+    Runs on setup, so it can set the memory format before the model is DDP wrapped. 
+    
+    Has no parameters.
+    """
+
+    def setup(self, trainer: Trainer, pl_module: LightningModule, stage: Optional[str] = None) -> None:
+        pl_module.to(memory_format=torch.channels_last)

--- a/tests/tests_pytorch/callbacks/test_channels_last.py
+++ b/tests/tests_pytorch/callbacks/test_channels_last.py
@@ -1,0 +1,41 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+import torch
+from lightning.pytorch import Trainer, LightningModule
+from lightning.pytorch.callbacks import ChannelsLast
+
+def test_channels_last_callback():
+
+    class DummyModule(LightningModule):
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv2d(3, 3, kernel_size=3)
+
+        def forward(self, x):
+            return self.conv(x)
+
+    model = DummyModule()
+
+    # create a dummy Trainer
+    trainer = Trainer(gpus=1, max_epochs=1)
+
+    # create the callback
+    callback = ChannelsLast()
+
+    # call the setup method
+    callback.setup(trainer, model)
+
+    # check that the memory format is channels_last
+    assert model.conv.weight.is_contiguous(memory_format=torch.channels_last)


### PR DESCRIPTION
## What does this PR do?

This PR fixes issue #15175 by adding a new feature to the `ChannelsLast` callback. This callback changes the module memory format on setup. This is useful when the user wants to use a different memory format and can lead to a considerable speedup in some cases.

Fixes #15175 

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

This PR does not introduce any breaking changes.

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Definitely ;)

-->
