### PR TITLE
Document non-strict loading of checkpoints in Fabric

### DIFF
--- a/docs/source-fabric/guide/checkpoint.rst
+++ b/docs/source-fabric/guide/checkpoint.rst
@@ -87,7 +87,7 @@ For this case, you can disable strict loading to avoid errors:
 
 .. code-block:: python
 
-    state = {"model1": model1}
+    state = {"model": model}
 
     # strict loading is the default
     fabric.load("path/to/checkpoint.ckpt", state, strict=True)

--- a/docs/source-fabric/guide/checkpoint.rst
+++ b/docs/source-fabric/guide/checkpoint.rst
@@ -77,6 +77,55 @@ If you want to be in complete control of how states get restored, you can omit p
 ----
 
 
+*************************
+Load a partial checkpoint
+*************************
+
+Loading a checkpoint is normally "strict", meaning parameter names in the checkpoint must match the parameter names in the model.
+However, when loading checkpoints for fine-tuning or transfer learning, it can happen that only a portion of the parameters match the model.
+For this case, you can disable strict loading to avoid errors:
+
+.. code-block:: python
+
+    state = {"model1": model1}
+
+    # strict loading is the default
+    fabric.load("path/to/checkpoint.ckpt", state, strict=True)
+
+    # disable strict loading
+    fabric.load("path/to/checkpoint.ckpt", state, strict=False)
+
+
+Here is a trivial example to illustrate how it works:
+
+.. code-block:: python
+
+    import torch
+    import lightning as L
+
+    fabric = L.Fabric()
+
+    # Save a checkpoint of a trained model
+    model1 = torch.nn.Linear(2, 2, bias=True)
+    state = {"model": model1}
+    fabric.save("state.ckpt", state)
+
+    # Later on, make a new model that misses a parameter
+    model2 = torch.nn.Linear(2, 2, bias=False)
+    state = {"model": model2}
+
+    # `strict=True` would lead to an error, because the bias
+    # parameter is missing, but we can load the rest of the
+    # parameters successfully
+    fabric.load("state.ckpt", state, strict=False)
+
+
+See also: `Saving and Loading models in PyTorch <https://pytorch.org/tutorials/beginner/saving_loading_models.html>`_.
+
+
+----
+
+
 **********
 Next steps
 **********

--- a/docs/source-fabric/guide/checkpoint.rst
+++ b/docs/source-fabric/guide/checkpoint.rst
@@ -120,7 +120,7 @@ Here is a trivial example to illustrate how it works:
     fabric.load("state.ckpt", state, strict=False)
 
 
-See also: `Saving and Loading models in PyTorch <https://pytorch.org/tutorials/beginner/saving_loading_models.html>`_.
+See also: `Saving and loading models in PyTorch <https://pytorch.org/tutorials/beginner/saving_loading_models.html>`_.
 
 
 ----

--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -352,9 +352,9 @@ class Fabric:
 
         dataloader = self._strategy.process_dataloader(dataloader)
         device = self.device if move_to_device and not isinstance(self._strategy, XLAStrategy) else None
-        lite_dataloader = _FabricDataLoader(dataloader=dataloader, device=device)
-        lite_dataloader = cast(DataLoader, lite_dataloader)
-        return lite_dataloader
+        fabric_dataloader = _FabricDataLoader(dataloader=dataloader, device=device)
+        fabric_dataloader = cast(DataLoader, fabric_dataloader)
+        return fabric_dataloader
 
     def backward(self, tensor: Tensor, *args: Any, model: Optional[_FabricModule] = None, **kwargs: Any) -> None:
         """Replaces ``loss.backward()`` in your training loop. Handles precision and automatically for you.


### PR DESCRIPTION
## What does this PR do?

Follow up to #17645 
Adds the docs for `Fabric.load(..., strict=False)`



cc @borda @awaelchli @carmocca @justusschock