### PR TITLE
Custom DeepSpeed config   format error with offload_optimizer

### DIFF
--- a/docs/source-pytorch/advanced/model_parallel.rst
+++ b/docs/source-pytorch/advanced/model_parallel.rst
@@ -658,7 +658,7 @@ In some cases you may want to define your own DeepSpeed Config, to access all pa
         },
         "zero_optimization": {
             "stage": 2,  # Enable Stage 2 ZeRO (Optimizer/Gradient state partitioning)
-            "offload_optimizer": True,  # Enable Offloading optimizer state/calculation to the host CPU
+            "offload_optimizer": {"device": "cpu"},  # Enable Offloading optimizer state/calculation to the host CPU
             "contiguous_gradients": True,  # Reduce gradient fragmentation.
             "overlap_comm": True,  # Overlap reduce/backward operation of gradients for speed.
             "allgather_bucket_size": 2e8,  # Number of elements to all gather at once.


### PR DESCRIPTION
Bug description
Currently custom DeepSpeed offload_optimizer config not match the official website.

```json
{
    "zero_optimization": {
        "stage": 2,
        "offload_optimizer": {
            "device": "cpu",
        }
        "contiguous_gradients": true,
        "overlap_comm": true
    }
}
```

https://github.com/microsoft/DeepSpeed/blob/df425097869214c3371d74a4cbd7c506bea3cef7/docs/_tutorials/zero-offload.md?plain=1#L47

How to reproduce the bug
config "offload_optimizer": True, 

Error messages and logs
File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for DeepSpeedZeroConfig
offload_optimizer
  value is not a valid dict (type=type_error.dict)