### PR TITLE
Replace `_FSDPPolicy` with public import

### DIFF
--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -78,9 +78,9 @@ if TYPE_CHECKING:
     from lightning.fabric.wrappers import _FabricModule
 
     if _TORCH_GREATER_EQUAL_2_0:
-        from torch.distributed.fsdp.wrap import _FSDPPolicy
+        from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 
-        _POLICY = Union[Set, Callable[[Module, bool, int], bool], _FSDPPolicy]
+        _POLICY = Union[Set, Callable[[Module, bool, int], bool], ModuleWrapPolicy]
     else:
         _POLICY = Union[Set, Callable[[Module, bool, int], bool]]  # type: ignore[misc]
 

--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -64,9 +64,9 @@ if TYPE_CHECKING:
     from torch.distributed.fsdp.fully_sharded_data_parallel import CPUOffload, MixedPrecision, ShardingStrategy
 
     if _TORCH_GREATER_EQUAL_2_0:
-        from torch.distributed.fsdp.wrap import _FSDPPolicy
+        from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 
-        _POLICY = Union[Set, Callable[[Module, bool, int], bool], _FSDPPolicy]
+        _POLICY = Union[Set, Callable[[Module, bool, int], bool], ModuleWrapPolicy]
     else:
         _POLICY = Union[Set, Callable[[Module, bool, int], bool]]  # type: ignore[misc]
 

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -335,7 +335,10 @@ def test_fsdp_strategy_full_state_dict(tmpdir, wrap_min_params):
         pytest.param(
             TestFSDPModelAutoWrapped(),
             FSDPStrategy,
-            {"auto_wrap_policy": ModuleWrapPolicy({nn.Linear}), "use_orig_params": True},
+            {
+                "auto_wrap_policy": ModuleWrapPolicy({nn.Linear}) if _TORCH_GREATER_EQUAL_2_1 else None,
+                "use_orig_params": True,
+            },
             marks=RunIf(min_torch="2.1.0"),
             id="autowrap_use_orig_params",
         ),

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -30,9 +30,9 @@ if _TORCH_GREATER_EQUAL_1_12:
 else:
     size_based_auto_wrap_policy = lambda *_, **__: False
 if _TORCH_GREATER_EQUAL_2_0:
-    from torch.distributed.fsdp.wrap import _FSDPPolicy
+    from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 else:
-    _FSDPPolicy = object
+    ModuleWrapPolicy = object
 
 
 class TestFSDPModel(BoringModel):
@@ -260,7 +260,7 @@ def test_fsdp_strategy_checkpoint(tmpdir, precision):
     _run_multiple_stages(trainer, model, os.path.join(tmpdir, "last.ckpt"))
 
 
-class CustomWrapPolicy(_FSDPPolicy):
+class CustomWrapPolicy(ModuleWrapPolicy):
     """This is a wrapper around :func:`_module_wrap_policy`."""
 
     def __init__(self, min_num_params: int):

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -260,19 +260,6 @@ def test_fsdp_strategy_checkpoint(tmpdir, precision):
     _run_multiple_stages(trainer, model, os.path.join(tmpdir, "last.ckpt"))
 
 
-class CustomWrapPolicy(ModuleWrapPolicy):
-    """This is a wrapper around :func:`_module_wrap_policy`."""
-
-    def __init__(self, min_num_params: int):
-        self._policy: Callable = partial(size_based_auto_wrap_policy, min_num_params=min_num_params)
-
-    @property
-    def policy(self):
-        return self._policy
-
-
-custom_fsdp_policy = CustomWrapPolicy(min_num_params=2)
-
 if _TORCH_GREATER_EQUAL_2_0:
 
     def custom_auto_wrap_policy(
@@ -348,7 +335,7 @@ def test_fsdp_strategy_full_state_dict(tmpdir, wrap_min_params):
         pytest.param(
             TestFSDPModelAutoWrapped(),
             FSDPStrategy,
-            {"auto_wrap_policy": custom_fsdp_policy, "use_orig_params": True},
+            {"auto_wrap_policy": ModuleWrapPolicy({nn.Linear}), "use_orig_params": True},
             marks=RunIf(min_torch="2.0.0"),
             id="autowrap_use_orig_params",
         ),

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -336,7 +336,7 @@ def test_fsdp_strategy_full_state_dict(tmpdir, wrap_min_params):
             TestFSDPModelAutoWrapped(),
             FSDPStrategy,
             {"auto_wrap_policy": ModuleWrapPolicy({nn.Linear}), "use_orig_params": True},
-            marks=RunIf(min_torch="2.0.0"),
+            marks=RunIf(min_torch="2.1.0"),
             id="autowrap_use_orig_params",
         ),
     ],

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -2,7 +2,7 @@ import os
 from contextlib import nullcontext
 from datetime import timedelta
 from functools import partial
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Dict, Optional
 from unittest import mock
 from unittest.mock import ANY, MagicMock, Mock
 


### PR DESCRIPTION
## What does this PR do?

The `_FSDPPolicy` was removed in torch nightly and replaced with `ModuleWrapPolicy`. This PR replaces the import.

This import error is currently blocking our CI:
https://dev.azure.com/Lightning-AI/lightning/_build/results?buildId=168433&view=logs&j=5b0799f7-725e-5b16-9b83-c0a5a25d03f0&t=447f4a64-1b89-5215-644b-382bd30b3565



cc @tchaton @carmocca @justusschock @awaelchli @borda