### PR TITLE
Bump minimum wandb version to 0.12.0

### DIFF
--- a/requirements/pytorch/loggers.info
+++ b/requirements/pytorch/loggers.info
@@ -2,5 +2,5 @@
 neptune
 comet-ml
 mlflow >=1.0.0
-wandb
+wandb >=0.12.0
 tensorboard >=2.9.1

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -91,6 +91,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Support kwargs input for LayerSummary ([#17709](https://github.com/Lightning-AI/lightning/pull/17709))
 
 
+- Dropped support for `wandb` versions older than 0.12.0 in `WandbLogger` ([#17876](https://github.com/Lightning-AI/lightning/pull/17876))
+
+
 ### Deprecated
 
 - Deprecated the `SingleTPUStrategy` (`strategy="single_tpu"`) in favor of `SingleDeviceXLAStrategy` (`strategy="single_xla"`) ([#17383](https://github.com/Lightning-AI/lightning/pull/17383))

--- a/src/lightning/pytorch/loggers/wandb.py
+++ b/src/lightning/pytorch/loggers/wandb.py
@@ -41,7 +41,6 @@ except ModuleNotFoundError:
     wandb, Run, RunDisabled = None, None, None
 
 _WANDB_AVAILABLE = RequirementCache("wandb")
-_WANDB_GREATER_EQUAL_0_10_22 = RequirementCache("wandb>=0.10.22")
 _WANDB_GREATER_EQUAL_0_12_10 = RequirementCache("wandb>=0.12.10")
 
 
@@ -312,13 +311,6 @@ class WandbLogger(Logger):
                 f"Providing log_model={log_model} and offline={offline} is an invalid configuration"
                 " since model checkpoints cannot be uploaded in offline mode.\n"
                 "Hint: Set `offline=False` to log your model."
-            )
-
-        if log_model and not _WANDB_GREATER_EQUAL_0_10_22:
-            rank_zero_warn(
-                f"Providing log_model={log_model} requires wandb version >= 0.10.22"
-                " for logging associated model metadata.\n"
-                "Hint: Upgrade with `pip install --upgrade wandb`."
             )
 
         super().__init__()
@@ -595,8 +587,6 @@ class WandbLogger(Logger):
                         if hasattr(checkpoint_callback, k)
                     },
                 }
-                if _WANDB_GREATER_EQUAL_0_10_22
-                else None
             )
             if not self._checkpoint_name:
                 self._checkpoint_name = f"model-{self.experiment.id}"

--- a/tests/tests_pytorch/loggers/test_wandb.py
+++ b/tests/tests_pytorch/loggers/test_wandb.py
@@ -215,8 +215,6 @@ def test_wandb_logger_dirs_creation(wandb, monkeypatch, tmpdir):
 @mock.patch("lightning.pytorch.loggers.wandb.wandb")
 def test_wandb_log_model(wandb, monkeypatch, tmpdir):
     """Test that the logger creates the folders and files in the right place."""
-    monkeypatch.setattr(lightning.pytorch.loggers.wandb, "_WANDB_GREATER_EQUAL_0_10_22", True)
-
     wandb.run = None
     model = BoringModel()
 
@@ -378,8 +376,6 @@ def test_wandb_log_model(wandb, monkeypatch, tmpdir):
 def test_wandb_log_model_with_score(wandb, monkeypatch, tmpdir):
     """Test to prevent regression on #15543, ensuring the score is logged as a Python number, not a scalar
     tensor."""
-    monkeypatch.setattr(lightning.pytorch.loggers.wandb, "_WANDB_GREATER_EQUAL_0_10_22", True)
-
     wandb.run = None
     model = BoringModel()
 


### PR DESCRIPTION
## What does this PR do?

Fixes #17850

This PR bumps the minimum wandb version to 0.12.0 (released August 2021). Version 0.10 was released in 2020, I believe  there is not much value in supporting this old of a version. 


<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


cc @awaelchli @morganmcg1 @borisdayma @scottire @parambharat