### PR TITLE
Cache `XLAEnvironment` properties

### DIFF
--- a/src/lightning/fabric/plugins/environments/xla.py
+++ b/src/lightning/fabric/plugins/environments/xla.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import functools
 import logging
 from typing import Any
 
@@ -51,6 +52,7 @@ class XLAEnvironment(ClusterEnvironment):
     def detect() -> bool:
         return XLAAccelerator.is_available()
 
+    @functools.lru_cache(maxsize=1)
     def world_size(self) -> int:
         import torch_xla.core.xla_model as xm
 
@@ -59,6 +61,7 @@ class XLAEnvironment(ClusterEnvironment):
     def set_world_size(self, size: int) -> None:
         log.debug("XLAEnvironment.set_world_size was called, but setting world size is not allowed. Ignored.")
 
+    @functools.lru_cache(maxsize=1)
     def global_rank(self) -> int:
         import torch_xla.core.xla_model as xm
 
@@ -67,11 +70,13 @@ class XLAEnvironment(ClusterEnvironment):
     def set_global_rank(self, rank: int) -> None:
         log.debug("XLAEnvironment.set_global_rank was called, but setting global rank is not allowed. Ignored.")
 
+    @functools.lru_cache(maxsize=1)
     def local_rank(self) -> int:
         import torch_xla.core.xla_model as xm
 
         return xm.get_local_ordinal()
 
+    @functools.lru_cache(maxsize=1)
     def node_rank(self) -> int:
         if _using_pjrt() and _XLA_GREATER_EQUAL_2_1:
             from torch_xla import runtime as xr


### PR DESCRIPTION
## What does this PR do?

Unlike for other `ClusterEnvironment` implementations, `XLAEnvironment` doesn't get the values for its properties from environment variables, making them expensive in a train loop that access `fabric.world_size` inside the training loop:

https://github.com/Lightning-AI/lit-gpt/blob/main/finetune/lora.py#L208

This PR adds cache for these properties to avoid this gotcha. This is okay because the XLA strategies will not call the `XLAEnvironment` implementations until the strategy has launched:

https://github.com/Lightning-AI/lightning/blob/master/src/lightning/fabric/strategies/xla.py#L85-L99