### PR TITLE
Update titles in FSDP docs

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -9,6 +9,7 @@ on:
   # it's important that the PR head SHA is checked out to run the changes
   pull_request_target:
     branches: ["master", "release/*"]
+    types: [opened, reopened, ready_for_review, synchronize]  # added `ready_for_review` since draft is skipped
     paths:
       - ".actions/*"
       - ".github/workflows/docs-build.yml"

--- a/docs/source-pytorch/accelerators/gpu.rst
+++ b/docs/source-pytorch/accelerators/gpu.rst
@@ -36,7 +36,7 @@ Accelerator: GPU training
 
 .. displayitem::
    :header: Advanced
-   :description: Train 1 trillion+ parameter models with these techniques.
+   :description: Train models with billions of parameters
    :col_css: col-md-4
    :button_link: gpu_advanced.html
    :height: 150

--- a/docs/source-pytorch/accelerators/gpu_advanced.rst
+++ b/docs/source-pytorch/accelerators/gpu_advanced.rst
@@ -19,7 +19,7 @@ For experts pushing the state-of-the-art in model development, Lightning offers 
         <div class="row">
 
 .. displayitem::
-   :header: Train 1 trillion+ parameter models
+   :header: Train models with billions of parameters
    :description:
    :col_css: col-md-4
    :button_link: ../advanced/model_parallel.html

--- a/docs/source-pytorch/advanced/model_parallel.rst
+++ b/docs/source-pytorch/advanced/model_parallel.rst
@@ -1,8 +1,8 @@
 .. _model-parallel:
 
-###########################################
-Training models with billions of parameters
-###########################################
+########################################
+Train models with billions of parameters
+########################################
 
 **Audience**: Users who want to train massive models of billions of parameters efficiently across multiple GPUs and machines.
 

--- a/docs/source-pytorch/common/index.rst
+++ b/docs/source-pytorch/common/index.rst
@@ -132,8 +132,8 @@ How-to Guides
     :height: 180
 
 .. displayitem::
-    :header: Train 1 trillion+ parameter models
-    :description: Scale GPU training to 1 trillion + parameter models
+    :header: Train models with billions of parameters
+    :description: Scale GPU training for models with billions of parameters
     :button_link: ../advanced/model_parallel.html
     :col_css: col-md-4
     :height: 180

--- a/docs/source-pytorch/common_usecases.rst
+++ b/docs/source-pytorch/common_usecases.rst
@@ -106,8 +106,8 @@ Customize and extend Lightning for things like custom hardware or distributed st
    :height: 100
 
 .. displayitem::
-   :header: Train 1 trillion+ parameter models
-   :description: Scale GPU training to 1 trillion + parameter models
+   :header: Train models with billions of parameters
+   :description: Scale GPU training to models with billions of parameters
    :col_css: col-md-12
    :button_link: advanced/model_parallel.html
    :height: 100

--- a/docs/source-pytorch/expertise_levels.rst
+++ b/docs/source-pytorch/expertise_levels.rst
@@ -215,7 +215,7 @@ Configure all aspects of Lightning for advanced usecases.
 
 .. displayitem::
    :header: Level 21: Train models with billions of parameters
-   :description: Scale to 1 trillion params on GPUs.
+   :description: Scale GPU training to models with billions of parameters
    :col_css: col-md-6
    :button_link: levels/advanced_level_22.html
    :height: 150

--- a/docs/source-pytorch/expertise_levels.rst
+++ b/docs/source-pytorch/expertise_levels.rst
@@ -214,7 +214,7 @@ Configure all aspects of Lightning for advanced usecases.
    :tag: advanced
 
 .. displayitem::
-   :header: Level 21: Reach 1 trillion parameters on GPUs
+   :header: Level 21: Train models with billions of parameters
    :description: Scale to 1 trillion params on GPUs.
    :col_css: col-md-6
    :button_link: levels/advanced_level_22.html

--- a/docs/source-pytorch/levels/advanced.rst
+++ b/docs/source-pytorch/levels/advanced.rst
@@ -70,7 +70,7 @@ Configure all aspects of Lightning for advanced usecases.
    :tag: advanced
 
 .. displayitem::
-   :header: Level 21: Reach 1 trillion parameters on GPUs
+   :header: Level 21: Train models with billions of parameters
    :description: Scale to 1 trillion params on GPUs.
    :col_css: col-md-6
    :button_link: advanced_level_22.html

--- a/docs/source-pytorch/levels/advanced.rst
+++ b/docs/source-pytorch/levels/advanced.rst
@@ -71,7 +71,7 @@ Configure all aspects of Lightning for advanced usecases.
 
 .. displayitem::
    :header: Level 21: Train models with billions of parameters
-   :description: Scale to 1 trillion params on GPUs.
+   :description: Scale GPU training to models with billions of parameters
    :col_css: col-md-6
    :button_link: advanced_level_22.html
    :height: 150

--- a/docs/source-pytorch/levels/advanced_level_22.rst
+++ b/docs/source-pytorch/levels/advanced_level_22.rst
@@ -1,10 +1,10 @@
 :orphan:
 
-#############################################
-Level 21: Reach 1 trillion parameters on GPUs
-#############################################
+##################################################
+Level 21: Train models with billions of parameters
+##################################################
 
-Scale to 1 trillion+ parameters with multiple distributed strategies.
+Scale to billions of parameters with multiple distributed strategies.
 
 ----
 
@@ -24,8 +24,8 @@ Scale to 1 trillion+ parameters with multiple distributed strategies.
    :tag: intermediate
 
 .. displayitem::
-   :header: Reach 1 trillion parameters on GPUs
-   :description: Scale to 1 trillion params on GPUs with FSDP and Deepspeed.
+   :header: Train models with billions of parameters
+   :description: Scale to billions of params on GPUs with FSDP or Deepspeed.
    :col_css: col-md-6
    :button_link: ../advanced/model_parallel.html
    :height: 150


### PR DESCRIPTION
## What does this PR do?

Makes the titles that point to the model-parallel docs consistent. Requested in TH.

cc @borda @awaelchli @carmocca