### PR TITLE
Add loggers to __all__ in lightning/pytorch/__init__.py to fix "cannot find reference" error

### DIFF
--- a/src/lightning/pytorch/__init__.py
+++ b/src/lightning/pytorch/__init__.py
@@ -6,7 +6,7 @@ import os
 from lightning_utilities import module_available
 
 if os.path.isfile(os.path.join(os.path.dirname(__file__), "__about__.py")):
-    from lightning.pytorch.__about__ import *  # noqa: F401, F403
+    from lightning.pytorch.__about__ import *  # noqa: F403
 if "__version__" not in locals():
     if os.path.isfile(os.path.join(os.path.dirname(__file__), "__version__.py")):
         from lightning.pytorch.__version__ import version as __version__

--- a/src/lightning/pytorch/__init__.py
+++ b/src/lightning/pytorch/__init__.py
@@ -30,7 +30,7 @@ from lightning.pytorch.trainer import Trainer  # noqa: E402
 # this import needs to go last as it will patch other modules
 import lightning.pytorch._graveyard  # noqa: E402, F401  # isort: skip
 
-__all__ = ["Trainer", "LightningDataModule", "LightningModule", "Callback", "seed_everything"]
+__all__ = ["Trainer", "LightningDataModule", "LightningModule", "Callback", "seed_everything", "loggers"]
 
 # for compatibility with namespace packages
 __import__("pkg_resources").declare_namespace(__name__)


### PR DESCRIPTION
Add loggers to __all__ variable in lightning/pytorch/__init__.py. This addresses issue [#17663](https://github.com/Lightning-AI/lightning/issues/17663), which complains of a "cannot find reference" error.