### PR TITLE
[TPU] Preserve the device with XLA's collectives

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -135,6 +135,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - DataLoader re-instantiation is now only performed when a distributed sampler is required ([#18191](https://github.com/Lightning-AI/lightning/pull/18191))
 
 
+- Broadcast and reduction of tensors with XLA-based strategies now preserve the input's device ([#18275](https://github.com/Lightning-AI/lightning/pull/18275))
+
 ### Deprecated
 
 - Deprecated the `DDPStrategy.is_distributed` property. This strategy is distributed by definition ([#17381](https://github.com/Lightning-AI/lightning/pull/17381))

--- a/src/lightning/fabric/strategies/xla.py
+++ b/src/lightning/fabric/strategies/xla.py
@@ -237,10 +237,9 @@ class XLAStrategy(ParallelStrategy):
         obj = obj[0]
 
         if not is_tensor:
+            # this will preserve the dtype and device of any tensors
             buffer = io.BytesIO(obj.cpu().byte().numpy())
-            # when an arbitrary pickle-able is broadcast, load back to CPU since we cannot set custom map
-            # locations for each component in the buffer
-            obj = torch.load(buffer, map_location="cpu")
+            obj = torch.load(buffer)
         elif original_device.type != "xla":
             obj = obj.to(original_device)
 

--- a/src/lightning/fabric/strategies/xla.py
+++ b/src/lightning/fabric/strategies/xla.py
@@ -162,17 +162,13 @@ class XLAStrategy(ParallelStrategy):
         if tensor.dim() == 0:
             tensor = tensor.unsqueeze(0)
         original_device = tensor.device
-        if original_device.type != "xla":
-            tensor = tensor.to(self.root_device)
+        tensor = tensor.to(self.root_device)
 
         import torch_xla.core.functions as xf
         import torch_xla.core.xla_model as xm
 
         tensor = xf.all_gather(tensor) if sync_grads else xm.all_gather(tensor)
-
-        if original_device.type != "xla":
-            tensor = tensor.to(original_device)
-
+        tensor = tensor.to(original_device)
         return tensor
 
     def all_reduce(
@@ -218,9 +214,8 @@ class XLAStrategy(ParallelStrategy):
             if obj.dim() == 0:
                 obj = obj.unsqueeze(0)
             original_device = obj.device
-            if original_device.type != "xla":
-                # XLA distributed requires that the data is on the XLA device
-                obj = obj.to(self.root_device)
+            # XLA distributed requires that the data is on the XLA device
+            obj = obj.to(self.root_device)
         else:
             # support for arbitrary pickle-ables
             buffer = io.BytesIO()
@@ -237,7 +232,7 @@ class XLAStrategy(ParallelStrategy):
             # this will preserve the dtype and device of any tensors
             buffer = io.BytesIO(obj.cpu().byte().numpy())
             obj = torch.load(buffer)
-        elif original_device.type != "xla":
+        else:
             obj = obj.to(original_device)
 
         return obj

--- a/src/lightning/fabric/strategies/xla.py
+++ b/src/lightning/fabric/strategies/xla.py
@@ -220,9 +220,6 @@ class XLAStrategy(ParallelStrategy):
             original_device = obj.device
             if original_device.type != "xla":
                 # XLA distributed requires that the data is on the XLA device
-                # TODO: this might OOM if a CPU object is broadcast that wouldn't fit on XLA's memory. a workaround
-                # for that would be to use regular torch distributed for CPU objects with gloo. however, that would
-                # have other challenges such as having to initialize it and the lack of bfloat16 support for gloo
                 obj = obj.to(self.root_device)
         else:
             # support for arbitrary pickle-ables

--- a/src/lightning/fabric/strategies/xla.py
+++ b/src/lightning/fabric/strategies/xla.py
@@ -161,13 +161,19 @@ class XLAStrategy(ParallelStrategy):
             )
         if tensor.dim() == 0:
             tensor = tensor.unsqueeze(0)
-        if tensor.device.type != "xla":
+        original_device = tensor.device
+        if original_device.type != "xla":
             tensor = tensor.to(self.root_device)
 
         import torch_xla.core.functions as xf
         import torch_xla.core.xla_model as xm
 
-        return xf.all_gather(tensor) if sync_grads else xm.all_gather(tensor)
+        tensor = xf.all_gather(tensor) if sync_grads else xm.all_gather(tensor)
+
+        if original_device.type != "xla":
+            tensor = tensor.to(original_device)
+
+        return tensor
 
     def all_reduce(
         self, output: Union[Tensor, Any], group: Optional[Any] = None, reduce_op: Optional[Union[ReduceOp, str]] = None
@@ -211,7 +217,12 @@ class XLAStrategy(ParallelStrategy):
         if is_tensor:
             if obj.dim() == 0:
                 obj = obj.unsqueeze(0)
-            if obj.device.type != "xla":
+            original_device = obj.device
+            if original_device.type != "xla":
+                # XLA distributed requires that the data is on the XLA device
+                # TODO: this might OOM if a CPU object is broadcast that wouldn't fit on XLA's memory. a workaround
+                # for that would be to use regular torch distributed for CPU objects with gloo. however, that would
+                # have other challenges such as having to initialize it and the lack of bfloat16 support for gloo
                 obj = obj.to(self.root_device)
         else:
             # support for arbitrary pickle-ables
@@ -227,7 +238,11 @@ class XLAStrategy(ParallelStrategy):
 
         if not is_tensor:
             buffer = io.BytesIO(obj.cpu().byte().numpy())
-            obj = torch.load(buffer)
+            # when an arbitrary pickle-able is broadcast, load back to CPU since we cannot set custom map
+            # locations for each component in the buffer
+            obj = torch.load(buffer, map_location="cpu")
+        elif original_device.type != "xla":
+            obj = obj.to(original_device)
 
         return obj
 

--- a/src/lightning/fabric/strategies/xla_fsdp.py
+++ b/src/lightning/fabric/strategies/xla_fsdp.py
@@ -322,9 +322,6 @@ class XLAFSDPStrategy(ParallelStrategy):
             original_device = obj.device
             if original_device.type != "xla":
                 # XLA distributed requires that the data is on the XLA device
-                # TODO: this might OOM if a CPU object is broadcast that wouldn't fit on XLA's memory. a workaround
-                # for that would be to use regular torch distributed for CPU objects with gloo. however, that would
-                # have other challenges such as having to initialize it and the lack of bfloat16 support for gloo
                 obj = obj.to(self.root_device)
         else:
             # support for arbitrary pickle-ables

--- a/src/lightning/fabric/strategies/xla_fsdp.py
+++ b/src/lightning/fabric/strategies/xla_fsdp.py
@@ -339,10 +339,9 @@ class XLAFSDPStrategy(ParallelStrategy):
         obj = obj[0]
 
         if not is_tensor:
+            # this will preserve the dtype and device of any tensors
             buffer = io.BytesIO(obj.cpu().byte().numpy())
-            # when an arbitrary pickle-able is broadcast, load back to CPU since we cannot set custom map
-            # locations for each component in the buffer
-            obj = torch.load(buffer, map_location="cpu")
+            obj = torch.load(buffer)
         elif original_device.type != "xla":
             obj = obj.to(original_device)
 

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -141,6 +141,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - The input tensors now get cast to the right precision type before transfer to the device ([#18264](https://github.com/Lightning-AI/lightning/pull/18264))
 
 
+- Broadcast and reduction of tensors with XLA-based strategies now preserve the input's device ([#18275](https://github.com/Lightning-AI/lightning/pull/18275))
+
 ### Deprecated
 
 - Deprecated the `SingleTPUStrategy` (`strategy="single_tpu"`) in favor of `SingleDeviceXLAStrategy` (`strategy="single_xla"`) ([#17383](https://github.com/Lightning-AI/lightning/pull/17383))

--- a/src/lightning/pytorch/strategies/xla.py
+++ b/src/lightning/pytorch/strategies/xla.py
@@ -189,9 +189,6 @@ class XLAStrategy(DDPStrategy):
             original_device = obj.device
             if original_device.type != "xla":
                 # XLA distributed requires that the data is on the XLA device
-                # TODO: this might OOM if a CPU object is broadcast that wouldn't fit on XLA's memory. a workaround
-                # for that would be to use regular torch distributed for CPU objects with gloo. however, that would
-                # have other challenges such as having to initialize it and the lack of bfloat16 support for gloo
                 obj = obj.to(self.root_device)
         else:
             # support for arbitrary pickle-ables

--- a/src/lightning/pytorch/strategies/xla.py
+++ b/src/lightning/pytorch/strategies/xla.py
@@ -187,9 +187,8 @@ class XLAStrategy(DDPStrategy):
             if obj.dim() == 0:
                 obj = obj.unsqueeze(0)
             original_device = obj.device
-            if original_device.type != "xla":
-                # XLA distributed requires that the data is on the XLA device
-                obj = obj.to(self.root_device)
+            # XLA distributed requires that the data is on the XLA device
+            obj = obj.to(self.root_device)
         else:
             # support for arbitrary pickle-ables
             buffer = io.BytesIO()
@@ -206,7 +205,7 @@ class XLAStrategy(DDPStrategy):
             # this will preserve the dtype and device of any tensors
             buffer = io.BytesIO(obj.cpu().byte().numpy())
             obj = torch.load(buffer)
-        elif original_device.type != "xla":
+        else:
             obj = obj.to(original_device)
 
         return obj
@@ -296,17 +295,13 @@ class XLAStrategy(DDPStrategy):
         if tensor.dim() == 0:
             tensor = tensor.unsqueeze(0)
         original_device = tensor.device
-        if original_device.type != "xla":
-            tensor = tensor.to(self.root_device)
+        tensor = tensor.to(self.root_device)
 
         import torch_xla.core.functions as xf
         import torch_xla.core.xla_model as xm
 
         tensor = xf.all_gather(tensor) if sync_grads else xm.all_gather(tensor)
-
-        if original_device.type != "xla":
-            tensor = tensor.to(original_device)
-
+        tensor = tensor.to(original_device)
         return tensor
 
     def teardown(self) -> None:

--- a/src/lightning/pytorch/strategies/xla.py
+++ b/src/lightning/pytorch/strategies/xla.py
@@ -186,7 +186,12 @@ class XLAStrategy(DDPStrategy):
         if is_tensor:
             if obj.dim() == 0:
                 obj = obj.unsqueeze(0)
-            if obj.device.type != "xla":
+            original_device = obj.device
+            if original_device.type != "xla":
+                # XLA distributed requires that the data is on the XLA device
+                # TODO: this might OOM if a CPU object is broadcast that wouldn't fit on XLA's memory. a workaround
+                # for that would be to use regular torch distributed for CPU objects with gloo. however, that would
+                # have other challenges such as having to initialize it and the lack of bfloat16 support for gloo
                 obj = obj.to(self.root_device)
         else:
             # support for arbitrary pickle-ables
@@ -202,7 +207,11 @@ class XLAStrategy(DDPStrategy):
 
         if not is_tensor:
             buffer = io.BytesIO(obj.cpu().byte().numpy())
-            obj = torch.load(buffer)
+            # when an arbitrary pickle-able is broadcast, load back to CPU since we cannot set custom map
+            # locations for each component in the buffer
+            obj = torch.load(buffer, map_location="cpu")
+        elif original_device.type != "xla":
+            obj = obj.to(original_device)
 
         return obj
 
@@ -290,13 +299,19 @@ class XLAStrategy(DDPStrategy):
             )
         if tensor.dim() == 0:
             tensor = tensor.unsqueeze(0)
-        if tensor.device.type != "xla":
+        original_device = tensor.device
+        if original_device.type != "xla":
             tensor = tensor.to(self.root_device)
 
         import torch_xla.core.functions as xf
         import torch_xla.core.xla_model as xm
 
-        return xf.all_gather(tensor) if sync_grads else xm.all_gather(tensor)
+        tensor = xf.all_gather(tensor) if sync_grads else xm.all_gather(tensor)
+
+        if original_device.type != "xla":
+            tensor = tensor.to(original_device)
+
+        return tensor
 
     def teardown(self) -> None:
         super().teardown()

--- a/src/lightning/pytorch/strategies/xla.py
+++ b/src/lightning/pytorch/strategies/xla.py
@@ -206,10 +206,9 @@ class XLAStrategy(DDPStrategy):
         obj = obj[0]
 
         if not is_tensor:
+            # this will preserve the dtype and device of any tensors
             buffer = io.BytesIO(obj.cpu().byte().numpy())
-            # when an arbitrary pickle-able is broadcast, load back to CPU since we cannot set custom map
-            # locations for each component in the buffer
-            obj = torch.load(buffer, map_location="cpu")
+            obj = torch.load(buffer)
         elif original_device.type != "xla":
             obj = obj.to(original_device)
 

--- a/tests/tests_fabric/strategies/test_xla.py
+++ b/tests/tests_fabric/strategies/test_xla.py
@@ -67,7 +67,7 @@ def broadcast_on_tpu_fn(strategy):
     obj = ("ver_0.5", "logger_name", strategy.global_rank, tensor)
     result = strategy.broadcast(obj, src=src)
     assert result == ("ver_0.5", "logger_name", src, ANY)
-    assert result[3].device.type == "cpu"  # the original device is not preserved with objects
+    assert result[3].device.type == "xla"  # the original device is preserved
     assert result[3].dtype == torch.bfloat16
 
 
@@ -138,7 +138,7 @@ def tpu_all_gather_fn(strategy):
         tensor = torch.tensor(1.0, requires_grad=True)
         result = strategy.all_gather(tensor, sync_grads=sync_grads)
         summed = result.sum()
-        assert summed.device.type == "xla"
+        assert summed.device.type == "cpu"  # the original device is preserved
         assert torch.equal(summed, torch.tensor(strategy.world_size, dtype=torch.float32))
         if not _XLA_GREATER_EQUAL_2_1:
             summed.backward()


### PR DESCRIPTION
## What does this PR do?

XLA distributed requires that tensors are on XLA device before calling a collective. The tensor is moved to conform to this requirement but wasn't moved back to the original device.

cc @borda @justusschock @carmocca @awaelchli @JackCaoG @steventk-g @Liyang90