### PR TITLE
fix: error when restarting distributed training from checkpoint

### DIFF
--- a/src/lightning/pytorch/callbacks/early_stopping.py
+++ b/src/lightning/pytorch/callbacks/early_stopping.py
@@ -245,8 +245,9 @@ class EarlyStopping(Callback):
     def _improvement_message(self, current: Tensor) -> str:
         """Formats a log message that informs the user about an improvement in the monitored score."""
         if torch.isfinite(self.best_score):
+            best_score = self.best_score.to(current.device)
             msg = (
-                f"Metric {self.monitor} improved by {abs(self.best_score - current):.3f} >="
+                f"Metric {self.monitor} improved by {abs(best_score - current):.3f} >="
                 f" min_delta = {abs(self.min_delta)}. New best score: {current:.3f}"
             )
         else:


### PR DESCRIPTION
error when restarting distributed training from a checkpoint which uses early stopping

best_score is saved in the checkpoint on device 0 but is never moved to the LOCAL_RANK, so you hit an error here


