### PR TITLE
Refresh the internal LightningOptimizer state for inspection

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -97,6 +97,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added automatic process cleanup to avoid zombie child processes and stalls when exceptions are raised ([#18218](https://github.com/Lightning-AI/lightning/pull/18218))
 
 
+- Added `LightningOptimizer.refresh()` to update the `__dict__` in case the optimizer it wraps has changed its internal state ([#18280](https://github.com/Lightning-AI/lightning/pull/18280))
+
+
 ### Changed
 
 - Removed the limitation to call `self.trainer.model.parameters()` in `LightningModule.configure_optimizers()` ([#17309](https://github.com/Lightning-AI/lightning/pull/17309))
@@ -201,6 +204,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
 - Ensure that the closure running inside the optimizer step has gradients enabled, even if the optimizer step has it disabled ([#18268](https://github.com/Lightning-AI/lightning/pull/18268))
+
+
+- Fixed an issue that could cause the `LightningOptimizer` wrapper returend by `LightningModule.optimizers()` have different internal state than the optimizer it wraps ([#18280](https://github.com/Lightning-AI/lightning/pull/18280))
+
 
 
 ## [2.0.5] - 2023-07-07

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -206,7 +206,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Ensure that the closure running inside the optimizer step has gradients enabled, even if the optimizer step has it disabled ([#18268](https://github.com/Lightning-AI/lightning/pull/18268))
 
 
-- Fixed an issue that could cause the `LightningOptimizer` wrapper returend by `LightningModule.optimizers()` have different internal state than the optimizer it wraps ([#18280](https://github.com/Lightning-AI/lightning/pull/18280))
+- Fixed an issue that could cause the `LightningOptimizer` wrapper returned by `LightningModule.optimizers()` have different internal state than the optimizer it wraps ([#18280](https://github.com/Lightning-AI/lightning/pull/18280))
 
 
 

--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -158,6 +158,10 @@ class LightningModule(
             opts: MODULE_OPTIMIZERS = self._fabric_optimizers
         elif use_pl_optimizer:
             opts = self.trainer.strategy._lightning_optimizers
+            for opt in opts:
+                # Make sure the internal states are in sync before using the optimizer, in case the user modified
+                # the state of the original optimizer
+                opt.refresh()
         else:
             opts = self.trainer.optimizers
 

--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -159,8 +159,6 @@ class LightningModule(
         elif use_pl_optimizer:
             opts = self.trainer.strategy._lightning_optimizers
             for opt in opts:
-                # Make sure the internal states are in sync before using the optimizer, in case the user modified
-                # the state of the original optimizer
                 opt.refresh()
         else:
             opts = self.trainer.optimizers

--- a/src/lightning/pytorch/core/optimizer.py
+++ b/src/lightning/pytorch/core/optimizer.py
@@ -35,12 +35,14 @@ def do_nothing_closure() -> None:
 
 class LightningOptimizer:
     """This class is used to wrap the user optimizers and handle properly the backward and optimizer_step logic across
-    accelerators, AMP, accumulate_grad_batches."""
+    accelerators, AMP, accumulate_grad_batches.
+
+    Note: The purpose of this wrapper is only to define new methods and redirect the `.step()` call. The internal
+    state ``__dict__`` is not kept in sync with the internal state of the original optimizer, but the Trainer never
+    relies on the internal state of the wrapper.
+    """
 
     def __init__(self, optimizer: Optimizer):
-        # copy most of the `Optimizer` methods into this instance. `__del__` is skipped in case the optimizer has
-        # implemented custom logic which we would not want to call on destruction of the `LightningOptimizer`
-        self.__dict__ = {k: v for k, v in optimizer.__dict__.items() if k not in ("step", "__del__")}
         self.__class__ = type("Lightning" + optimizer.__class__.__name__, (self.__class__, optimizer.__class__), {})
 
         self._optimizer = optimizer
@@ -49,19 +51,11 @@ class LightningOptimizer:
         self._on_before_step = do_nothing_closure
         self._on_after_step = do_nothing_closure
 
+        self.refresh()
+
     @property
     def optimizer(self) -> Optimizer:
         return self._optimizer
-
-    @classmethod
-    def _to_lightning_optimizer(
-        cls, optimizer: Union[Optimizer, "LightningOptimizer"], strategy: "pl.strategies.Strategy"
-    ) -> "LightningOptimizer":
-        # the user could return a `LightningOptimizer` from `configure_optimizers`, see test:
-        # tests/core/test_lightning_optimizer.py::test_lightning_optimizer[False]
-        lightning_optimizer = optimizer if isinstance(optimizer, LightningOptimizer) else cls(optimizer)
-        lightning_optimizer._strategy = proxy(strategy)
-        return lightning_optimizer
 
     @contextmanager
     def toggle_model(self, sync_grad: bool = True) -> Generator[None, None, None]:
@@ -85,6 +79,11 @@ class LightningOptimizer:
             lightning_module.toggle_optimizer(self)
             yield
             lightning_module.untoggle_optimizer(self)
+
+    def refresh(self) -> None:
+        # copy most of the `Optimizer` methods into this instance. `__del__` is skipped in case the optimizer has
+        # implemented custom logic which we would not want to call on destruction of the `LightningOptimizer`
+        self.__dict__.update({k: v for k, v in self.optimizer.__dict__.items() if k not in ("step", "__del__")})
 
     def step(self, closure: Optional[Callable[[], Any]] = None, **kwargs: Any) -> Any:
         """Performs a single optimization step (parameter update).
@@ -160,6 +159,16 @@ class LightningOptimizer:
         self._on_after_step()
 
         return step_output
+
+    @classmethod
+    def _to_lightning_optimizer(
+        cls, optimizer: Union[Optimizer, "LightningOptimizer"], strategy: "pl.strategies.Strategy"
+    ) -> "LightningOptimizer":
+        # the user could return a `LightningOptimizer` from `configure_optimizers`, see test:
+        # tests/core/test_lightning_optimizer.py::test_lightning_optimizer[False]
+        lightning_optimizer = optimizer if isinstance(optimizer, LightningOptimizer) else cls(optimizer)
+        lightning_optimizer._strategy = proxy(strategy)
+        return lightning_optimizer
 
 
 def _init_optimizers_and_lr_schedulers(

--- a/src/lightning/pytorch/core/optimizer.py
+++ b/src/lightning/pytorch/core/optimizer.py
@@ -81,6 +81,10 @@ class LightningOptimizer:
             lightning_module.untoggle_optimizer(self)
 
     def refresh(self) -> None:
+        """Refreshes the ``__dict__`` so that it matches the internal states in the wrapped optimizer.
+
+        This is only needed to present the user with an updated view in case they inspect the state of this wrapper.
+        """
         # copy most of the `Optimizer` methods into this instance. `__del__` is skipped in case the optimizer has
         # implemented custom logic which we would not want to call on destruction of the `LightningOptimizer`
         self.__dict__.update({k: v for k, v in self.optimizer.__dict__.items() if k not in ("step", "__del__")})

--- a/tests/tests_pytorch/core/test_lightning_optimizer.py
+++ b/tests/tests_pytorch/core/test_lightning_optimizer.py
@@ -323,7 +323,15 @@ def test_lightning_optimizer_keeps_hooks():
 
 def test_params_groups_and_state_are_accessible(tmpdir):
     class TestModel(BoringModel):
+        def on_train_start(self):
+            # Update the learning rate manually on the unwrapped optimizer
+            assert not isinstance(self.trainer.optimizers[0], LightningOptimizer)
+            self.trainer.optimizers[0].param_groups[0]['lr'] = 2.0
+
         def training_step(self, batch, batch_idx):
+            opt = self.optimizers()
+            assert opt.param_groups[0]['lr'] == 2.0
+
             loss = self.step(batch)
             self.__loss = loss
             return loss

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -509,16 +509,17 @@ def test_set_timeout(init_process_group_mock):
 @RunIf(min_torch="1.12")
 def test_fsdp_strategy_load_optimizer_states_multiple():
     strategy = FSDPStrategy(parallel_devices=[torch.device("cpu")])
+    spec = torch.optim.Optimizer
 
     # More states than optimizers configured
-    strategy.optimizers = [Mock()]
-    checkpoint = {"optimizer_states": [Mock(), Mock()]}
+    strategy.optimizers = [Mock(spec=spec)]
+    checkpoint = {"optimizer_states": [Mock(spec=spec), Mock(spec=spec)]}
     with pytest.raises(RuntimeError, match="1 optimizers but the checkpoint contains 2 optimizers to load"):
         strategy.load_optimizer_state_dict(checkpoint)
 
     # Fewer states than optimizers configured
-    strategy.optimizers = [Mock(), Mock()]
-    checkpoint = {"optimizer_states": [Mock()]}
+    strategy.optimizers = [Mock(spec=spec), Mock(spec=spec)]
+    checkpoint = {"optimizer_states": [Mock(spec=spec)]}
     with pytest.raises(RuntimeError, match="2 optimizers but the checkpoint contains 1 optimizers to load"):
         strategy.load_optimizer_state_dict(checkpoint)
 


### PR DESCRIPTION
## What does this PR do?

Fixes #18279

Our internal wrapper `LightningOptimizer` can't guarantee to keep 100% in sync with internal variables of the optimizer it wraps. This is not an issue for optimization, because the wrapper is only used to redirect the `step()` call, and optimization always uses the real optimizer. This PR ensures the internal state is updated in case the user accesses the LightningOptimizer through `self.optimizers()` in the LightningModule and inspects its state.



cc @borda