### PR TITLE
docs: add example note for gradient accumulation in manual optimization mode

### DIFF
--- a/docs/source-pytorch/model/manual_optimization.rst
+++ b/docs/source-pytorch/model/manual_optimization.rst
@@ -86,8 +86,9 @@ after every ``N`` steps, you can do as such.
     def training_step(self, batch, batch_idx):
         opt = self.optimizers()
 
-        loss = self.compute_loss(batch)
-        self.manual_backward(loss)
+        # scale losses by 1/N (for N batches of gradient accumulation)
+        loss = self.compute_loss(batch) / N
+        self.manual_backward(loss) 
 
         # accumulate gradients of N batches
         if (batch_idx + 1) % N == 0:

--- a/docs/source-pytorch/model/manual_optimization.rst
+++ b/docs/source-pytorch/model/manual_optimization.rst
@@ -88,7 +88,7 @@ after every ``N`` steps, you can do as such.
 
         # scale losses by 1/N (for N batches of gradient accumulation)
         loss = self.compute_loss(batch) / N
-        self.manual_backward(loss) 
+        self.manual_backward(loss)
 
         # accumulate gradients of N batches
         if (batch_idx + 1) % N == 0:


### PR DESCRIPTION
Fix for issue #17957.

Added divide by N for losses in the gradient accumulation example of the manual optimization documentation for explicit clarity that it's up to the user to ensure losses are properly scaled.

