### PR TITLE
Don't reapply activation checkpointing

### DIFF
--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -599,7 +599,17 @@ def _setup_activation_checkpointing(module: "FullyShardedDataParallel", layers: 
         apply_activation_checkpointing,
         checkpoint_wrapper,
         CheckpointImpl,
+        CheckpointWrapper,
     )
+
+    if any(isinstance(mod, CheckpointWrapper) for mod in module.modules()):
+        if layers:
+            rank_zero_warn(
+                f"FSDP checkpointing for the layers {layers} is configured, but the model already contains checkpointed"
+                " layers. Checkpointing will be ignored."
+            )
+        # the module is already wrapped with activation checkpointing, avoid wrapping again
+        return
 
     check_fn = lambda submodule: isinstance(submodule, tuple(layers))
     wrapper = functools.partial(


### PR DESCRIPTION
## What does this PR do?

If the user were manually applying activation checkpointing and configuring with FSDP, Fabric and the Trainer would apply it again. 

The added test fails in master.

Part of #18004