### PR TITLE
Fix: added map_location as an argument for the cls load_from_checkpoint

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -136,6 +136,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed incorrect parsing of arguments when augmenting exception messages in DDP ([#17948](https://github.com/Lightning-AI/lightning/pull/17948))
 
 
+- Added missing `map_location` argument for the `LightningDataModule.load_from_checkpoint` function ([#17950](https://github.com/Lightning-AI/lightning/pull/17950))
+
+
 ## [2.0.3] - 2023-06-07
 
 ### Changed

--- a/src/lightning/pytorch/core/datamodule.py
+++ b/src/lightning/pytorch/core/datamodule.py
@@ -217,7 +217,7 @@ class LightningDataModule(DataHooks, HyperparametersMixin):
         loaded = _load_from_checkpoint(
             cls,
             checkpoint_path,
-            map_location=map_location,
+            map_location=map_location,#input args from load_from_checkpoint
             hparams_file=hparams_file,
             strict=None,
             **kwargs,

--- a/src/lightning/pytorch/core/datamodule.py
+++ b/src/lightning/pytorch/core/datamodule.py
@@ -158,6 +158,7 @@ class LightningDataModule(DataHooks, HyperparametersMixin):
         cls,
         checkpoint_path: Union[_PATH, IO],
         hparams_file: Optional[_PATH] = None,
+        map_location=None,  # Add for #17945
         **kwargs: Any,
     ) -> Self:
         r"""
@@ -216,7 +217,7 @@ class LightningDataModule(DataHooks, HyperparametersMixin):
         loaded = _load_from_checkpoint(
             cls,
             checkpoint_path,
-            map_location=None,
+            map_location=map_location,# Add for #17945
             hparams_file=hparams_file,
             strict=None,
             **kwargs,

--- a/src/lightning/pytorch/core/datamodule.py
+++ b/src/lightning/pytorch/core/datamodule.py
@@ -158,7 +158,7 @@ class LightningDataModule(DataHooks, HyperparametersMixin):
         cls,
         checkpoint_path: Union[_PATH, IO],
         hparams_file: Optional[_PATH] = None,
-        map_location=None,  # Add for #17945
+        map_location: Optional[str] = None,
         **kwargs: Any,
     ) -> Self:
         r"""
@@ -217,7 +217,7 @@ class LightningDataModule(DataHooks, HyperparametersMixin):
         loaded = _load_from_checkpoint(
             cls,
             checkpoint_path,
-            map_location=map_location,# Add for #17945
+            map_location=map_location,
             hparams_file=hparams_file,
             strict=None,
             **kwargs,

--- a/src/lightning/pytorch/core/datamodule.py
+++ b/src/lightning/pytorch/core/datamodule.py
@@ -221,7 +221,7 @@ class LightningDataModule(DataHooks, HyperparametersMixin):
         loaded = _load_from_checkpoint(
             cls,
             checkpoint_path,
-            map_location=map_location,  # input args from load_from_checkpoint
+            map_location=map_location,
             hparams_file=hparams_file,
             strict=None,
             **kwargs,

--- a/src/lightning/pytorch/core/datamodule.py
+++ b/src/lightning/pytorch/core/datamodule.py
@@ -217,7 +217,7 @@ class LightningDataModule(DataHooks, HyperparametersMixin):
         loaded = _load_from_checkpoint(
             cls,
             checkpoint_path,
-            map_location=map_location,#input args from load_from_checkpoint
+            map_location=map_location,  # input args from load_from_checkpoint
             hparams_file=hparams_file,
             strict=None,
             **kwargs,

--- a/src/lightning/pytorch/core/datamodule.py
+++ b/src/lightning/pytorch/core/datamodule.py
@@ -20,7 +20,7 @@ from torch.utils.data import DataLoader, Dataset, IterableDataset
 from typing_extensions import Self
 
 import lightning.pytorch as pl
-from lightning.fabric.utilities.types import _PATH
+from lightning.fabric.utilities.types import _MAP_LOCATION_TYPE, _PATH
 from lightning.pytorch.core.hooks import DataHooks
 from lightning.pytorch.core.mixins import HyperparametersMixin
 from lightning.pytorch.core.saving import _load_from_checkpoint
@@ -157,8 +157,8 @@ class LightningDataModule(DataHooks, HyperparametersMixin):
     def load_from_checkpoint(
         cls,
         checkpoint_path: Union[_PATH, IO],
+        map_location: _MAP_LOCATION_TYPE = None,
         hparams_file: Optional[_PATH] = None,
-        map_location: Optional[str] = None,
         **kwargs: Any,
     ) -> Self:
         r"""
@@ -169,6 +169,10 @@ class LightningDataModule(DataHooks, HyperparametersMixin):
 
         Args:
             checkpoint_path: Path to checkpoint. This can also be a URL, or file-like object
+            map_location:
+                If your checkpoint saved a GPU model and you now load on CPUs
+                or a different number of GPUs, use this to map to the new setup.
+                The behaviour is the same as in :func:`torch.load`.
             hparams_file: Optional path to a ``.yaml`` or ``.csv`` file with hierarchical structure
                 as in this example::
 

--- a/src/lightning/pytorch/loggers/neptune.py
+++ b/src/lightning/pytorch/loggers/neptune.py
@@ -240,7 +240,7 @@ class NeptuneLogger(Logger):
         prefix: str = "training",
         **neptune_run_kwargs: Any,
     ):
-        if not _NEPTUNE_AVAILABLE:
+        if not _NEPTUNE_AVAILABLE and not _NEPTUNE_CLIENT_AVAILABLE:
             raise ModuleNotFoundError(str(_NEPTUNE_AVAILABLE))
         # verify if user passed proper init arguments
         self._verify_input_arguments(api_key, project, name, run, neptune_run_kwargs)

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -3,7 +3,7 @@ import torch
 
 import lightning.pytorch as pl
 from lightning.pytorch.callbacks import ModelCheckpoint
-from lightning.pytorch.demos.boring_classes import BoringModel
+from lightning.pytorch.demos.boring_classes import BoringModel, BoringDataModule
 from tests_pytorch.helpers.runif import RunIf
 
 
@@ -26,6 +26,7 @@ def create_boring_checkpoint(tmp_path, model, accelerator="cuda"):
 def test_load_from_checkpoint_map_location_cpu(tmp_path, map_location):
     create_boring_checkpoint(tmp_path, BoringModel(), accelerator="cpu")
     model = BoringModel.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", map_location=map_location)
+    _ = BoringDataModule.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", map_location=map_location)
     assert model.device.type == "cpu"
 
 
@@ -36,6 +37,7 @@ def test_load_from_checkpoint_map_location_cpu(tmp_path, map_location):
 def test_load_from_checkpoint_map_location_gpu(tmp_path, map_location):
     create_boring_checkpoint(tmp_path, BoringModel(), accelerator="cuda")
     model = BoringModel.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", map_location=map_location)
+    _ = BoringDataModule.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", map_location=map_location)
     assert model.device.type == "cuda"
 
 
@@ -44,6 +46,7 @@ def test_load_from_checkpoint_map_location_gpu(tmp_path, map_location):
 def test_load_from_checkpoint_map_location_gpu_to_cpu(tmp_path, map_location):
     create_boring_checkpoint(tmp_path, BoringModel(), accelerator="cpu")
     model = BoringModel.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", map_location=map_location)
+    _ = BoringDataModule.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", map_location=map_location)
     assert model.device.type == "cpu"
 
 
@@ -54,6 +57,7 @@ def test_load_from_checkpoint_map_location_gpu_to_cpu(tmp_path, map_location):
 def test_load_from_checkpoint_map_location_cpu_to_gpu(tmp_path, map_location):
     create_boring_checkpoint(tmp_path, BoringModel(), accelerator="cpu")
     model = BoringModel.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", map_location=map_location)
+    _ = BoringDataModule.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", map_location=map_location)
     assert model.device.type == "cuda"
 
 

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -3,7 +3,7 @@ import torch
 
 import lightning.pytorch as pl
 from lightning.pytorch.callbacks import ModelCheckpoint
-from lightning.pytorch.demos.boring_classes import BoringModel, BoringDataModule
+from lightning.pytorch.demos.boring_classes import BoringDataModule, BoringModel
 from tests_pytorch.helpers.runif import RunIf
 
 


### PR DESCRIPTION
## What does this PR do?

This PR addresses a bug in the PyTorch Lightning codebase where the `LightningDataModule.load_from_checkpoint` method was not correctly handling the `map_location` argument. This was causing issues when trying to load a DataModule from a checkpoint that was saved on a GPU-enabled machine, but being loaded on a CPU-only machine.

Fixes #17945
Fixes #17895

## Before submitting

- Was this **discussed/agreed** via a GitHub issue? Yes, this was discussed in issue #17945.
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

Did you have fun? Yes, I had fun coding 🙃
