### PR TITLE
Fix saving FSDP checkpoint when world size = 1 and torch <= 2.0

### DIFF
--- a/src/lightning/app/runners/cloud.py
+++ b/src/lightning/app/runners/cloud.py
@@ -220,7 +220,8 @@ class CloudRuntime(Runtime):
         # Resolution
         root = self._resolve_root()
         # If the root will already be there, we don't need to upload and preserve the absolute entrypoint
-        absolute_entrypoint = str(root).startswith("/project")
+        top_folder = os.getenv("FILESYSTEM_TOP_FOLDER_NAME", "project")
+        absolute_entrypoint = str(root).startswith(f"/{top_folder}")
         # If system customization files found, it will set their location path
         sys_customizations_root = self._resolve_env_root()
         repo = self._resolve_repo(

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -808,14 +808,16 @@ def _get_sharded_state_dict_context(module: Module) -> Generator[None, None, Non
     return state_dict_type_context  # type: ignore[return-value]
 
 
-def _get_full_state_dict_context(module: Module, world_size: int, rank0_only: bool = True) -> Generator[None, None, None]:
+def _get_full_state_dict_context(
+    module: Module, world_size: int, rank0_only: bool = True
+) -> Generator[None, None, None]:
     from torch.distributed.fsdp import FullStateDictConfig
     from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
     from torch.distributed.fsdp import StateDictType
 
     # In PyTorch <= 2.0, offload to CPU in combination with `world_size=1` is not possible
     offload_to_cpu = not (world_size == 1 and not _TORCH_GREATER_EQUAL_2_1)
-    
+
     state_dict_config = FullStateDictConfig(offload_to_cpu=offload_to_cpu, rank0_only=rank0_only)
 
     if _TORCH_GREATER_EQUAL_2_0:

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -487,7 +487,7 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
                 torch.save(metadata, path / _METADATA_FILENAME)
 
         elif self._state_dict_type == "full":
-            state_dict_ctx = _get_full_state_dict_context(module)
+            state_dict_ctx = _get_full_state_dict_context(module, world_size=self.world_size)
             full_state: Dict[str, Any] = {}
             with state_dict_ctx:
                 for key, obj in state.items():
@@ -531,7 +531,7 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
         path = Path(self.broadcast(path))
 
         if isinstance(state, Module):
-            _load_raw_module_state_from_path(path, module=state, strict=strict)
+            _load_raw_module_state_from_path(path, module=state, world_size=self.world_size, strict=strict)
             return {}
 
         if isinstance(state, Optimizer):
@@ -597,7 +597,7 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
 
         if _is_full_checkpoint(path):
             checkpoint = _lazy_load(path) if _TORCH_GREATER_EQUAL_2_0 else torch.load(path, map_location="cpu")
-            _load_raw_module_state(checkpoint.pop(module_key), module=module, strict=strict)
+            _load_raw_module_state(checkpoint.pop(module_key), module=module, world_size=world_size, strict=strict)
 
             if isinstance(state, Module):
                 return {}
@@ -610,7 +610,7 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
             # Load optimizer states
             for optim_key, optim in optimizers.items():
                 # rank0_only should be false because we need to load the optimizer state on all ranks
-                with _get_full_state_dict_context(module, rank0_only=False):
+                with _get_full_state_dict_context(module, world_size=self.world_size, rank0_only=False):
                     temp_state_dict = checkpoint.pop(optim_key)
 
                     # Handling the case where the optimizer state is saved from a normal optimizer
@@ -808,17 +808,20 @@ def _get_sharded_state_dict_context(module: Module) -> Generator[None, None, Non
     return state_dict_type_context  # type: ignore[return-value]
 
 
-def _get_full_state_dict_context(module: Module, rank0_only: bool = True) -> Generator[None, None, None]:
+def _get_full_state_dict_context(module: Module, world_size: int, rank0_only: bool = True) -> Generator[None, None, None]:
     from torch.distributed.fsdp import FullStateDictConfig
     from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
     from torch.distributed.fsdp import StateDictType
 
-    state_dict_config = FullStateDictConfig(offload_to_cpu=True, rank0_only=rank0_only)
+    # In PyTorch <= 2.0, offload to CPU in combination with `world_size=1` is not possible
+    offload_to_cpu = not (world_size == 1 and not _TORCH_GREATER_EQUAL_2_1)
+    
+    state_dict_config = FullStateDictConfig(offload_to_cpu=offload_to_cpu, rank0_only=rank0_only)
 
     if _TORCH_GREATER_EQUAL_2_0:
         from torch.distributed.fsdp.api import FullOptimStateDictConfig
 
-        optim_state_dict_config = FullOptimStateDictConfig(offload_to_cpu=True, rank0_only=rank0_only)
+        optim_state_dict_config = FullOptimStateDictConfig(offload_to_cpu=offload_to_cpu, rank0_only=rank0_only)
         state_dict_type_context = FSDP.state_dict_type(
             module=module,
             state_dict_type=StateDictType.FULL_STATE_DICT,
@@ -849,7 +852,7 @@ def _has_fsdp_modules(module: object) -> TypeGuard[Module]:
     return isinstance(module, Module) and any(isinstance(m, FullyShardedDataParallel) for m in module.modules())
 
 
-def _load_raw_module_state_from_path(path: Path, module: Module, strict: bool = True) -> None:
+def _load_raw_module_state_from_path(path: Path, module: Module, world_size: int, strict: bool = True) -> None:
     """Loads the state dict from a file path into the FSDP module."""
     if not _is_full_checkpoint(path):
         raise ValueError(
@@ -857,13 +860,13 @@ def _load_raw_module_state_from_path(path: Path, module: Module, strict: bool = 
             f" full state dict: {path}"
         )
     # Use `lazy_load` instead of `torch.load` here to avoid storing a copy of the full checkpoint per rank
-    _load_raw_module_state(state_dict=_lazy_load(path), module=module, strict=strict)
+    _load_raw_module_state(state_dict=_lazy_load(path), module=module, world_size=world_size, strict=strict)
 
 
-def _load_raw_module_state(state_dict: Dict[str, Any], module: Module, strict: bool = True) -> None:
+def _load_raw_module_state(state_dict: Dict[str, Any], module: Module, world_size: int, strict: bool = True) -> None:
     """Loads the state dict into the module by gathering all weights first and then and writing back to each shard."""
 
-    with _get_full_state_dict_context(module, rank0_only=False):
+    with _get_full_state_dict_context(module, world_size=world_size, rank0_only=False):
         module.load_state_dict(state_dict, strict=strict)
 
 

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -597,7 +597,7 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
 
         if _is_full_checkpoint(path):
             checkpoint = _lazy_load(path) if _TORCH_GREATER_EQUAL_2_0 else torch.load(path, map_location="cpu")
-            _load_raw_module_state(checkpoint.pop(module_key), module=module, world_size=world_size, strict=strict)
+            _load_raw_module_state(checkpoint.pop(module_key), module=module, world_size=self.world_size, strict=strict)
 
             if isinstance(state, Module):
                 return {}

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -816,8 +816,7 @@ def _get_full_state_dict_context(
     from torch.distributed.fsdp import StateDictType
 
     # In PyTorch <= 2.0, offload to CPU in combination with `world_size=1` is not possible
-    offload_to_cpu = not (world_size == 1 and not _TORCH_GREATER_EQUAL_2_1)
-
+    offload_to_cpu = world_size > 1 or _TORCH_GREATER_EQUAL_2_1
     state_dict_config = FullStateDictConfig(offload_to_cpu=offload_to_cpu, rank0_only=rank0_only)
 
     if _TORCH_GREATER_EQUAL_2_0:

--- a/tests/tests_fabric/strategies/test_fsdp.py
+++ b/tests/tests_fabric/strategies/test_fsdp.py
@@ -422,6 +422,7 @@ def test_has_meta_device_parameters():
 @pytest.mark.parametrize("torch_ge_2_1", [True, False])
 @mock.patch("torch.distributed.fsdp.fully_sharded_data_parallel.FullyShardedDataParallel.set_state_dict_type")
 def test_get_full_state_dict_context_offload(set_type_mock, monkeypatch, torch_ge_2_1):
+    """Test that the state dict context manager handles CPU offloading depending on the PyTorch version."""
     monkeypatch.setattr("lightning.fabric.strategies.fsdp._TORCH_GREATER_EQUAL_2_1", torch_ge_2_1)
 
     with _get_full_state_dict_context(module=Mock(spec=FullyShardedDataParallel), world_size=1):

--- a/tests/tests_fabric/strategies/test_fsdp.py
+++ b/tests/tests_fabric/strategies/test_fsdp.py
@@ -418,7 +418,7 @@ def test_has_meta_device_parameters():
         _has_meta_device_parameters(None)
 
 
-@RunIf(min_torch="1.12")
+@RunIf(min_torch="2.0")
 @pytest.mark.parametrize("torch_ge_2_1", [True, False])
 @mock.patch("torch.distributed.fsdp.fully_sharded_data_parallel.FullyShardedDataParallel.set_state_dict_type")
 def test_get_full_state_dict_context_offload(set_type_mock, monkeypatch, torch_ge_2_1):


### PR DESCRIPTION
## What does this PR do?

Discovered in  https://github.com/Lightning-AI/lightning/pull/18364 thanks to the curiosity of @carmocca.
Limited to torch < 2.1, world_size=1, full-state-dict saving. 


Repro:
```py
from lightning.fabric import Fabric
from lightning.fabric.strategies import FSDPStrategy
import torch
import torch.nn as nn

fabric = Fabric(devices=1, strategy=FSDPStrategy(auto_wrap_policy={nn.Linear}, state_dict_type="full"))
fabric.launch()

model = torch.nn.Linear(100, 100)
model = fabric.setup(model)

fabric.save("test.ckpt", state={"model": model})
```
Error:
```
Initializing distributed: GLOBAL_RANK: 0, MEMBER: 1/1
----------------------------------------------------------------------------------------------------
distributed_backend=nccl
All distributed processes registered. Starting with 1 processes
----------------------------------------------------------------------------------------------------

You are using a CUDA device ('NVIDIA A100-SXM4-40GB') that has Tensor Cores. To properly utilize them, you should set `torch.set_float32_matmul_precision('medium' | 'high')` which will trade-off precision for performance. For more details, read https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision
/home/adrian/.conda/envs/lightning/lib/python3.10/site-packages/torch/distributed/fsdp/_init_utils.py:295: UserWarning: FSDP is switching to use `NO_SHARD` instead of ShardingStrategy.FULL_SHARD since the world size is 1.
  warnings.warn(
Traceback (most recent call last):
  File "/home/adrian/repositories/lightning/examples/pytorch/bug_report/bug_report_model.py", line 12, in <module>
    fabric.save("test.ckpt", state={"model": model})
  File "/home/adrian/repositories/lightning/src/lightning/fabric/fabric.py", line 738, in save
    self._strategy.save_checkpoint(path=path, state=_unwrap_objects(state), filter=filter)
  File "/home/adrian/repositories/lightning/src/lightning/fabric/strategies/fsdp.py", line 495, in save_checkpoint
    converted = obj.state_dict()
  File "/home/adrian/.conda/envs/lightning/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1815, in state_dict
    self._save_to_state_dict(destination, prefix, keep_vars)
  File "/home/adrian/.conda/envs/lightning/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1722, in _save_to_state_dict
    hook(self, prefix, keep_vars)
  File "/home/adrian/.conda/envs/lightning/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/home/adrian/.conda/envs/lightning/lib/python3.10/site-packages/torch/distributed/fsdp/_state_dict_utils.py", line 669, in _pre_state_dict_hook
    _pre_state_dict_hook_fn[fsdp_state._state_dict_type](
  File "/home/adrian/.conda/envs/lightning/lib/python3.10/site-packages/torch/distributed/fsdp/_state_dict_utils.py", line 271, in _full_pre_state_dict_hook
    _common_unshard_pre_state_dict_hook(
  File "/home/adrian/.conda/envs/lightning/lib/python3.10/site-packages/torch/distributed/fsdp/_state_dict_utils.py", line 143, in _common_unshard_pre_state_dict_hook
    _enter_unshard_params_ctx(
  File "/home/adrian/.conda/envs/lightning/lib/python3.10/site-packages/torch/distributed/fsdp/_state_dict_utils.py", line 109, in _enter_unshard_params_ctx
    fsdp_state._unshard_params_ctx[module].__enter__()
  File "/home/adrian/.conda/envs/lightning/lib/python3.10/contextlib.py", line 135, in __enter__
    return next(self.gen)
  File "/home/adrian/.conda/envs/lightning/lib/python3.10/site-packages/torch/distributed/fsdp/_unshard_param_utils.py", line 171, in _unshard_fsdp_state_params
    _validate_unshard_params_args(
  File "/home/adrian/.conda/envs/lightning/lib/python3.10/site-packages/torch/distributed/fsdp/_unshard_param_utils.py", line 140, in _validate_unshard_params_args
    raise NotImplementedError(
NotImplementedError: offload_to_cpu=True and NO_SHARD is not supported yet
```

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


cc @borda @carmocca @justusschock @awaelchli