### PR TITLE
DeepSpeed precision simplifications

### DIFF
--- a/src/lightning/fabric/strategies/deepspeed.py
+++ b/src/lightning/fabric/strategies/deepspeed.py
@@ -875,7 +875,7 @@ def _format_precision_config(
     if precision == "16-mixed":
         if "fp16" not in ("16-mixed", "16-true"):
             # FP16 is a DeepSpeed standalone AMP implementation
-            rank_zero_info("Enabling DeepSpeed FP16.")
+            rank_zero_info("Enabling DeepSpeed FP16. Model parameters and inputs will be cast to `float16`.")
             config["fp16"] = {
                 "enabled": True,
                 "auto_cast": True,
@@ -886,5 +886,5 @@ def _format_precision_config(
                 "min_loss_scale": min_loss_scale,
             }
     elif "bf16" not in config and precision in ("bf16-mixed", "bf16-true"):
-        rank_zero_info("Enabling DeepSpeed BF16.")
+        rank_zero_info("Enabling DeepSpeed BF16. Model parameters and inputs will be cast to `bfloat16`.")
         config["bf16"] = {"enabled": True}

--- a/src/lightning/fabric/strategies/deepspeed.py
+++ b/src/lightning/fabric/strategies/deepspeed.py
@@ -353,6 +353,7 @@ class DeepSpeedStrategy(DDPStrategy, _Sharded):
     def module_sharded_context(self) -> Generator[None, None, None]:
         # Current limitation in Fabric: The config needs to be fully determined at the time of calling the context
         # manager. Later modifications through e.g. `Fabric.setup()` won't have an effect here.
+
         import deepspeed
 
         assert self._config_initialized

--- a/src/lightning/fabric/strategies/deepspeed.py
+++ b/src/lightning/fabric/strategies/deepspeed.py
@@ -651,7 +651,7 @@ class DeepSpeedStrategy(DDPStrategy, _Sharded):
                     "hysteresis": self.hysteresis,
                     "min_loss_scale": self.min_loss_scale,
                 }
-        elif "bf16" not in self.config and self.precision.precision == ("bf16-mixed", "bf16-true"):
+        elif "bf16" not in self.config and self.precision.precision in ("bf16-mixed", "bf16-true"):
             rank_zero_info("Enabling DeepSpeed BF16.")
             self.config["bf16"] = {"enabled": True}
 

--- a/src/lightning/fabric/strategies/deepspeed.py
+++ b/src/lightning/fabric/strategies/deepspeed.py
@@ -351,6 +351,8 @@ class DeepSpeedStrategy(DDPStrategy, _Sharded):
 
     @contextmanager
     def module_sharded_context(self) -> Generator[None, None, None]:
+        # Current limitation in Fabric: The config needs to be fully determined at the time of calling the context
+        # manager. Later modifications through e.g. `Fabric.setup()` won't have an effect here.
         import deepspeed
 
         assert self._config_initialized

--- a/src/lightning/fabric/strategies/deepspeed.py
+++ b/src/lightning/fabric/strategies/deepspeed.py
@@ -872,18 +872,17 @@ def _format_precision_config(
     initial_scale_power: int,
     hysteresis: int,
 ) -> None:
-    if precision == "16-mixed":
-        if "fp16" not in ("16-mixed", "16-true"):
-            # FP16 is a DeepSpeed standalone AMP implementation
-            rank_zero_info("Enabling DeepSpeed FP16. Model parameters and inputs will be cast to `float16`.")
-            config["fp16"] = {
-                "enabled": True,
-                "loss_scale": loss_scale,
-                "initial_scale_power": initial_scale_power,
-                "loss_scale_window": loss_scale_window,
-                "hysteresis": hysteresis,
-                "min_loss_scale": min_loss_scale,
-            }
+    if "fp16" not in config and precision in ("16-mixed", "16-true"):
+        # FP16 is a DeepSpeed standalone AMP implementation
+        rank_zero_info("Enabling DeepSpeed FP16. Model parameters and inputs will be cast to `float16`.")
+        config["fp16"] = {
+            "enabled": True,
+            "loss_scale": loss_scale,
+            "initial_scale_power": initial_scale_power,
+            "loss_scale_window": loss_scale_window,
+            "hysteresis": hysteresis,
+            "min_loss_scale": min_loss_scale,
+        }
     elif "bf16" not in config and precision in ("bf16-mixed", "bf16-true"):
         rank_zero_info("Enabling DeepSpeed BF16. Model parameters and inputs will be cast to `bfloat16`.")
         config["bf16"] = {"enabled": True}

--- a/src/lightning/fabric/strategies/deepspeed.py
+++ b/src/lightning/fabric/strategies/deepspeed.py
@@ -878,7 +878,6 @@ def _format_precision_config(
             rank_zero_info("Enabling DeepSpeed FP16. Model parameters and inputs will be cast to `float16`.")
             config["fp16"] = {
                 "enabled": True,
-                "auto_cast": True,
                 "loss_scale": loss_scale,
                 "initial_scale_power": initial_scale_power,
                 "loss_scale_window": loss_scale_window,

--- a/src/lightning/fabric/strategies/deepspeed.py
+++ b/src/lightning/fabric/strategies/deepspeed.py
@@ -354,25 +354,19 @@ class DeepSpeedStrategy(DDPStrategy, _Sharded):
         # Current limitation in Fabric: The config needs to be fully determined at the time of calling the context
         # manager, which happens at the start of `Fabric.run()`. Later modifications through e.g. `Fabric.setup()`
         # won't have an effect here.
-
         import deepspeed
 
         if self.zero_stage_3:
             assert self._config_initialized
-
-            # Note: For the mixed settings '16-mixed' and 'bf16-mixed', we shouldn't convert the weights to half
-            # precision, but we are keeping the 'bug' for backward compatibility.
-            # TODO: This can be properly implemented once https://github.com/Lightning-AI/lightning/issues/17581
-            #   gets resolved
-            if self.precision.precision in ("16-mixed", "16-true"):
-                dtype = torch.float16
-            elif self.precision.precision in ("bf16-mixed", "bf16-true"):
-                dtype = torch.bfloat16
-            else:
-                dtype = torch.float32
+            # if self.precision.precision == "16-true":
+            #     dtype = torch.float16
+            # elif self.precision.precision == "bf16-true":
+            #     dtype = torch.bfloat16
+            # else:
+            #     dtype = torch.float32
 
             with deepspeed.zero.Init(
-                remote_device=self.remote_device, pin_memory=True, config_dict_or_path=self.config, dtype=dtype
+                remote_device=self.remote_device, pin_memory=True, config_dict_or_path=self.config
             ):
                 yield
         else:

--- a/tests/tests_fabric/strategies/test_deepspeed_integration.py
+++ b/tests/tests_fabric/strategies/test_deepspeed_integration.py
@@ -390,9 +390,7 @@ def test_deepspeed_init_module_with_stage_3(empty_init):
 
     with mock.patch("deepspeed.zero.Init") as zero_init_mock, fabric.init_module(empty_init=empty_init):
         BoringModel()
-    zero_init_mock.assert_called_once_with(
-        remote_device="cpu", pin_memory=True, config_dict_or_path=ANY, dtype=torch.bfloat16
-    )
+    zero_init_mock.assert_called_once_with(enabled=True, remote_device=None, config_dict_or_path=ANY)
 
 
 @RunIf(min_cuda_gpus=2, standalone=True, deepspeed=True, bf16_cuda=True)

--- a/tests/tests_fabric/strategies/test_deepspeed_integration.py
+++ b/tests/tests_fabric/strategies/test_deepspeed_integration.py
@@ -407,6 +407,6 @@ def test_deepspeed_init_module_with_stages_1_2(stage, empty_init):
     ) as init_mock, fabric.init_module(empty_init=empty_init):
         model = BoringModel()
 
-    zero_init_mock.assert_not_called()
+    zero_init_mock.assert_called_with(enabled=False, remote_device=None, config_dict_or_path=ANY)
     assert init_mock.call_count == int(not empty_init)
     assert model.layer.weight.dtype == torch.bfloat16

--- a/tests/tests_pytorch/strategies/test_deepspeed_strategy.py
+++ b/tests/tests_pytorch/strategies/test_deepspeed_strategy.py
@@ -1311,7 +1311,7 @@ def test_deepspeed_init_module_with_stages_1_2(stage):
     with mock.patch("deepspeed.zero.Init") as zero_init_mock:
         trainer.fit(model)
 
-    zero_init_mock.assert_not_called()
+    zero_init_mock.assert_called_once_with(enabled=False, remote_device=None, config_dict_or_path=ANY)
     assert model.layer.weight.dtype == torch.bfloat16
 
 


### PR DESCRIPTION
## What does this PR do?

Closes https://github.com/Lightning-AI/lightning/issues/18016
Closes #12591

1. DeepSpeed sets the parameters to float16/bfloat16 if running mixed precision, this can't be controlled. The dtype parameter set in `deepspeed.zero.Init(dtype=)` has no effect on the parameter dtype if mixed precision is enabled. 
2. This PR also sets the `remote_device` default to `None`, like it is in the default DeepSpeed setting.


cc @borda @justusschock @awaelchli @carmocca