### PR TITLE
Raise Empty when request_queue is None

### DIFF
--- a/src/lightning/app/CHANGELOG.md
+++ b/src/lightning/app/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
--
+- Fixed handling a `None` request in the file orchestration queue ([#18111](https://github.com/Lightning-AI/lightning/pull/18111))
 
 
 ## [2.0.5] - 2023-07-07

--- a/src/lightning/app/storage/orchestrator.py
+++ b/src/lightning/app/storage/orchestrator.py
@@ -106,6 +106,9 @@ class StorageOrchestrator(Thread):
             request_queue = self.request_queues[work_name]
             try:
                 request: _PathRequest = request_queue.get(timeout=0)  # this should not block
+                # This should not happen under normal conditions, but it has occurred.
+                # For now we are tolerant with respect to requests being None in the queue
+                # and just move on.
                 if request is None:
                     raise Empty
             except Empty:

--- a/src/lightning/app/storage/orchestrator.py
+++ b/src/lightning/app/storage/orchestrator.py
@@ -106,6 +106,8 @@ class StorageOrchestrator(Thread):
             request_queue = self.request_queues[work_name]
             try:
                 request: _PathRequest = request_queue.get(timeout=0)  # this should not block
+                if request is None:
+                    raise Empty
             except Empty:
                 pass
             else:

--- a/tests/tests_app/storage/test_orchestrator.py
+++ b/tests/tests_app/storage/test_orchestrator.py
@@ -47,6 +47,13 @@ def test_orchestrator():
     orchestrator.run_once("work_a")
     orchestrator.run_once("work_b")
 
+    # edge case: `None` requests on the queue get ignored
+    # TODO: Investigate how `None` values end up in the queue
+    request_queues["work_a"].put(None)
+    orchestrator.run_once("work_a")
+    orchestrator.run_once("work_b")
+    assert not request_queues["work_a"]._queue
+
     # simulate copier A confirms that the file is available on the shared volume
     response = _GetResponse(source="work_a", path="/a/b/c.txt", hash="", destination="work_b", name="")
     copy_request_queues["work_a"].get()


### PR DESCRIPTION
## What does this PR do?

A user has reported an error:

```
ERROR: Traceback (most recent call last):
    File " /.../python3.10/site-packages/lightning/app/storage/orchestrator.py", line 93, in run
        self.run_once(work_name)
    File " /.../python3.10/site-packages/lightning/app/storage/orchestrator.py", line 112, in run_once
        request.destination = work name
AttributeError: 'NoneType' object has no attribute 'destination'
````

For now we avoid the error by handling a request being `None` to be equivalent to the queue being `Empty`.


<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


cc @borda