### PR TITLE
Fix race condition when downloading data

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,10 @@ Fabric is designed for the most complex models like foundation model scaling, LL
 + import lightning as L
   import torch; import torchvision as tv
 
+ dataset = tv.datasets.CIFAR10("data", download=True,
+                               train=True,
+                               transform=tv.transforms.ToTensor())
+
 + fabric = L.Fabric()
 + fabric.launch()
 
@@ -346,9 +350,6 @@ Fabric is designed for the most complex models like foundation model scaling, LL
 - model.to(device)
 + model, optimizer = fabric.setup(model, optimizer)
 
-  dataset = tv.datasets.CIFAR10("data", download=True,
-                                train=True,
-                                transform=tv.transforms.ToTensor())
   dataloader = torch.utils.data.DataLoader(dataset, batch_size=8)
 + dataloader = fabric.setup_dataloaders(dataloader)
 
@@ -375,6 +376,10 @@ Fabric is designed for the most complex models like foundation model scaling, LL
 import lightning as L
 import torch; import torchvision as tv
 
+dataset = tv.datasets.CIFAR10("data", download=True,
+                              train=True,
+                              transform=tv.transforms.ToTensor())
+
 fabric = L.Fabric()
 fabric.launch()
 
@@ -382,9 +387,6 @@ model = tv.models.resnet18()
 optimizer = torch.optim.SGD(model.parameters(), lr=0.001)
 model, optimizer = fabric.setup(model, optimizer)
 
-dataset = tv.datasets.CIFAR10("data", download=True,
-                              train=True,
-                              transform=tv.transforms.ToTensor())
 dataloader = torch.utils.data.DataLoader(dataset, batch_size=8)
 dataloader = fabric.setup_dataloaders(dataloader)
 

--- a/src/lightning_fabric/README.md
+++ b/src/lightning_fabric/README.md
@@ -41,6 +41,10 @@ Fabric is designed for the most complex models like foundation model scaling, LL
 + import lightning as L
   import torch; import torchvision as tv
 
+  dataset = tv.datasets.CIFAR10("data", download=True,
+                                train=True,
+                                transform=tv.transforms.ToTensor())
+
 + fabric = L.Fabric()
 + fabric.launch()
 
@@ -50,9 +54,6 @@ Fabric is designed for the most complex models like foundation model scaling, LL
 - model.to(device)
 + model, optimizer = fabric.setup(model, optimizer)
 
-  dataset = tv.datasets.CIFAR10("data", download=True,
-                                train=True,
-                                transform=tv.transforms.ToTensor())
   dataloader = torch.utils.data.DataLoader(dataset, batch_size=8)
 + dataloader = fabric.setup_dataloaders(dataloader)
 
@@ -78,6 +79,10 @@ Fabric is designed for the most complex models like foundation model scaling, LL
 import lightning as L
 import torch; import torchvision as tv
 
+dataset = tv.datasets.CIFAR10("data", download=True,
+                              train=True,
+                              transform=tv.transforms.ToTensor())
+
 fabric = L.Fabric()
 fabric.launch()
 
@@ -85,9 +90,6 @@ model = tv.models.resnet18()
 optimizer = torch.optim.SGD(model.parameters(), lr=0.001)
 model, optimizer = fabric.setup(model, optimizer)
 
-dataset = tv.datasets.CIFAR10("data", download=True,
-                              train=True,
-                              transform=tv.transforms.ToTensor())
 dataloader = torch.utils.data.DataLoader(dataset, batch_size=8)
 dataloader = fabric.setup_dataloaders(dataloader)
 


### PR DESCRIPTION
## What does this PR do?

On a distributed machine with the previous example, each rank would download the data.
Since shared filesystems are commonly used, this created a race condition where one rank could finish downloading and start checking the data integrity whilst another was still downloading. That would could corrupt the file for the finished rank.

This PR proposes to fix it by downloading before processes are launched. When they get launched, they will not download it again:

```python
Downloading https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz to data/cifar-10-python.tar.gz
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 170498071/170498071 [00:02<00:00, 77082286.83it/s]
Extracting data/cifar-10-python.tar.gz to data  # rank 0 (main) is finished before processes launched
Initializing distributed: GLOBAL_RANK: 0, MEMBER: 1/4  # processes launched
Files already downloaded and verified  # the other ranks know it is downloaded
Files already downloaded and verified
Files already downloaded and verified
Initializing distributed: GLOBAL_RANK: 1, MEMBER: 2/4
Initializing distributed: GLOBAL_RANK: 3, MEMBER: 4/4
Initializing distributed: GLOBAL_RANK: 2, MEMBER: 3/4
```

An alternative solution would be to do the following after processes have been launched

```python
is_global_zero = fabric.global_rank == 0
if is_global_zero:  # download on rank zero only, assumes shared filesystem
    dataset = tv.datasets.CIFAR10("data", download=True,
                                  train=True,
                                  transform=tv.transforms.ToTensor())
fabric.barrier()  # wait until the data is available
if not is_global_zero:
    dataset = tv.datasets.CIFAR10("data", download=False,
                                  train=True,
                                  transform=tv.transforms.ToTensor())
```

This would have the benefit of:
- not having to check the integrity twice for the 1..N processes
- it would be necessary for spawn support.

However, I went for the simple option for the sake of having a minimal example. Spawn support would also need to convert the code into a launched function.