### PR TITLE
Validate Trainer settings against cluster environment

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -115,6 +115,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added automatic process cleanup to avoid zombie child processes and stalls when exceptions are raised ([#18218](https://github.com/Lightning-AI/lightning/pull/18218))
 
 
+- Added validation of user input for `devices` and `num_nodes` when running with `SLURM` or `TorchElastic` ([#18292](https://github.com/Lightning-AI/lightning/pull/18292))
+
+
 ### Changed
 
 - Allow using iterable-style datasets with TPUs ([#17331](https://github.com/Lightning-AI/lightning/pull/17331))

--- a/src/lightning/fabric/connector.py
+++ b/src/lightning/fabric/connector.py
@@ -293,7 +293,7 @@ class _Connector:
                 self._parallel_devices = self._strategy_flag.parallel_devices
 
     def _check_device_config_and_set_final_flags(self, devices: Union[List[int], str, int], num_nodes: int) -> None:
-        self._num_nodes_flag = int(num_nodes) if num_nodes is not None else 1
+        self._num_nodes_flag = num_nodes
         self._devices_flag = devices
 
         if self._devices_flag in ([], 0, "0"):

--- a/src/lightning/fabric/connector.py
+++ b/src/lightning/fabric/connector.py
@@ -113,7 +113,7 @@ class _Connector:
         accelerator = self._argument_from_env("accelerator", accelerator, default="auto")
         strategy = self._argument_from_env("strategy", strategy, default="auto")
         devices = self._argument_from_env("devices", devices, default="auto")
-        num_nodes = self._argument_from_env("num_nodes", num_nodes, default=1)
+        num_nodes = int(self._argument_from_env("num_nodes", num_nodes, default=1))
         precision = self._argument_from_env("precision", precision, default="32-true")
 
         # 1. Parsing flags

--- a/src/lightning/fabric/plugins/environments/cluster_environment.py
+++ b/src/lightning/fabric/plugins/environments/cluster_environment.py
@@ -62,8 +62,8 @@ class ClusterEnvironment(ABC):
         """The rank (index) of the node on which the current process runs."""
 
     def validate_settings(self, num_devices: int, num_nodes: int) -> None:
-        """Validates settings configured in the script against the environment, and raises an exception if there is
-        an inconsistency."""
+        """Validates settings configured in the script against the environment, and raises an exception if there is an
+        inconsistency."""
         pass
 
     def teardown(self) -> None:

--- a/src/lightning/fabric/plugins/environments/cluster_environment.py
+++ b/src/lightning/fabric/plugins/environments/cluster_environment.py
@@ -61,6 +61,11 @@ class ClusterEnvironment(ABC):
     def node_rank(self) -> int:
         """The rank (index) of the node on which the current process runs."""
 
+    def validate_settings(self, num_devices: int, num_nodes: int) -> None:
+        """Validates settings configured in the script against the environment, and raises an exception if there is
+        an inconsistency."""
+        pass
+
     def teardown(self) -> None:
         """Clean up any state set after execution finishes."""
         pass

--- a/src/lightning/fabric/plugins/environments/slurm.py
+++ b/src/lightning/fabric/plugins/environments/slurm.py
@@ -141,6 +141,20 @@ class SLURMEnvironment(ClusterEnvironment):
     def node_rank(self) -> int:
         return int(os.environ["SLURM_NODEID"])
 
+    def validate_settings(self, num_devices: int, num_nodes: int) -> None:
+        ntasks_per_node = os.environ.get("SLURM_NTASKS_PER_NODE")
+        if ntasks_per_node is not None and int(ntasks_per_node) != num_devices:
+            raise ValueError(
+                f"You set `devices={num_devices}` in Lightning, but the number of tasks per node configured in SLURM"
+                f" `--ntasks-per-node={ntasks_per_node}` does not match. HINT: Set `devices={ntasks_per_node}`."
+            )
+        nnodes = os.environ.get("SLURM_NNODES")
+        if nnodes is not None and int(nnodes) != num_nodes:
+            raise ValueError(
+                f"You set `num_nodes={num_nodes}` in Lightning, but the number nodes configured in SLURM"
+                f" `--nodes={nnodes}` does not match. HINT: Set `num_nodes={nnodes}`."
+            )
+
     @staticmethod
     def resolve_root_node_address(nodes: str) -> str:
         """The node selection format in SLURM supports several formats.
@@ -182,8 +196,7 @@ class SLURMEnvironment(ClusterEnvironment):
         """Checks for conflicting or incorrectly set variables set through `srun` and raises a useful error message.
 
         Right now, we only check for the most common user errors. See
-        `the srun docs <https://slurm.schedmd.com/srun.html>`_
-        for a complete list of supported srun variables.
+        `the srun docs <https://slurm.schedmd.com/srun.html>`_ for a complete list of supported srun variables.
 
         """
         ntasks = int(os.environ.get("SLURM_NTASKS", "1"))

--- a/src/lightning/fabric/plugins/environments/slurm.py
+++ b/src/lightning/fabric/plugins/environments/slurm.py
@@ -142,6 +142,8 @@ class SLURMEnvironment(ClusterEnvironment):
         return int(os.environ["SLURM_NODEID"])
 
     def validate_settings(self, num_devices: int, num_nodes: int) -> None:
+        if _is_slurm_interactive_mode():
+            return
         ntasks_per_node = os.environ.get("SLURM_NTASKS_PER_NODE")
         if ntasks_per_node is not None and int(ntasks_per_node) != num_devices:
             raise ValueError(
@@ -151,7 +153,7 @@ class SLURMEnvironment(ClusterEnvironment):
         nnodes = os.environ.get("SLURM_NNODES")
         if nnodes is not None and int(nnodes) != num_nodes:
             raise ValueError(
-                f"You set `num_nodes={num_nodes}` in Lightning, but the number nodes configured in SLURM"
+                f"You set `num_nodes={num_nodes}` in Lightning, but the number of nodes configured in SLURM"
                 f" `--nodes={nnodes}` does not match. HINT: Set `num_nodes={nnodes}`."
             )
 

--- a/src/lightning/fabric/plugins/environments/torchelastic.py
+++ b/src/lightning/fabric/plugins/environments/torchelastic.py
@@ -72,3 +72,10 @@ class TorchElasticEnvironment(ClusterEnvironment):
 
     def node_rank(self) -> int:
         return int(os.environ.get("GROUP_RANK", 0))
+
+    def validate_settings(self, num_devices: int, num_nodes: int) -> None:
+        if num_devices * num_nodes != self.world_size():
+            raise ValueError(
+                f"You set `devices={num_devices}` and `num_nodes={num_nodes}` in Lightning, but the product"
+                f" ({num_devices} * {num_nodes}) does not match the world size ({self.world_size()})."
+            )

--- a/src/lightning/fabric/strategies/launchers/subprocess_script.py
+++ b/src/lightning/fabric/strategies/launchers/subprocess_script.py
@@ -94,6 +94,7 @@ class _SubprocessScriptLauncher(_Launcher):
             **kwargs: Optional keyword arguments to be passed to the given function.
 
         """
+        self.cluster_environment.validate_settings(num_devices=self.num_processes, num_nodes=self.num_nodes)
         if not self.cluster_environment.creates_processes_externally:
             self._call_children_scripts()
             _launch_process_observer(self.procs)

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -100,6 +100,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `LightningOptimizer.refresh()` to update the `__dict__` in case the optimizer it wraps has changed its internal state ([#18280](https://github.com/Lightning-AI/lightning/pull/18280))
 
 
+- Added validation of user input for `devices` and `num_nodes` when running with `SLURM` or `TorchElastic` ([#18292](https://github.com/Lightning-AI/lightning/pull/18292))
+
+
+
 ### Changed
 
 - Removed the limitation to call `self.trainer.model.parameters()` in `LightningModule.configure_optimizers()` ([#17309](https://github.com/Lightning-AI/lightning/pull/17309))

--- a/src/lightning/pytorch/strategies/launchers/subprocess_script.py
+++ b/src/lightning/pytorch/strategies/launchers/subprocess_script.py
@@ -92,6 +92,7 @@ class _SubprocessScriptLauncher(_Launcher):
             **kwargs: Optional keyword arguments to be passed to the given function.
 
         """
+        self.cluster_environment.validate_settings(num_devices=self.num_processes, num_nodes=self.num_nodes)
         if not self.cluster_environment.creates_processes_externally:
             self._call_children_scripts()
             _launch_process_observer(self.procs)

--- a/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
@@ -321,7 +321,7 @@ class _AcceleratorConnector:
         devices: Union[List[int], str, int],
         num_nodes: int,
     ) -> None:
-        self._num_nodes_flag = int(num_nodes) if num_nodes is not None else 1
+        self._num_nodes_flag = num_nodes
         self._devices_flag = devices
 
         if self._devices_flag in ([], 0, "0"):

--- a/tests/tests_fabric/plugins/environments/test_slurm.py
+++ b/tests/tests_fabric/plugins/environments/test_slurm.py
@@ -16,6 +16,7 @@ import os
 import shutil
 import sys
 from unittest import mock
+from unittest.mock import Mock
 
 import pytest
 from lightning_utilities.test.warning import no_warning_call
@@ -159,3 +160,23 @@ def test_srun_variable_validation():
         RuntimeError, match="You set `--ntasks=2` in your SLURM"
     ):
         SLURMEnvironment()
+
+
+def test_validate_user_settings():
+    """Test that the environment can validate the number of devices and nodes set in Fabric."""
+    env = SLURMEnvironment()
+    with mock.patch.dict(os.environ, {"SLURM_NTASKS_PER_NODE": "4", "SLURM_NNODES": "2"}):
+        env.validate_settings(num_devices=4, num_nodes=2)
+
+        with pytest.raises(ValueError, match="the number of tasks per node configured .* does not match"):
+            env.validate_settings(num_devices=2, num_nodes=2)
+
+        with pytest.raises(ValueError, match="the number of nodes configured in SLURM .* does not match"):
+            env.validate_settings(num_devices=4, num_nodes=1)
+
+    # in interactive mode, validation is skipped becauses processes get launched by Fabric, not SLURM
+    with mock.patch(
+        "lightning.fabric.plugins.environments.slurm.SLURMEnvironment.job_name", return_value="interactive"
+    ):
+        env = SLURMEnvironment()
+        env.validate_settings(num_devices=4, num_nodes=1)  # no error

--- a/tests/tests_fabric/plugins/environments/test_slurm.py
+++ b/tests/tests_fabric/plugins/environments/test_slurm.py
@@ -162,19 +162,19 @@ def test_srun_variable_validation():
         SLURMEnvironment()
 
 
+@mock.patch.dict(os.environ, {"SLURM_NTASKS_PER_NODE": "4", "SLURM_NNODES": "2"})
 def test_validate_user_settings():
-    """Test that the environment can validate the number of devices and nodes set in Fabric."""
+    """Test that the environment can validate the number of devices and nodes set in Fabric/Trainer."""
     env = SLURMEnvironment()
-    with mock.patch.dict(os.environ, {"SLURM_NTASKS_PER_NODE": "4", "SLURM_NNODES": "2"}):
-        env.validate_settings(num_devices=4, num_nodes=2)
+    env.validate_settings(num_devices=4, num_nodes=2)
 
-        with pytest.raises(ValueError, match="the number of tasks per node configured .* does not match"):
-            env.validate_settings(num_devices=2, num_nodes=2)
+    with pytest.raises(ValueError, match="the number of tasks per node configured .* does not match"):
+        env.validate_settings(num_devices=2, num_nodes=2)
 
-        with pytest.raises(ValueError, match="the number of nodes configured in SLURM .* does not match"):
-            env.validate_settings(num_devices=4, num_nodes=1)
+    with pytest.raises(ValueError, match="the number of nodes configured in SLURM .* does not match"):
+        env.validate_settings(num_devices=4, num_nodes=1)
 
-    # in interactive mode, validation is skipped becauses processes get launched by Fabric, not SLURM
+    # in interactive mode, validation is skipped becauses processes get launched by Fabric/Trainer, not SLURM
     with mock.patch(
         "lightning.fabric.plugins.environments.slurm.SLURMEnvironment.job_name", return_value="interactive"
     ):

--- a/tests/tests_fabric/plugins/environments/test_torchelastic.py
+++ b/tests/tests_fabric/plugins/environments/test_torchelastic.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import logging
 import os
+import re
 from unittest import mock
 
 import pytest
@@ -82,3 +83,12 @@ def test_detect():
         },
     ):
         assert TorchElasticEnvironment.detect()
+
+
+@mock.patch.dict(os.environ, {"WORLD_SIZE": "8"})
+def test_validate_user_settings():
+    """Test that the environment can validate the number of devices and nodes set in Fabric/Trainer."""
+    env = TorchElasticEnvironment()
+    env.validate_settings(num_devices=4, num_nodes=2)
+    with pytest.raises(ValueError, match=re.escape("the product (2 * 2) does not match the world size (8)")):
+        env.validate_settings(num_devices=2, num_nodes=2)

--- a/tests/tests_fabric/strategies/launchers/test_subprocess_script.py
+++ b/tests/tests_fabric/strategies/launchers/test_subprocess_script.py
@@ -170,3 +170,15 @@ def test_child_process_observer(sleep_mock, os_kill_mock):
     observer()
     assert observer._finished
     sleep_mock.assert_called_once_with(5)
+
+
+@mock.patch("lightning.fabric.strategies.launchers.subprocess_script.subprocess.Popen")
+@mock.patch("lightning.fabric.strategies.launchers.subprocess_script.Thread")
+def test_validate_cluster_environment_user_settings(*_):
+    """Test that the launcher calls into the cluster environment to validate the user settings."""
+    cluster_env = Mock(validate_settings=Mock(side_effect=RuntimeError("test")))
+    cluster_env.creates_processes_externally = True
+    launcher = _SubprocessScriptLauncher(cluster_env, num_processes=2, num_nodes=1)
+
+    with pytest.raises(RuntimeError, match="test"):
+        launcher.launch(Mock())

--- a/tests/tests_pytorch/strategies/launchers/test_subprocess_script.py
+++ b/tests/tests_pytorch/strategies/launchers/test_subprocess_script.py
@@ -88,3 +88,15 @@ def test_kill(_):
     launcher.kill(15)
     proc0.send_signal.assert_called_once_with(15)
     proc1.send_signal.assert_called_once_with(15)
+
+
+@mock.patch("lightning.fabric.strategies.launchers.subprocess_script.subprocess.Popen")
+@mock.patch("lightning.fabric.strategies.launchers.subprocess_script.Thread")
+def test_validate_cluster_environment_user_settings(*_):
+    """Test that the launcher calls into the cluster environment to validate the user settings."""
+    cluster_env = Mock(validate_settings=Mock(side_effect=RuntimeError("test")))
+    cluster_env.creates_processes_externally = True
+    launcher = _SubprocessScriptLauncher(cluster_env, num_processes=2, num_nodes=1)
+
+    with pytest.raises(RuntimeError, match="test"):
+        launcher.launch(Mock())


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/Lightning-AI/lightning/issues/10107
Fixes https://github.com/Lightning-AI/lightning/issues/8993

This PR adds checks that the user sets `devices` and `num_nodes` correctly in a cluster environment where processes get configured and launched externally. In this PR, we do this for SLURM and torchelastic launch, and others are left for future work (not needed for LightningEnvironment).

Note: This is an intermediate step towards automatically inferring the number of nodes in a cluster environment, so the user doesn't have to set it by hand: #14078, #7361


cc @borda @carmocca @justusschock @awaelchli