### PR TITLE
Integration tests for XLA precision [TPU]

### DIFF
--- a/src/lightning/fabric/plugins/precision/xla.py
+++ b/src/lightning/fabric/plugins/precision/xla.py
@@ -15,13 +15,10 @@ import os
 from typing import Any, Literal
 
 import torch
-from lightning_utilities.core.apply_func import apply_to_collection
-from torch import Tensor
 from typing_extensions import get_args
 
 from lightning.fabric.accelerators.xla import _XLA_AVAILABLE
 from lightning.fabric.plugins.precision.precision import Precision
-from lightning.fabric.plugins.precision.utils import _convert_fp_tensor
 from lightning.fabric.utilities.types import Optimizable
 
 _PRECISION_INPUT = Literal["32-true", "16-true", "bf16-true"]
@@ -58,12 +55,6 @@ class XLAPrecision(Precision):
             self._desired_dtype = torch.bfloat16
         else:
             self._desired_dtype = torch.float32
-
-    def convert_input(self, data: Any) -> Any:
-        return apply_to_collection(data, function=_convert_fp_tensor, dtype=Tensor, dst_type=self._desired_dtype)
-
-    def convert_output(self, data: Any) -> Any:
-        return apply_to_collection(data, function=_convert_fp_tensor, dtype=Tensor, dst_type=torch.get_default_dtype())
 
     def optimizer_step(
         self,

--- a/tests/tests_fabric/plugins/precision/test_xla_integration.py
+++ b/tests/tests_fabric/plugins/precision/test_xla_integration.py
@@ -28,8 +28,8 @@ class BoringPrecisionModule(nn.Module):
 
     def forward(self, x):
         assert x.dtype == self.expected_dtype
-        # the default dtype for new tensors is now float16/bfloat16
-        assert torch.tensor([0.0]).dtype == self.expected_dtype
+        # TODO: This should be float16/bfloat16
+        assert torch.tensor([0.0]).dtype == torch.float32
         return self.layer(x)
 
 

--- a/tests/tests_fabric/plugins/precision/test_xla_integration.py
+++ b/tests/tests_fabric/plugins/precision/test_xla_integration.py
@@ -27,8 +27,8 @@ class BoringPrecisionModule(nn.Module):
         self.layer = torch.nn.Linear(32, 2)
 
     def forward(self, x):
-        assert x.dtype == self.expected_dtype
-        # TODO: This should be float16/bfloat16
+        # TODO: These should be float16/bfloat16
+        assert x.dtype == torch.float32
         assert torch.tensor([0.0]).dtype == torch.float32
         return self.layer(x)
 

--- a/tests/tests_fabric/plugins/precision/test_xla_integration.py
+++ b/tests/tests_fabric/plugins/precision/test_xla_integration.py
@@ -1,0 +1,61 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+import torch
+import torch.nn as nn
+
+from lightning.fabric import Fabric
+from lightning.fabric.plugins import XLAPrecision
+from tests_fabric.helpers.runif import RunIf
+
+
+class BoringPrecisionModule(nn.Module):
+    def __init__(self, expected_dtype):
+        super().__init__()
+        self.expected_dtype = expected_dtype
+        self.layer = torch.nn.Linear(32, 2)
+
+    def forward(self, x):
+        assert x.dtype == self.expected_dtype
+        # the default dtype for new tensors is now float16/bfloat16
+        assert torch.tensor([0.0]).dtype == self.expected_dtype
+        return self.layer(x)
+
+
+def _run_xla_precision(fabric, expected_dtype):
+    with fabric.init_module():
+        model = BoringPrecisionModule(expected_dtype)
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.1)
+    model, optimizer = fabric.setup(model, optimizer)
+
+    batch = torch.rand(2, 32, device=fabric.device)
+    assert model.layer.weight.dtype == model.layer.bias.dtype == expected_dtype
+
+    assert batch.dtype == torch.float32
+    output = model(batch)
+    assert output.dtype == torch.float32
+    loss = torch.nn.functional.mse_loss(output, torch.ones_like(output))
+    fabric.backward(loss)
+    assert model.layer.weight.grad.dtype == expected_dtype
+    optimizer.step()
+    optimizer.zero_grad()
+
+
+@pytest.mark.parametrize("precision, expected_dtype", [("16-true", torch.float16), ("bf16-true", torch.bfloat16)])
+@RunIf(tpu=True, standalone=True)
+def test_xla_precision(precision, expected_dtype):
+    fabric = Fabric(devices=1, precision=precision)
+    assert isinstance(fabric._precision, XLAPrecision)
+    fabric.launch(_run_xla_precision, expected_dtype=expected_dtype)

--- a/tests/tests_fabric/plugins/precision/test_xla_integration.py
+++ b/tests/tests_fabric/plugins/precision/test_xla_integration.py
@@ -53,7 +53,7 @@ def _run_xla_precision(fabric, expected_dtype):
     optimizer.zero_grad()
 
 
-@pytest.mark.parametrize("precision, expected_dtype", [("16-true", torch.float16), ("bf16-true", torch.bfloat16)])
+@pytest.mark.parametrize(("precision", "expected_dtype"), [("16-true", torch.float16), ("bf16-true", torch.bfloat16)])
 @RunIf(tpu=True, standalone=True)
 def test_xla_precision(precision, expected_dtype):
     fabric = Fabric(devices=1, precision=precision)

--- a/tests/tests_fabric/plugins/precision/test_xla_integration.py
+++ b/tests/tests_fabric/plugins/precision/test_xla_integration.py
@@ -41,7 +41,9 @@ def _run_xla_precision(fabric, expected_dtype):
     model, optimizer = fabric.setup(model, optimizer)
 
     batch = torch.rand(2, 32, device=fabric.device)
-    assert model.layer.weight.dtype == model.layer.bias.dtype == expected_dtype
+
+    # TODO: This should be float16/bfloat16
+    assert model.layer.weight.dtype == model.layer.bias.dtype == torch.float32
 
     assert batch.dtype == torch.float32
     output = model(batch)

--- a/tests/tests_fabric/strategies/test_xla_fsdp_integration.py
+++ b/tests/tests_fabric/strategies/test_xla_fsdp_integration.py
@@ -23,6 +23,35 @@ from tests_fabric.helpers.models import RandomDataset
 from tests_fabric.helpers.runif import RunIf
 
 
+def _xla_fsdp_rewrap_warning(fabric: Fabric):
+    """Fabric launch function for test_xla_fsdp_rewrap_warning."""
+    from torch_xla.distributed.fsdp.xla_fully_sharded_data_parallel import XlaFullyShardedDataParallel
+
+    with fabric.init_module():
+        model = torch.nn.Sequential(
+            torch.nn.Linear(1, 1), torch.nn.ReLU(), XlaFullyShardedDataParallel(torch.nn.Linear(1, 1))
+        )
+    if fabric.node_rank:
+        with pytest.warns(match="submodule is already wrapped"):
+            model = fabric.setup_module(model)
+    else:
+        model = fabric.setup_module(model)
+    fabric.barrier("warning_check")
+    assert not isinstance(model._forward_module[0], XlaFullyShardedDataParallel)
+    assert not isinstance(model._forward_module[1], XlaFullyShardedDataParallel)
+    assert isinstance(model._forward_module[2], XlaFullyShardedDataParallel)
+
+
+@RunIf(min_torch="2.0", tpu=True, standalone=True)
+def test_xla_fsdp_rewrap_warning():
+    """Test that XLAFSDP warns about rewrapping the modules."""
+    from torch_xla.distributed.fsdp.wrap import always_wrap_policy
+
+    strategy = XLAFSDPStrategy(auto_wrap_policy=always_wrap_policy)
+    fabric = Fabric(accelerator="tpu", strategy=strategy)
+    fabric.launch(_xla_fsdp_rewrap_warning)
+
+
 def xla_fsdp_train_save_load(fabric: Fabric, tmp_path, state_dict_type):
     """Fabric launch function for test_xla_fsdp_train_save_load."""
     # check if multihost


### PR DESCRIPTION
## What does this PR do?

Adds TPU tests for running XLA with half precision in Fabric.
Addresses https://github.com/Lightning-AI/lightning/pull/18213#discussion_r1291547571


TODO: Investigate
```
plugins/precision/test_xla_integration.py::test_xla_precision[16-true-expected_dtype0] src/tcmalloc.cc:332] Attempt to free invalid pointer 0x7ffea0cde700 
Fatal Python error: Aborted
```


cc @carmocca @JackCaoG @steventk-g @Liyang90 @justusschock @awaelchli @borda