### PR TITLE
Extend FSDP guide with checkpointing 

### DIFF
--- a/docs/source-fabric/advanced/model_parallel/fsdp.rst
+++ b/docs/source-fabric/advanced/model_parallel/fsdp.rst
@@ -386,6 +386,8 @@ You can easily load checkpoints saved by Fabric to resume training:
     # model.load_state_dict(torch.load("path/to/checkpoint/file"))
 
 Fabric will automatically recognize whether the provided path contains a checkpoint saved with ``state_dict_type="full"`` or ``state_dict_type="sharded"``.
+Checkpoints saved with ``state_dict_type="full"`` can be loaded by all strategies, but sharded checkpoints can only be loaded by FSDP.
+Read :doc:`the checkpoints guide <../guide/checkpoints>` to explore more features.
 
 
 ----

--- a/docs/source-fabric/advanced/model_parallel/fsdp.rst
+++ b/docs/source-fabric/advanced/model_parallel/fsdp.rst
@@ -387,7 +387,7 @@ You can easily load checkpoints saved by Fabric to resume training:
 
 Fabric will automatically recognize whether the provided path contains a checkpoint saved with ``state_dict_type="full"`` or ``state_dict_type="sharded"``.
 Checkpoints saved with ``state_dict_type="full"`` can be loaded by all strategies, but sharded checkpoints can only be loaded by FSDP.
-Read :doc:`the checkpoints guide <../guide/checkpoints>` to explore more features.
+Read :doc:`the checkpoints guide <../guide/checkpoint>` to explore more features.
 
 
 ----

--- a/docs/source-fabric/advanced/model_parallel/fsdp.rst
+++ b/docs/source-fabric/advanced/model_parallel/fsdp.rst
@@ -387,7 +387,7 @@ You can easily load checkpoints saved by Fabric to resume training:
 
 Fabric will automatically recognize whether the provided path contains a checkpoint saved with ``state_dict_type="full"`` or ``state_dict_type="sharded"``.
 Checkpoints saved with ``state_dict_type="full"`` can be loaded by all strategies, but sharded checkpoints can only be loaded by FSDP.
-Read :doc:`the checkpoints guide <../guide/checkpoint>` to explore more features.
+Read :doc:`the checkpoints guide <../../guide/checkpoint>` to explore more features.
 
 
 ----

--- a/docs/source-pytorch/advanced/model_parallel/fsdp.rst
+++ b/docs/source-pytorch/advanced/model_parallel/fsdp.rst
@@ -359,7 +359,7 @@ Save a checkpoint
 *****************
 
 Since training large models can be very expensive, it is best practice to checkpoint the training state periodically in case it gets interrupted unexpectedly.
-Lightning saves a checkpoint every epoch by default, and there are :ref:`several ways to configure the checkpointing behavior further <checkpointing>`.
+Lightning saves a checkpoint every epoch by default, and there are :ref:`several settings to configure the checkpointing behavior in detail <checkpointing>`.
 
 .. code-block:: python
 
@@ -373,8 +373,8 @@ Lightning saves a checkpoint every epoch by default, and there are :ref:`several
     # DON'T do this (inefficient):
     # torch.save("path/to/checkpoint/file", model.state_dict())
 
-For single-machine training this is typically fine, but for larger models saving a checkpoint can become slow (minutes not seconds) or overflow CPU memory (OOM) depending on the system.
-To reduce memory peaks and speed up the saving to disk, set `state_dict_type="sharded"`:
+For single-machine training this typically works fine, but for larger models saving a checkpoint can become slow (minutes not seconds) or overflow CPU memory (OOM) depending on the system.
+To reduce memory peaks and speed up the saving to disk, set ``state_dict_type="sharded"``:
 
 .. code-block:: python
 

--- a/docs/source-pytorch/advanced/model_parallel/fsdp.rst
+++ b/docs/source-pytorch/advanced/model_parallel/fsdp.rst
@@ -421,7 +421,7 @@ You can easily :ref:`load checkpoints <checkpointing>` saved by Lightning to res
     trainer.fit(model, ckpt_path="path/to/checkpoint/file")
 
 
-Fabric will automatically recognize whether the provided path contains a checkpoint saved with ``state_dict_type="full"`` or ``state_dict_type="sharded"``.
+The Trainer will automatically recognize whether the provided path contains a checkpoint saved with ``state_dict_type="full"`` or ``state_dict_type="sharded"``.
 Checkpoints saved with ``state_dict_type="full"`` can be loaded by all strategies, but sharded checkpoints can only be loaded by FSDP.
 Read :ref:`the checkpoints guide <checkpointing>` to explore more features.
 

--- a/docs/source-pytorch/advanced/model_parallel/fsdp.rst
+++ b/docs/source-pytorch/advanced/model_parallel/fsdp.rst
@@ -359,8 +359,7 @@ Save a checkpoint
 *****************
 
 Since training large models can be very expensive, it is best practice to checkpoint the training state periodically in case it gets interrupted unexpectedly.
-Lightning saves a checkpoint every epoch by default, and further settings for when, how, and where the files get saved can be configured through
-the `ModelCheckpoint` callback"
+Lightning saves a checkpoint every epoch by default, and there are :ref:`several ways to configure the checkpointing behavior further <checkpointing>`.
 
 .. code-block:: python
 

--- a/docs/source-pytorch/advanced/model_parallel/fsdp.rst
+++ b/docs/source-pytorch/advanced/model_parallel/fsdp.rst
@@ -373,7 +373,19 @@ Lightning saves a checkpoint every epoch by default, and there are :ref:`several
     # DON'T do this (inefficient):
     # torch.save("path/to/checkpoint/file", model.state_dict())
 
-To reduce memory peaks and speed up the saving to disk, each process/GPU will save its own file into a folder at the given path by default.
+For single-machine training this is typically fine, but for larger models saving a checkpoint can become slow (minutes not seconds) or overflow CPU memory (OOM) depending on the system.
+To reduce memory peaks and speed up the saving to disk, set `state_dict_type="sharded"`:
+
+.. code-block:: python
+
+    # Default: Save a single, consolidated checkpoint file
+    strategy = FSDPStrategy(state_dict_type="full")
+
+    # Save individual files with state from each process
+    strategy = FSDPStrategy(state_dict_type="sharded")
+
+
+With this, each process/GPU will save its own file into a folder at the given path by default.
 The resulting checkpoint folder will have this structure:
 
 .. code-block:: text
@@ -384,17 +396,7 @@ The resulting checkpoint folder will have this structure:
     ├── __1_0.distcp
     └── meta.pt
 
-The “sharded” checkpoint format is the most efficient to save and load in Fabric.
-However, if you prefer to have a single consolidated file instead, you can configure this by setting the ``state_dict_type`` flag in the strategy:
-
-.. code-block:: python
-
-    # Default: Save individual files with state from each process
-    strategy = FSDPStrategy(state_dict_type="sharded")
-
-    # Save a single, consolidated checkpoint file
-    strategy = FSDPStrategy(state_dict_type="full")
-
+The “sharded” checkpoint format is the most efficient to save and load in Lightning.
 
 **Which checkpoint format should I use?**
 

--- a/docs/source-pytorch/advanced/model_parallel/fsdp.rst
+++ b/docs/source-pytorch/advanced/model_parallel/fsdp.rst
@@ -411,20 +411,19 @@ The “sharded” checkpoint format is the most efficient to save and load in Li
 Load a checkpoint
 *****************
 
-You can easily load checkpoints saved by Fabric to resume training:
+You can easily :ref:`load checkpoints <checkpointing>` saved by Lightning to resume training:
 
 .. code-block:: python
 
-    # 1. Define model, optimizer, and other training loop state
-    state = {"model": model, "optimizer": optimizer, "iter": iteration}
+    trainer = L.Trainer(...)
 
-    # 2. Load using Fabric's method
-    fabric.load("path/to/checkpoint/file", state)
+    # Restore the training progress, weights, and optimizer state
+    trainer.fit(model, ckpt_path="path/to/checkpoint/file")
 
-    # DON'T do this (inefficient):
-    # model.load_state_dict(torch.load("path/to/checkpoint/file"))
 
 Fabric will automatically recognize whether the provided path contains a checkpoint saved with ``state_dict_type="full"`` or ``state_dict_type="sharded"``.
+Checkpoints saved with ``state_dict_type="full"`` can be loaded by all strategies, but sharded checkpoints can only be loaded by FSDP.
+Read :ref:`the checkpoints guide <checkpointing>` to explore more features.
 
 
 ----


### PR DESCRIPTION
## What does this PR do?

Adds docs for the distributed checkpointing features added in  https://github.com/Lightning-AI/lightning/pull/18364 an d #18358.
The structure is borrowed from the equivalent guide in Fabric. The text had to be reorganized a bit because in Fabric, the defaults are different.



cc @borda @carmocca @justusschock @awaelchli