### PR TITLE
Checkpoints: Fix inherited wrapped hparams

### DIFF
--- a/src/lightning/pytorch/core/saving.py
+++ b/src/lightning/pytorch/core/saving.py
@@ -129,7 +129,7 @@ def _load_state(
 
         # 4. Update cls_kwargs_new with cls_kwargs_old, such that new has higher priority
         args_name = checkpoint.get(cls.CHECKPOINT_HYPER_PARAMS_NAME)
-        if args_name and args_name in cls_init_args_name:
+        if args_name and (args_name in cls_init_args_name or not cls_init_args_name):
             cls_kwargs_loaded = {args_name: cls_kwargs_loaded}
 
     _cls_kwargs = {}

--- a/src/lightning/pytorch/utilities/parsing.py
+++ b/src/lightning/pytorch/utilities/parsing.py
@@ -182,8 +182,7 @@ def save_hyperparameters(
         isx_non_str = [i for i, arg in enumerate(args) if not isinstance(arg, str)]
         if len(isx_non_str) == 1:
             hp = args[isx_non_str[0]]
-            cand_names = [k for k, v in init_args.items() if v == hp]
-            obj._hparams_name = cand_names[0] if cand_names else None
+            obj._hparams_name = list(init_args.keys())[isx_non_str[0]]
         else:
             hp = {arg: init_args[arg] for arg in args if isinstance(arg, str)}
             obj._hparams_name = "kwargs"


### PR DESCRIPTION
## What does this PR do?

Fixes #17889 

### Breaking changes:
None that I am aware of. However, this PR does change the `hparams_name` in checkpoints and slightly modifies checkpoint loading behaviour, both of which are subject of the bug fix. Code that relied on this faulty behaviour may break. All existing tests pass.

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
    - I submitted an issue, but it was left unread.
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)
    - I assume this is not necessary since this is a minor change.

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

I would like to specifically request a review on the following line of code for commit e913c8e642e4262ca19ac5b73d45b1c6ccf21d16:

```python3
# file: lightning/core/pytorch/utilities/parsing.py
if args_name and (args_name in cls_init_args_name or not cls_init_args_name):
```
since I added this change out of purely empirical reasons (in short, because it works :nerd_face:). `cls_init_args_name` is empty when a child class has a signature like `def __init__(self, *args, **kwargs):`, which is subject of the bug fix.

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
