### PR TITLE
[TPU] Add `sequential_save` to save FSDP checkpoint shards sequentially

### DIFF
--- a/src/lightning/fabric/strategies/xla_fsdp.py
+++ b/src/lightning/fabric/strategies/xla_fsdp.py
@@ -52,8 +52,7 @@ class XLAFSDPStrategy(ParallelStrategy):
 
     Args:
         sequential_save: With this enabled, individual ranks consecutively save their state dictionary shards, reducing
-            peak system RAM usage, although it elongates the saving process. The shards will be later consolidated into
-            a single "full" checkpoint on the main process.
+            peak system RAM usage, although it elongates the saving process.
     """
 
     def __init__(

--- a/tests/tests_fabric/strategies/test_xla_fsdp_integration.py
+++ b/tests/tests_fabric/strategies/test_xla_fsdp_integration.py
@@ -122,14 +122,24 @@ def xla_fsdp_train_save_load(fabric: Fabric, tmp_path, state_dict_type):
 
 
 @RunIf(min_torch="2.0", tpu=True, standalone=True)
-@pytest.mark.parametrize("use_auto_wrap_policy", [False, True])
-@pytest.mark.parametrize("state_dict_type", ["sharded", "full"])
-def test_xla_fsdp_train_save_load(tmp_path, use_auto_wrap_policy, state_dict_type):
+@pytest.mark.parametrize(
+    ("use_auto_wrap_policy", "state_dict_type", "sequential_save"),
+    [
+        (False, "sharded", False),
+        (False, "full", False),
+        (False, "full", True),
+        (True, "sharded", False),
+        (True, "full", False),
+    ],
+)
+def test_xla_fsdp_train_save_load(tmp_path, use_auto_wrap_policy, state_dict_type, sequential_save):
     """Test XLAFSDP training, saving and loading checkpoint (both full and sharded)."""
     from torch_xla.distributed.fsdp.wrap import always_wrap_policy
 
     strategy = XLAFSDPStrategy(
-        auto_wrap_policy=always_wrap_policy if use_auto_wrap_policy else None, state_dict_type=state_dict_type
+        auto_wrap_policy=always_wrap_policy if use_auto_wrap_policy else None,
+        state_dict_type=state_dict_type,
+        sequential_save=sequential_save,
     )
     fabric = Fabric(accelerator="tpu", strategy=strategy)
     fabric.launch(xla_fsdp_train_save_load, tmp_path, state_dict_type)


### PR DESCRIPTION
## What does this PR do?

TPU VMs can be limited in system memory (RAM) when working with large models.

The current XLA FSDP saving mechanism will create a state dict (shard) on each rank with params on device which are saved and consolidated after.

The shards are moved to CPU before saving: https://github.com/Lightning-AI/lightning/blob/master/src/lightning/fabric/plugins/io/xla.py#L67-L68 which can make it go OOM.

This PR adds a flag to save each shard sequentially.

Regular FSDP doesn't need it because it already supports this behaviour automatically via the `rank0_only` flag in it's context manager to save the state dict.


cc @borda @carmocca @justusschock @awaelchli @JackCaoG @steventk-g @Liyang90