### PR TITLE
Increase batch size in Readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ train, val = data.random_split(dataset, [55000, 5000])
 # -------------------
 autoencoder = LitAutoEncoder()
 trainer = L.Trainer()
-trainer.fit(autoencoder, data.DataLoader(train), data.DataLoader(val))
+trainer.fit(autoencoder, data.DataLoader(train, batch_size=256), data.DataLoader(val, batch_size=256))
 ```
 
 Run the model on your terminal


### PR DESCRIPTION
## What does this PR do?

The model is tiny, and on fast GPUs, the usage is not great. Increasing the batch size should help, but is not enough on fast GPUs (A100 etc). They are too fast. 

Other changes that could be made:
- Set num_workers > 0
- Disable checkpointing
- Disable logger

But this will increase the footprint of the example. 

