### PR TITLE
slightly changing the behavior of val_loop specifying the limit_val_batches or reaching should_stop

### DIFF
--- a/examples/fabric/build_your_own_trainer/trainer.py
+++ b/examples/fabric/build_your_own_trainer/trainer.py
@@ -293,8 +293,7 @@ class MyCustomTrainer:
         for batch_idx, batch in enumerate(iterable):
             # end epoch if stopping training completely or max batches for this epoch reached
             if self.should_stop or batch_idx >= limit_batches:
-                self.fabric.call("on_validation_epoch_end")
-                return
+                break
 
             self.fabric.call("on_validation_batch_start", batch, batch_idx)
 


### PR DESCRIPTION
## What does this PR do?

This PR changes the code that is run in the val_loop of the base.py trainer, the changes are very minor but i think they result in more consistent and sane code.

couple of things: the old code called the self.fabric.call("on_validation_epoch_end") callback and then returned from the function. This kind of returning is unsafe and causes crashes because when you return from there you miss a couple of potentially important lines of code such as re enabling gradients when exiting the validation loop which is VERY IMPORTANT. The second line's importance depends on your code.

lines not being called with return behavior:
torch.set_grad_enabled(True)
self.fabric.call("on_validation_model_train")


My PR makes it so that when you reach either the should_stop or limit_batches condition you just break the for loop and call the 2 lines of code that are below the for loop and training can continue normally.


If you are confused i suggest you check the code differences, reread the val_loop and feel free to discuss this PR, it is my opinion that breaking the loop instead of calling a callback+return is more robust and readable code

Future work: maybe apply the same line of reason to the train_loop function as well, but i think a discussion on how to tackle this should come first.

This is my first PR on this repo, im unsure whether i have followed the procedure accordingly.

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun? yes :)

Make sure you had fun coding 🙃

-->
