### PR TITLE
[TPU][Fabric] `mark_step` after `optimizer.step`

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -68,6 +68,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support for loading optimizer states from a full-state checkpoint file ([#17747](https://github.com/Lightning-AI/lightning/pull/17747))
 
 
+- Automatically call `xla_model.mark_step()` after `optimizer.step()` with XLA ([#17883](https://github.com/Lightning-AI/lightning/pull/17883))
+
+
 ### Changed
 
 - Allow using iterable-style datasets with TPUs ([#17331](https://github.com/Lightning-AI/lightning/pull/17331))

--- a/src/lightning/fabric/plugins/precision/xla.py
+++ b/src/lightning/fabric/plugins/precision/xla.py
@@ -33,4 +33,5 @@ class XLAPrecision(Precision):
     ) -> Any:
         import torch_xla.core.xla_model as xm
 
-        return xm.optimizer_step(optimizer, optimizer_args=kwargs)
+        # you always want to `xm.mark_step()` after `optimizer.step` for better performance, so we set `wait=True`
+        return xm.optimizer_step(optimizer, optimizer_args=kwargs, barrier=True)

--- a/src/lightning/fabric/plugins/precision/xla.py
+++ b/src/lightning/fabric/plugins/precision/xla.py
@@ -33,5 +33,5 @@ class XLAPrecision(Precision):
     ) -> Any:
         import torch_xla.core.xla_model as xm
 
-        # you always want to `xm.mark_step()` after `optimizer.step` for better performance, so we set `wait=True`
+        # you always want to `xm.mark_step()` after `optimizer.step` for better performance, so we set `barrier=True`
         return xm.optimizer_step(optimizer, optimizer_args=kwargs, barrier=True)


### PR DESCRIPTION
## What does this PR do?

Removes the following boilerplate from Lit-Parrot:

```python
pretrain/openwebtext.py:149:            optimizer.step()
pretrain/openwebtext.py-150-            if fabric.device.type == "xla":
pretrain/openwebtext.py-151-                xm.mark_step()
--
pretrain/redpajama.py:184:            optimizer.step()
pretrain/redpajama.py-185-            if fabric.device.type == "xla":
pretrain/redpajama.py-186-                xm.mark_step()
--
finetune/adapter.py:168:            optimizer.step()
finetune/adapter.py-169-            if fabric.device.type == "xla":
finetune/adapter.py-170-                xm.mark_step()
--
finetune/lora.py:168:            optimizer.step()
finetune/lora.py-169-            if fabric.device.type == "xla":
finetune/lora.py-170-                xm.mark_step()
--
finetune/adapter_v2.py:174:            optimizer.step()
finetune/adapter_v2.py-175-            if fabric.device.type == "xla":
finetune/adapter_v2.py-176-                xm.mark_step()
```

Note that the Trainer already does this:

https://github.com/Lightning-AI/lightning/blob/59c7fadc8c9b50c47e1f4f5e9de4a4e9569508f8/src/lightning/pytorch/plugins/precision/xla.py#L51

cc @borda @carmocca @justusschock @awaelchli @JackCaoG @steventk-g @Liyang90