### PR TITLE
Prettier warning output

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -138,6 +138,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - DataLoader re-instantiation is now only performed when a distributed sampler is required ([#18191](https://github.com/Lightning-AI/lightning/pull/18191))
 
 
+- Improved the formatting of emitted warnings ([#18288](https://github.com/Lightning-AI/lightning/pull/18288))
+
+
 - Broadcast and reduction of tensors with XLA-based strategies now preserve the input's device ([#18275](https://github.com/Lightning-AI/lightning/pull/18275))
 
 

--- a/src/lightning/fabric/utilities/warnings.py
+++ b/src/lightning/fabric/utilities/warnings.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Warning-related utilities."""
+import importlib.util
+import os
 import warnings
+from functools import wraps
+from pathlib import Path
+from typing import Callable, List, Optional, Type, Union
 
 from lightning.fabric.utilities.rank_zero import LightningDeprecationWarning
 
@@ -20,5 +25,46 @@ from lightning.fabric.utilities.rank_zero import LightningDeprecationWarning
 warnings.simplefilter("default", category=LightningDeprecationWarning)
 
 
+def _wrap_formatwarning(default_format_warning: Callable) -> Callable:
+    """Custom formatting that avoids an extra line in case warnings are emitted from the `rank_zero`-functions."""
+
+    @wraps(default_format_warning)
+    def wrapper(
+        message: Union[Warning, str], category: Type[Warning], filename: str, lineno: int, line: Optional[str] = None
+    ) -> str:
+        if _is_path_in_lightning(Path(filename)):
+            # The warning originates from the Lightning package
+            return f"{filename}:{lineno}: {message}\n"
+        return default_format_warning(message, category, filename, lineno, line)
+
+    return wrapper
+
+
+warnings.formatwarning = _wrap_formatwarning(warnings.formatwarning)
+
+
 class PossibleUserWarning(UserWarning):
     """Warnings that could be false positives."""
+
+
+def _is_path_in_lightning(path: Path) -> bool:
+    """Checks whether the given path is a subpath of the Lightning package."""
+    path = Path(path).absolute()
+    lightning_roots = _get_lightning_package_roots()
+    for lightning_root in lightning_roots:
+        if path.drive != lightning_root.drive:  # handle windows
+            continue
+        common_path = Path(os.path.commonpath([path, lightning_root]))
+        if common_path.name in ("lightning", "lightning_fabric", "pytorch_lightning"):
+            return True
+    return False
+
+
+def _get_lightning_package_roots() -> List[Path]:
+    """Returns the absolute path to each of the Lightning packages."""
+    roots = []
+    for name in ("lightning", "lightning_fabric", "pytorch_lightning"):
+        spec = importlib.util.find_spec(name)
+        if spec is not None and spec.origin is not None:
+            roots.append(Path(spec.origin).parent.absolute())
+    return roots

--- a/src/lightning/fabric/utilities/warnings.py
+++ b/src/lightning/fabric/utilities/warnings.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Warning-related utilities."""
-import importlib.util
-import os
 import warnings
 from functools import wraps
 from pathlib import Path
-from typing import Callable, List, Optional, Type, Union
+from typing import Callable, Optional, Type, Union
 
 from lightning.fabric.utilities.rank_zero import LightningDeprecationWarning
 
@@ -48,23 +46,5 @@ class PossibleUserWarning(UserWarning):
 
 
 def _is_path_in_lightning(path: Path) -> bool:
-    """Checks whether the given path is a subpath of the Lightning package."""
-    path = Path(path).absolute()
-    lightning_roots = _get_lightning_package_roots()
-    for lightning_root in lightning_roots:
-        if path.drive != lightning_root.drive:  # handle windows
-            continue
-        common_path = Path(os.path.commonpath([path, lightning_root]))
-        if common_path.name in ("lightning", "lightning_fabric", "pytorch_lightning"):
-            return True
-    return False
-
-
-def _get_lightning_package_roots() -> List[Path]:
-    """Returns the absolute path to each of the Lightning packages."""
-    roots = []
-    for name in ("lightning", "lightning_fabric", "pytorch_lightning"):
-        spec = importlib.util.find_spec(name)
-        if spec is not None and spec.origin is not None:
-            roots.append(Path(spec.origin).parent.absolute())
-    return roots
+    """Naive check whether the path looks like a path from the lightning package."""
+    return "lightning" in str(path.absolute())

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -162,6 +162,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - The input tensors now get cast to the right precision type before transfer to the device ([#18264](https://github.com/Lightning-AI/lightning/pull/18264))
 
 
+- Improved the formatting of emitted warnings ([#18288](https://github.com/Lightning-AI/lightning/pull/18288))
+
+
 - Broadcast and reduction of tensors with XLA-based strategies now preserve the input's device ([#18275](https://github.com/Lightning-AI/lightning/pull/18275))
 
 

--- a/tests/tests_fabric/utilities/test_warnings.py
+++ b/tests/tests_fabric/utilities/test_warnings.py
@@ -95,27 +95,22 @@ if __name__ == "__main__":
 
 def test_is_path_in_lightning(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
-
     if sys.platform != "win32":
-        monkeypatch.setattr(
-            "lightning.fabric.utilities.warnings._get_lightning_package_roots", lambda: [Path("/a/b/c/lightning")]
-        )
         assert _is_path_in_lightning(Path("/a/b/c/lightning"))
         assert _is_path_in_lightning(Path("/a/b/c/lightning/core/lightning.py"))
         assert _is_path_in_lightning(Path("/a/b/c/lightning/lightning"))
-        assert not _is_path_in_lightning(Path(""))
         assert not _is_path_in_lightning(Path("/a/b/c/"))
-        assert not _is_path_in_lightning(Path("/a/b/lightning"))
-        assert not _is_path_in_lightning(Path("a/b/c/lightning"))
-
+        # The following statements should assert the opposite for correctness, but a naive implementation of
+        # `_is_path_in_lightning` was requested, thus it cannot handle these cases
+        assert _is_path_in_lightning(Path(""))
+        assert _is_path_in_lightning(Path("/a/b/lightning"))
+        assert _is_path_in_lightning(Path("a/b/c/lightning"))
     else:
-        assert not _is_path_in_lightning(Path(r"C:\a\b\c\lightning"))
-        monkeypatch.setattr(
-            "lightning.fabric.utilities.warnings._get_lightning_package_roots", lambda: [Path(r"C:\a\b\c\lightning")]
-        )
         assert _is_path_in_lightning(Path(r"C:\a\b\c\lightning"))
         assert _is_path_in_lightning(Path(r"C:\a\b\c\lightning\core\lightning.py"))
         assert _is_path_in_lightning(Path(r"C:\a\b\c\lightning\lightning"))
         assert not _is_path_in_lightning(Path(r"\a\b\c"))
         assert not _is_path_in_lightning(Path(r"C:\a\b\c"))
-        assert not _is_path_in_lightning(Path(r"D:\a\b\c\lightning"))  # drive letter mismatch
+        # The following statements should assert the opposite for correctness, but a naive implementation of
+        # `_is_path_in_lightning` was requested, thus it cannot handle these cases
+        assert _is_path_in_lightning(Path(r"D:\a\b\c\lightning"))  # drive letter mismatch

--- a/tests/tests_fabric/utilities/test_warnings.py
+++ b/tests/tests_fabric/utilities/test_warnings.py
@@ -16,17 +16,27 @@
 Needs to be run outside of `pytest` as it captures all the warnings.
 
 """
+import inspect
+import sys
 from contextlib import redirect_stderr
 from io import StringIO
+from pathlib import Path
 
 from lightning_utilities.core.rank_zero import _warn, WarningCache
 
 from lightning.fabric.utilities.rank_zero import rank_zero_deprecation, rank_zero_warn
+from lightning.fabric.utilities.warnings import _is_path_in_lightning
+
+
+def line_number():
+    return inspect.currentframe().f_back.f_lineno
+
 
 if __name__ == "__main__":
     stderr = StringIO()
     # recording
     with redirect_stderr(stderr):
+        base_line = line_number() + 1
         _warn("test1")
         _warn("test2", category=DeprecationWarning)
 
@@ -40,19 +50,19 @@ if __name__ == "__main__":
         cache.deprecation("test7")
 
     output = stderr.getvalue()
-    base_line = 30
     expected_lines = [
-        f"test_warnings.py:{base_line}: UserWarning: test1",
-        f"test_warnings.py:{base_line+1}: DeprecationWarning: test2",
-        f"test_warnings.py:{base_line+3}: UserWarning: test3",
-        f"test_warnings.py:{base_line+4}: DeprecationWarning: test4",
-        f"test_warnings.py:{base_line+6}: LightningDeprecationWarning: test5",
-        f"test_warnings.py:{base_line+9}: UserWarning: test6",
-        f"test_warnings.py:{base_line+10}: LightningDeprecationWarning: test7",
+        f"test_warnings.py:{base_line}: test1",
+        f"test_warnings.py:{base_line+1}: test2",
+        f"test_warnings.py:{base_line+3}: test3",
+        f"test_warnings.py:{base_line+4}: test4",
+        f"test_warnings.py:{base_line+6}: test5",
+        f"test_warnings.py:{base_line+9}: test6",
+        f"test_warnings.py:{base_line+10}: test7",
     ]
 
     for ln in expected_lines:
         assert ln in output, f"Missing line {ln!r} in:\n{output}"
+        assert "rank_zero_warn(" not in output, "customized warning wrapper is not used"
 
     # check that logging is properly configured
     import logging
@@ -81,3 +91,31 @@ if __name__ == "__main__":
 
     output = stderr.getvalue()
     assert output == "test2\n", repr(output)
+
+
+def test_is_path_in_lightning(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    if sys.platform != "win32":
+        monkeypatch.setattr(
+            "lightning.fabric.utilities.warnings._get_lightning_package_roots", lambda: [Path("/a/b/c/lightning")]
+        )
+        assert _is_path_in_lightning(Path("/a/b/c/lightning"))
+        assert _is_path_in_lightning(Path("/a/b/c/lightning/core/lightning.py"))
+        assert _is_path_in_lightning(Path("/a/b/c/lightning/lightning"))
+        assert not _is_path_in_lightning(Path(""))
+        assert not _is_path_in_lightning(Path("/a/b/c/"))
+        assert not _is_path_in_lightning(Path("/a/b/lightning"))
+        assert not _is_path_in_lightning(Path("a/b/c/lightning"))
+
+    else:
+        assert not _is_path_in_lightning(Path(r"C:\a\b\c\lightning"))
+        monkeypatch.setattr(
+            "lightning.fabric.utilities.warnings._get_lightning_package_roots", lambda: [Path(r"C:\a\b\c\lightning")]
+        )
+        assert _is_path_in_lightning(Path(r"C:\a\b\c\lightning"))
+        assert _is_path_in_lightning(Path(r"C:\a\b\c\lightning\core\lightning.py"))
+        assert _is_path_in_lightning(Path(r"C:\a\b\c\lightning\lightning"))
+        assert not _is_path_in_lightning(Path(r"\a\b\c"))
+        assert not _is_path_in_lightning(Path(r"C:\a\b\c"))
+        assert not _is_path_in_lightning(Path(r"D:\a\b\c\lightning"))  # drive letter mismatch


### PR DESCRIPTION
## What does this PR do?

This PR proposes a prettier warning printing. Currently, the user sees a warning formatted like this, with all the text crammed in a single line and a strange `rank_zero_warn(` on a new line:

```
/Users/adrian/repositories/lightning/src/lightning/pytorch/trainer/connectors/data_connector.py:444: PossibleUserWarning: The dataloader, train_dataloader, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 10 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.
  rank_zero_warn(
```
In a normally sized terminal window, the filename can take up a big chunk of space. The user then only sees very little of the actual warning message, and has to scroll horizontally which could be considered annoying. 

I experimented with custom formatting. Here are a few versions:

**Version 1:** Multi-line: Warning type on same line
```
/Users/adrian/repositories/lightning/src/lightning/pytorch/trainer/connectors/data_connector.py:444: PossibleUserWarning: 
The dataloader, train_dataloader, does not have many workers which may be a bottleneck. Consider
increasing the value of the `num_workers` argument` (try 10 which is the number of cpus on this
machine) in the `DataLoader` init to improve performance.
```

 **Version 2:** Multi-line: Warning type on new line
```
/Users/adrian/repositories/lightning/src/lightning/pytorch/trainer/connectors/data_connector.py:444:
PossibleUserWarning: The dataloader, train_dataloader, does not have many workers which may be a
bottleneck. Consider increasing the value of the `num_workers` argument` (try 10 which is the number
of cpus on this machine) in the `DataLoader` init to improve performance.
```

 **Version 3:** Multi-line: With indentation
```
/Users/adrian/repositories/lightning/src/lightning/pytorch/trainer/connectors/data_connector.py:444:
    PossibleUserWarning: The dataloader, train_dataloader, does not have many workers which may be a
    bottleneck. Consider increasing the value of the `num_workers` argument` (try 10 which is the number
    of cpus on this machine) in the `DataLoader` init to improve performance.
```

 **Version 4:** Single line, but no awkward "rank_zero_only(" on new line
```
/Users/adrian/repositories/lightning/src/lightning/pytorch/trainer/connectors/data_connector.py:444: PossibleUserWarning: The dataloader, train_dataloader, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 10 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.
```


Please let me know whether you find this a good idea, you have any suggestions or if you see any problems with this formatting style.



cc @carmocca @justusschock @awaelchli