### PR TITLE
Fix typo in BasePredictionWriter documentation

### DIFF
--- a/docs/source-pytorch/deploy/production_basic.rst
+++ b/docs/source-pytorch/deploy/production_basic.rst
@@ -94,7 +94,7 @@ By using the predict step in Lightning you get free distributed inference using 
             torch.save(batch_indices, os.path.join(self.output_dir, f"batch_indices_{trainer.global_rank}.pt"))
 
 
-    # or you can set `writer_interval="batch"` and override `write_on_batch_end` to save
+    # or you can set `write_interval="batch"` and override `write_on_batch_end` to save
     # predictions at batch level
     pred_writer = CustomWriter(output_dir="pred_path", write_interval="epoch")
     trainer = Trainer(accelerator="gpu", strategy="ddp", devices=8, callbacks=[pred_writer])

--- a/src/lightning/pytorch/callbacks/prediction_writer.py
+++ b/src/lightning/pytorch/callbacks/prediction_writer.py
@@ -93,7 +93,7 @@ class BasePredictionWriter(Callback):
                 torch.save(batch_indices, os.path.join(self.output_dir, f"batch_indices_{trainer.global_rank}.pt"))
 
 
-        # or you can set `writer_interval="batch"` and override `write_on_batch_end` to save
+        # or you can set `write_interval="batch"` and override `write_on_batch_end` to save
         # predictions at batch level
         pred_writer = CustomWriter(output_dir="pred_path", write_interval="epoch")
         trainer = Trainer(accelerator="gpu", strategy="ddp", devices=8, callbacks=[pred_writer])


### PR DESCRIPTION
Documentation is corrected from `writer_interval="batch"` to `write_interval="batch"`, as the correct usage in the code is `write_interval`.