### PR TITLE
add `save_hp_params` config to tensorboard logger

### DIFF
--- a/src/lightning/pytorch/loggers/tensorboard.py
+++ b/src/lightning/pytorch/loggers/tensorboard.py
@@ -109,7 +109,7 @@ class TensorBoardLogger(Logger, FabricTensorBoardLogger):
         default_hp_metric: bool = True,
         prefix: str = "",
         sub_dir: Optional[_PATH] = None,
-        save_hp_params: bool =True,
+        save_hp_params: bool = True,
         **kwargs: Any,
     ):
         super().__init__(

--- a/src/lightning/pytorch/loggers/tensorboard.py
+++ b/src/lightning/pytorch/loggers/tensorboard.py
@@ -109,7 +109,7 @@ class TensorBoardLogger(Logger, FabricTensorBoardLogger):
         default_hp_metric: bool = True,
         prefix: str = "",
         sub_dir: Optional[_PATH] = None,
-        save_hp_params=True,
+        save_hp_params: bool =True,
         **kwargs: Any,
     ):
         super().__init__(

--- a/src/lightning/pytorch/loggers/tensorboard.py
+++ b/src/lightning/pytorch/loggers/tensorboard.py
@@ -81,7 +81,7 @@ class TensorBoardLogger(Logger, FabricTensorBoardLogger):
         sub_dir: Sub-directory to group TensorBoard logs. If a sub_dir argument is passed
             then logs are saved in ``/save_dir/name/version/sub_dir/``. Defaults to ``None`` in which
             logs are saved in ``/save_dir/name/version/``.
-        save_hp_params： enable to save the hyperparams to tensorboard. if your saving hyperparams 
+        save_hp_params： enable to save the hyperparams to tensorboard. if your saving hyperparams
             to tensorboard is failed, please turn it off.
         \**kwargs: Additional arguments used by :class:`tensorboardX.SummaryWriter` can be passed as keyword
             arguments in this logger. To automatically flush to disk, `max_queue` sets the size

--- a/src/lightning/pytorch/loggers/tensorboard.py
+++ b/src/lightning/pytorch/loggers/tensorboard.py
@@ -107,6 +107,7 @@ class TensorBoardLogger(Logger, FabricTensorBoardLogger):
         default_hp_metric: bool = True,
         prefix: str = "",
         sub_dir: Optional[_PATH] = None,
+        save_hp_params=True,
         **kwargs: Any,
     ):
         super().__init__(
@@ -125,6 +126,7 @@ class TensorBoardLogger(Logger, FabricTensorBoardLogger):
             )
         self._log_graph = log_graph and _TENSORBOARD_AVAILABLE
         self.hparams: Union[Dict[str, Any], Namespace] = {}
+        self.save_hp_params = save_hp_params
 
     @property
     def root_dir(self) -> str:
@@ -215,7 +217,7 @@ class TensorBoardLogger(Logger, FabricTensorBoardLogger):
         hparams_file = os.path.join(dir_path, self.NAME_HPARAMS_FILE)
 
         # save the metatags file if it doesn't exist and the log directory exists
-        if self._fs.isdir(dir_path) and not self._fs.isfile(hparams_file):
+        if self._fs.isdir(dir_path) and not self._fs.isfile(hparams_file) and self.save_hp_params:
             save_hparams_to_yaml(hparams_file, self.hparams)
 
     @rank_zero_only

--- a/src/lightning/pytorch/loggers/tensorboard.py
+++ b/src/lightning/pytorch/loggers/tensorboard.py
@@ -81,6 +81,8 @@ class TensorBoardLogger(Logger, FabricTensorBoardLogger):
         sub_dir: Sub-directory to group TensorBoard logs. If a sub_dir argument is passed
             then logs are saved in ``/save_dir/name/version/sub_dir/``. Defaults to ``None`` in which
             logs are saved in ``/save_dir/name/version/``.
+        save_hp_params： enable to save the hyperparams to tensorboard. if your saving hyperparams 
+            to tensorboard is failed, please turn it off.
         \**kwargs: Additional arguments used by :class:`tensorboardX.SummaryWriter` can be passed as keyword
             arguments in this logger. To automatically flush to disk, `max_queue` sets the size
             of the queue for pending logs before flushing. `flush_secs` determines how many seconds


### PR DESCRIPTION
actually if i use obj pass to LightningModule to build own module, the save function of tensorboard logger will failed. So add a option to turn it off.