### PR TITLE
Allow accessing rank information before processes are launched in XLA

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -103,6 +103,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `Fabric.load_raw()` for loading raw PyTorch state dict checkpoints for model or optimizer objects ([#18049](https://github.com/Lightning-AI/lightning/pull/18049))
 
 
+- Allowed accessing rank information in the main process before processes are launched when using the `XLAStrategy` ([#18194](https://github.com/Lightning-AI/lightning/pull/18194))
+
+
 ### Changed
 
 - Allow using iterable-style datasets with TPUs ([#17331](https://github.com/Lightning-AI/lightning/pull/17331))

--- a/src/lightning/fabric/strategies/xla.py
+++ b/src/lightning/fabric/strategies/xla.py
@@ -82,6 +82,22 @@ class XLAStrategy(ParallelStrategy):
     def checkpoint_io(self, io: Optional[CheckpointIO]) -> None:
         self._checkpoint_io = io
 
+    @property
+    def global_rank(self) -> int:
+        return super().global_rank if self._launched else 0
+
+    @property
+    def local_rank(self) -> int:
+        return super().local_rank if self._launched else 0
+
+    @property
+    def node_rank(self) -> int:
+        return super().node_rank if self._launched else 0
+
+    @property
+    def world_size(self) -> int:
+        return super().world_size if self._launched else 1
+
     def _configure_launcher(self) -> None:
         self._launcher = _XLALauncher(self)
 

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -88,6 +88,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Improved error messages when attempting to load a DeepSpeed checkpoint at an invalid path ([#17795](https://github.com/Lightning-AI/lightning/pull/17795))
 
 
+- Allowed accessing rank information in the main process before processes are launched when using the `XLAStrategy` ([#18194](https://github.com/Lightning-AI/lightning/pull/18194))
+
+
 ### Changed
 
 - Removed the limitation to call `self.trainer.model.parameters()` in `LightningModule.configure_optimizers()` ([#17309](https://github.com/Lightning-AI/lightning/pull/17309))

--- a/src/lightning/pytorch/strategies/xla.py
+++ b/src/lightning/pytorch/strategies/xla.py
@@ -93,6 +93,22 @@ class XLAStrategy(DDPStrategy):
 
         return xm.xla_device()
 
+    @property
+    def global_rank(self) -> int:
+        return super().global_rank if self._launched else 0
+
+    @property
+    def local_rank(self) -> int:
+        return super().local_rank if self._launched else 0
+
+    @property
+    def node_rank(self) -> int:
+        return super().node_rank if self._launched else 0
+
+    @property
+    def world_size(self) -> int:
+        return super().world_size if self._launched else 1
+
     def _configure_launcher(self) -> None:
         self._launcher = _XLALauncher(self)
 

--- a/tests/tests_fabric/strategies/test_xla.py
+++ b/tests/tests_fabric/strategies/test_xla.py
@@ -181,3 +181,15 @@ def test_tpu_sync_module_states(sync_module_states):
     )
     partial_fn = partial(tpu_sync_module_states_fn, sync_module_states)
     xla_launch(partial_fn, strategy)
+
+
+@RunIf(tpu=True)
+@mock.patch.dict(os.environ, os.environ.copy(), clear=True)
+def test_rank_properties_in_main_process():
+    """Test that the strategy returns the default values for rank properties in the main process."""
+    strategy = XLAStrategy()
+    assert not strategy._launched
+    assert strategy.global_rank == 0
+    assert strategy.local_rank == 0
+    assert strategy.node_rank == 0
+    assert strategy.world_size == 1

--- a/tests/tests_pytorch/strategies/test_xla.py
+++ b/tests/tests_pytorch/strategies/test_xla.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import os
 from unittest import mock
+from unittest.mock import Mock
 
 import torch
 
@@ -48,13 +49,22 @@ def test_xla_strategy_debug_state():
     assert "PT_XLA_DEBUG" not in os.environ
 
 
-@RunIf(tpu=True)
 @mock.patch.dict(os.environ, os.environ.copy(), clear=True)
-def test_rank_properties_in_main_process():
-    """Test that the strategy returns the default values for rank properties in the main process."""
+def test_rank_properties_access(xla_available):
+    """Test that the strategy returns the expected values depending on whether we're in the main process or not."""
     strategy = XLAStrategy()
+    strategy.cluster_environment = Mock()
+
+    # we're in the main process, no processes have been launched yet
     assert not strategy._launched
     assert strategy.global_rank == 0
     assert strategy.local_rank == 0
     assert strategy.node_rank == 0
     assert strategy.world_size == 1
+
+    # simulate we're in a worker process
+    strategy._launched = True
+    assert strategy.global_rank == strategy.cluster_environment.global_rank()
+    assert strategy.local_rank == strategy.cluster_environment.local_rank()
+    assert strategy.node_rank == strategy.cluster_environment.node_rank()
+    assert strategy.world_size == strategy.cluster_environment.world_size()

--- a/tests/tests_pytorch/strategies/test_xla.py
+++ b/tests/tests_pytorch/strategies/test_xla.py
@@ -46,3 +46,15 @@ def test_xla_strategy_debug_state():
     assert isinstance(trainer.strategy, XLAStrategy)
     trainer.fit(model)
     assert "PT_XLA_DEBUG" not in os.environ
+
+
+@RunIf(tpu=True)
+@mock.patch.dict(os.environ, os.environ.copy(), clear=True)
+def test_rank_properties_in_main_process():
+    """Test that the strategy returns the default values for rank properties in the main process."""
+    strategy = XLAStrategy()
+    assert not strategy._launched
+    assert strategy.global_rank == 0
+    assert strategy.local_rank == 0
+    assert strategy.node_rank == 0
+    assert strategy.world_size == 1


### PR DESCRIPTION
## What does this PR do?

Fixes #18168

This prevents the strategy accessing the xla device too early when calling `.local_rank`, `.global_rank` etc. in the main process before processes are launched. 

See also my comment here about whether this should be addressed in XLA: https://github.com/Lightning-AI/lit-gpt/pull/317#issuecomment-1657358874


cc @borda @carmocca @JackCaoG @steventk-g @Liyang90 @justusschock @awaelchli