### PR TITLE
Add exponential backoff to HTTPQueue put

### DIFF
--- a/requirements/app/base.txt
+++ b/requirements/app/base.txt
@@ -13,6 +13,7 @@ inquirer >=2.10.0, <=3.1.3
 psutil <5.9.5
 click <=8.1.3
 python-multipart>=0.0.5, <=0.0.6
+backoff >=2.2.1, <2.3.0
 
 fastapi >=0.92.0, <0.100.0
 starlette  # https://fastapi.tiangolo.com/deployment/versions/#about-starlette

--- a/src/lightning/app/core/queues.py
+++ b/src/lightning/app/core/queues.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any, Optional, Tuple
 from urllib.parse import urljoin
 
+import backoff
 import requests
 from requests.exceptions import ConnectionError, ConnectTimeout, ReadTimeout
 
@@ -431,6 +432,7 @@ class HTTPQueue(BaseQueue):
             # we consider the queue is empty to avoid failing the app.
             raise queue.Empty
 
+    @backoff.on_exception(backoff.expo, (RuntimeError, requests.exceptions.HTTPError))
     def put(self, item: Any) -> None:
         if not self.app_id:
             raise ValueError(f"The Lightning App ID couldn't be extracted from the queue name: {self.name}")

--- a/tests/tests_app/core/test_queues.py
+++ b/tests/tests_app/core/test_queues.py
@@ -217,13 +217,21 @@ class TestHTTPQueue:
 
 def test_unreachable_queue(monkeypatch):
     monkeypatch.setattr(queues, "HTTP_QUEUE_TOKEN", "test-token")
+
     test_queue = QueuingSystem.HTTP.get_queue(queue_name="test_http_queue")
 
-    resp = mock.MagicMock()
-    resp.status_code = 204
+    resp1 = mock.MagicMock()
+    resp1.status_code = 204
+
+    resp2 = mock.MagicMock()
+    resp2.status_code = 201
 
     test_queue.client = mock.MagicMock()
-    test_queue.client.post.return_value = resp
+    test_queue.client.post = mock.Mock(side_effect=[resp1, resp1, resp2])
 
     with pytest.raises(queue.Empty):
         test_queue._get()
+
+    # Test backoff on queue.put
+    test_queue.put("foo")
+    assert test_queue.client.post.call_count == 3


### PR DESCRIPTION
## What does this PR do?

This PR adds exponential backoff to posts to the HTTP queue, for added resiliency on the works.

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


cc @borda