### PR TITLE
Address feedback for `Fabric.init_module()` (1/4)

### DIFF
--- a/docs/source-fabric/api/fabric_methods.rst
+++ b/docs/source-fabric/api/fabric_methods.rst
@@ -157,10 +157,6 @@ This eliminates the waiting time to transfer the model parameters from the CPU t
 For strategies that handle large sharded models (FSDP, DeepSpeed), the :meth:`~lightning.fabric.fabric.Fabric.init_module` method will allocate the model parameters on the meta device first before sharding.
 This makes it possible to work with models that are larger than the memory of a single device.
 
-.. tip::
-
-    This is a wrapper over :meth:`~lightning.fabric.fabric.Fabric.init` and :meth:`~lightning.fabric.fabric.Fabric.sharded_model` which implement the features described above.
-    Using these separately can provide more control for expert users.
 
 autocast
 ========

--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -35,7 +35,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added `Fabric.init()` context manager to instantiate tensors or models efficiently directly on device and dtype ([#17488](https://github.com/Lightning-AI/lightning/pull/17488))
 
-- Added `Fabric.init_module()` context manager to instantiate large models efficiently directly on device, dtype ([#17462](https://github.com/Lightning-AI/lightning/pull/17462))
+- Added `Fabric.init_module()` context manager to instantiate large models efficiently directly on device, dtype, and with sharding support ([#17462](https://github.com/Lightning-AI/lightning/pull/17462))
 
 - Added `lightning.fabric.plugins.Precision.init_context()` context manager to control model and tensor instantiation ([#17462](https://github.com/Lightning-AI/lightning/pull/17462))
   * Creates the model parameters in the desired dtype (`torch.float32`, `torch.float64`, `torch.float16`, or `torch.bfloat16`) depending on the 'true' precision choice in `Fabric(precision='32-true'|'64-true'|'16-true'|'bf16-true')`

--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -35,7 +35,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added `Fabric.init()` context manager to instantiate tensors or models efficiently directly on device and dtype ([#17488](https://github.com/Lightning-AI/lightning/pull/17488))
 
-- Added `Fabric.init_module()` context manager to instantiate large models efficiently directly on device, dtype, and sharding them ([#17462](https://github.com/Lightning-AI/lightning/pull/17462))
+- Added `Fabric.init_module()` context manager to instantiate large models efficiently directly on device, dtype ([#17462](https://github.com/Lightning-AI/lightning/pull/17462))
 
 - Added `lightning.fabric.plugins.Precision.init_context()` context manager to control model and tensor instantiation ([#17462](https://github.com/Lightning-AI/lightning/pull/17462))
   * Creates the model parameters in the desired dtype (`torch.float32`, `torch.float64`, `torch.float16`, or `torch.bfloat16`) depending on the 'true' precision choice in `Fabric(precision='32-true'|'64-true'|'16-true'|'bf16-true')`

--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -22,7 +22,7 @@ import torch
 import torch.nn as nn
 from lightning_utilities.core.apply_func import apply_to_collection
 from lightning_utilities.core.overrides import is_overridden
-from lightning_utilities.core.rank_zero import rank_zero_warn, rank_zero_deprecation
+from lightning_utilities.core.rank_zero import rank_zero_deprecation, rank_zero_warn
 from torch import Tensor
 from torch.optim import Optimizer
 from torch.utils.data import BatchSampler, DataLoader, DistributedSampler, RandomSampler, SequentialSampler
@@ -607,8 +607,8 @@ class Fabric:
         """Instantiate the model and its parameters under this context manager to reduce peak memory usage.
 
         The parameters get created on the device and with the right data type right away without wasting memory being
-        allocated unnecessarily.
-        The automatic device placement under this context manager is only supported with PyTorch 2.0 and newer.
+        allocated unnecessarily. The automatic device placement under this context manager is only supported with
+        PyTorch 2.0 and newer.
         """
         with self._strategy.init_context(), _old_sharded_model_context(self.strategy):
             yield

--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -585,8 +585,11 @@ class Fabric:
     @contextmanager
     def sharded_model(self) -> Generator:
         """Shard the parameters of the model instantly when instantiating the layers."""
-        context = self._strategy.init_sharded_context() if isinstance(self._strategy, _Sharded) else nullcontext()
-        with context:
+        """Instantiate a model under this context manager to prepare it for model-parallel sharding.
+        .. deprecated:: This context manager is deprecated in favor of :meth:`init_module`, use it instead.
+        """
+        rank_zero_deprecation("`Fabric.sharded_model()` is deprecated in favor of `Fabric.init_module()`.")
+        with _old_sharded_model_context(self._strategy):
             yield
 
     @contextmanager
@@ -605,7 +608,7 @@ class Fabric:
 
         It is recommended to instantiate your modules under this.
         """
-        with self.init(), self.sharded_model():
+        with self._strategy.init_context(), _old_sharded_model_context(self.strategy):
             yield
 
     def save(self, path: Union[str, Path], state: Dict[str, Union[nn.Module, Optimizer, Any]]) -> None:
@@ -781,9 +784,9 @@ class Fabric:
         self._strategy.setup_environment()
         # TODO: remove sharded_context from here as users are meant to enable it manually
         # apply sharded context to prevent OOM
-        with self.sharded_model(), _replace_dunder_methods(DataLoader, "dataset"), _replace_dunder_methods(
-            BatchSampler
-        ):
+        with _old_sharded_model_context(self._strategy), _replace_dunder_methods(
+            DataLoader, "dataset"
+        ), _replace_dunder_methods(BatchSampler):
             return to_run(*args, **kwargs)
 
     def _move_model_to_device(self, model: nn.Module, optimizers: List[Optimizer]) -> nn.Module:
@@ -888,3 +891,12 @@ class Fabric:
 
         if any(not isinstance(dl, DataLoader) for dl in dataloaders):
             raise TypeError("Only PyTorch DataLoader are currently supported in `setup_dataloaders`.")
+
+
+@contextmanager
+def _old_sharded_model_context(strategy: Strategy) -> Generator:
+    if isinstance(strategy, _Sharded):
+        with strategy.init_sharded_context():
+            yield
+    else:
+        yield

--- a/tests/tests_fabric/test_fabric.py
+++ b/tests/tests_fabric/test_fabric.py
@@ -719,12 +719,12 @@ def test_module_sharding_context():
     otherwise."""
     fabric = Fabric()
     fabric._strategy = MagicMock(spec=DDPStrategy, init_sharded_context=Mock())
-    with fabric.sharded_model():
+    with pytest.warns(DeprecationWarning, match="sharded_model"), fabric.sharded_model():
         pass
     fabric._strategy.init_sharded_context.assert_not_called()
 
     fabric._strategy = MagicMock(spec=_Sharded)
-    with fabric.sharded_model():
+    with pytest.warns(DeprecationWarning, match="sharded_model"), fabric.sharded_model():
         pass
     fabric._strategy.init_sharded_context.assert_called_once()
 


### PR DESCRIPTION
## What does this PR do?

Part of https://github.com/Lightning-AI/lightning/issues/17581
Partially reverts https://github.com/Lightning-AI/lightning/pull/17488
Executes on the original vision of #17462

Adds back the deprecation that was added in https://github.com/Lightning-AI/lightning/pull/17462 and then removed in https://github.com/Lightning-AI/lightning/pull/17488



cc @borda @carmocca @justusschock @awaelchli