### PR TITLE
Change error to warning if state_dict is empty in `load_from_checkpoint`

### DIFF
--- a/src/lightning/pytorch/core/saving.py
+++ b/src/lightning/pytorch/core/saving.py
@@ -96,7 +96,8 @@ def _load_from_checkpoint(
         model = _load_state(cls, checkpoint, strict=strict, **kwargs)
         state_dict = checkpoint["state_dict"]
         if not state_dict:
-            raise ValueError(f"The state dict in {checkpoint_path!r} contains no parameters.")
+            rank_zero_warn(f"The state dict in {checkpoint_path!r} contains no parameters.")
+            return model
 
         device = next((t for t in state_dict.values() if isinstance(t, torch.Tensor)), torch.tensor(0)).device
         assert isinstance(model, pl.LightningModule)

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -1,6 +1,7 @@
+import warnings
+
 import pytest
 import torch
-import warnings
 
 import lightning.pytorch as pl
 from lightning.pytorch.callbacks import ModelCheckpoint
@@ -107,7 +108,7 @@ def test_load_from_checkpoint_device_placement_with_extra_state(tmp_path):
 
 
 def test_load_from_checkpoint_warn_on_empty_state_dict(tmp_path):
-    """Test that checkpoints can be loaded with an empty state dict and that the appropriate warning is raised"""
+    """Test that checkpoints can be loaded with an empty state dict and that the appropriate warning is raised."""
     create_boring_checkpoint(tmp_path, BoringModel(), accelerator="cpu")
     # Now edit so the state_dict is empty
     checkpoint = torch.load(f"{tmp_path}/checkpoint.ckpt")

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+import warnings
 
 import lightning.pytorch as pl
 from lightning.pytorch.callbacks import ModelCheckpoint
@@ -103,3 +104,17 @@ def test_load_from_checkpoint_device_placement_with_extra_state(tmp_path):
     create_boring_checkpoint(tmp_path, ExtraStateModel(), accelerator="cuda")
     model = ExtraStateModel.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", map_location=None)
     assert model.device.type == "cuda"
+
+
+def test_load_from_checkpoint_warn_on_empty_state_dict(tmp_path):
+    """Test that checkpoints can be loaded with an empty state dict and that the appropriate warning is raised"""
+    create_boring_checkpoint(tmp_path, BoringModel(), accelerator="cpu")
+    # Now edit so the state_dict is empty
+    checkpoint = torch.load(f"{tmp_path}/checkpoint.ckpt")
+    checkpoint["state_dict"] = {}
+    torch.save(checkpoint, f"{tmp_path}/checkpoint.ckpt")
+
+    with warnings.catch_warnings(record=True) as w:
+        model = BoringModel.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", strict=False)
+        assert "contains no parameters" in str(w[-1].message)
+        assert model.device.type == "cpu"

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -111,9 +111,9 @@ def test_load_from_checkpoint_warn_on_empty_state_dict(tmp_path):
     """Test that checkpoints can be loaded with an empty state dict and that the appropriate warning is raised."""
     create_boring_checkpoint(tmp_path, BoringModel(), accelerator="cpu")
     # Now edit so the state_dict is empty
-    checkpoint = torch.load(f"{tmp_path}/checkpoint.ckpt")
+    checkpoint = torch.load(tmp_path / "checkpoint.ckpt")
     checkpoint["state_dict"] = {}
-    torch.save(checkpoint, f"{tmp_path}/checkpoint.ckpt")
+    torch.save(checkpoint, tmp_path / "checkpoint.ckpt")
 
     with warnings.catch_warnings(record=True) as w:
         model = BoringModel.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", strict=False)

--- a/tests/tests_pytorch/core/test_saving.py
+++ b/tests/tests_pytorch/core/test_saving.py
@@ -1,5 +1,3 @@
-import warnings
-
 import pytest
 import torch
 
@@ -115,7 +113,6 @@ def test_load_from_checkpoint_warn_on_empty_state_dict(tmp_path):
     checkpoint["state_dict"] = {}
     torch.save(checkpoint, tmp_path / "checkpoint.ckpt")
 
-    with warnings.catch_warnings(record=True) as w:
-        model = BoringModel.load_from_checkpoint(f"{tmp_path}/checkpoint.ckpt", strict=False)
-        assert "contains no parameters" in str(w[-1].message)
-        assert model.device.type == "cpu"
+    with pytest.warns(UserWarning, match="contains no parameters"):
+        model = BoringModel.load_from_checkpoint(tmp_path / "checkpoint.ckpt", strict=False)
+    assert model.device.type == "cpu"


### PR DESCRIPTION
## What does this PR do?

`load_from_checkpoint` raises an error if the state_dict in the checkpoint is empty, change this to a warning and return the created model on cpu with the rest of the checkpoint parameters.

Add a test that models can be loaded from checkpoint with empty `state_dict`

Motivation: in #18240 a user has use of loading checkpoints with empty `state_dict` which was possible in previous versions of lightning

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fixes #18240

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
