### PR TITLE
Fix "optimizer in backward" compatibility with torch 2.1 nightly

### DIFF
--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -855,7 +855,7 @@ def _apply_optimizers_during_fsdp_backward(
     assert param_handles, f"Module {module} does not appear to contain any FSDP modules."
     fsdp_state = _get_module_fsdp_state(module)
     assert fsdp_state is not None
-    fsdp_stream = fsdp_state._streams["post_backward"]
+    fsdp_stream = fsdp_state._post_backward_stream if _TORCH_GREATER_EQUAL_2_1 else fsdp_state._streams["post_backward"]
 
     if isinstance(optimizers, Optimizer):
         optimizers = [optimizers]
@@ -879,7 +879,7 @@ def _apply_optimizers_during_fsdp_backward(
                 optimizer.step()
                 optimizer.zero_grad()
 
-                # Used to call `_clear_grads_if_needed`. Otherwise FSDP might hold on to the memory.
+                # Used to call `_reset_flat_param_grad_info_if_needed`. Otherwise FSDP might hold on to the memory.
                 post_step()
 
     try:
@@ -903,7 +903,8 @@ def _apply_optimizers_during_fsdp_backward(
                     assert prepare_gradient.__func__ is FlatParamHandle.prepare_gradient_for_optim
                     prepare_gradient()
                     h.prepare_gradient_for_optim = _no_op  # type: ignore[method-assign]
-                    maybe_step(flat_param._params or (), h._clear_grads_if_needed)
+                    post_step = h._reset_flat_param_grad_info_if_needed if _TORCH_GREATER_EQUAL_2_1 else h._clear_grads_if_needed
+                    maybe_step(flat_param._params or (), post_step=post_step)
 
             hook = partial(_opt_hook, h, flat_param)
             hook_handles.append(fsdp_acc_grad.register_hook(hook))

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -903,7 +903,11 @@ def _apply_optimizers_during_fsdp_backward(
                     assert prepare_gradient.__func__ is FlatParamHandle.prepare_gradient_for_optim
                     prepare_gradient()
                     h.prepare_gradient_for_optim = _no_op  # type: ignore[method-assign]
-                    post_step = h._reset_flat_param_grad_info_if_needed if _TORCH_GREATER_EQUAL_2_1 else h._clear_grads_if_needed
+                    post_step = (
+                        h._reset_flat_param_grad_info_if_needed
+                        if _TORCH_GREATER_EQUAL_2_1
+                        else h._clear_grads_if_needed
+                    )
                     maybe_step(flat_param._params or (), post_step=post_step)
 
             hook = partial(_opt_hook, h, flat_param)

--- a/tests/tests_fabric/strategies/test_fsdp.py
+++ b/tests/tests_fabric/strategies/test_fsdp.py
@@ -539,7 +539,10 @@ def test_apply_optimizer_in_backward(checkpoint):
                 # baseline case a bit.
                 param_handles = _get_fsdp_handles(baseline_model._forward_module)
                 for h in param_handles:
-                    h._clear_grads_if_needed()
+                    if _TORCH_GREATER_EQUAL_2_1:
+                        h._reset_flat_param_grad_info_if_needed()
+                    else:
+                        h._clear_grads_if_needed()
 
             baseline_peak_memory = torch.cuda.max_memory_allocated(fabric.device)
 


### PR DESCRIPTION
## What does this PR do?

Fixes #18118

We already have a test, but it is currently disabled. Remaining test fixes will be done in #17959. This feature is unreleased and undocumented (only in a blogpost). Official documentation will be added in #18109.

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


cc @borda @carmocca @justusschock @awaelchli