### PR TITLE
Improve error message for ddp unused parameters on Python 3.11

### DIFF
--- a/src/lightning/pytorch/utilities/exceptions.py
+++ b/src/lightning/pytorch/utilities/exceptions.py
@@ -34,10 +34,6 @@ class _TunerExitException(Exception):
 
 
 def _augment_message(exception: BaseException, pattern: str, new_message: str) -> None:
-    # Remove this when Python 3.11 becomes the minimum supported version
-    if not _PYTHON_GREATER_EQUAL_3_11_0:
-        exception.args = tuple(
-            new_message if isinstance(arg, str) and re.match(pattern, arg, re.DOTALL) else arg for arg in exception.args
-        )
-    elif any(re.match(pattern, message, re.DOTALL) for message in exception.args if isinstance(message, str)):
-        exception.add_note(new_message)
+    exception.args = tuple(
+        new_message if isinstance(arg, str) and re.match(pattern, arg, re.DOTALL) else arg for arg in exception.args
+    )

--- a/src/lightning/pytorch/utilities/exceptions.py
+++ b/src/lightning/pytorch/utilities/exceptions.py
@@ -14,7 +14,6 @@
 import re
 
 from lightning.fabric.utilities.exceptions import MisconfigurationException  # noqa: F401
-from lightning.pytorch.utilities.imports import _PYTHON_GREATER_EQUAL_3_11_0
 
 
 class SIGTERMException(SystemExit):


### PR DESCRIPTION
## What does this PR do?

If the user has unused parameters in their model and the `find_unused_parameters` flag is not set in the DDP strategy, we currently show this error:
```
It looks like your LightningModule has parameters that were not used in producing the loss returned by training_step. If this is intentional, you must enable the detection of unused parameters in DDP, either by setting the string value `strategy='ddp_find_unused_parameters_true'` or by setting the flag in the strategy with `strategy=DDPStrategy(find_unused_parameters=True)`.
```

But on Python 3.11, the user gets this huge wall of text:
```
RuntimeError: Expected to have finished reduction in the prior iteration before starting a new one. This error indicates that your module has parameters that were not used in producing loss. You can enable unused parameter detection by passing the keyword argument `find_unused_parameters=True` to `torch.nn.parallel.DistributedDataParallel`, and by 
making sure all `forward` function outputs participate in calculating loss. 
If you already have done the above, then the distributed data parallel module wasn't able to locate the output tensors in the return value of your module's `forward` function. Please include the loss function and the structure of the return value of `forward` of your module when reporting this issue (e.g. list, dict, iterable).
Parameter indices which did not receive grad for rank 1: 2 3
 In addition, you can set the environment variable TORCH_DISTRIBUTED_DEBUG to either INFO or DETAIL to print out information about which particular parameters did not receive gradient on this rank as part of this error


It looks like your LightningModule has parameters that were not used in producing the loss returned by training_step. If this is intentional, you must enable the detection of unused parameters in DDP, either by setting the string value `strategy='ddp_find_unused_parameters_true'` or by setting the flag in the strategy with `strategy=DDPStrategy(find_unused_parameters=True)`.
```
because the code we have sets the error message as a note to the original message. This PR reverts this decision and makes the error message more consumable, only showing Lightning's message.

Found this in #17822

Repro:
```py
import torch
from torch.utils.data import DataLoader, Dataset

from lightning.pytorch import LightningModule, Trainer


class RandomDataset(Dataset):
    def __init__(self, size, length):
        self.len = length
        self.data = torch.randn(length, size)

    def __getitem__(self, index):
        return self.data[index]

    def __len__(self):
        return self.len


class BoringModel(LightningModule):
    def __init__(self):
        super().__init__()
        self.layer = torch.nn.Linear(32, 2)

    def forward(self, x):
        return self.layer(x)

    def training_step(self, batch, batch_idx):
        loss = self(batch).sum()
        return {"loss": loss}

    def configure_optimizers(self):
        return torch.optim.SGD(self.layer.parameters(), lr=0.1)


class UnusedParametersModel(BoringModel):
    def __init__(self):
        super().__init__()
        self.intermediate_layer = torch.nn.Linear(32, 32)

    def training_step(self, batch, batch_idx):
        with torch.no_grad():
            batch = self.intermediate_layer(batch)
        return super().training_step(batch, batch_idx)


def run():
    train_data = DataLoader(RandomDataset(32, 64), batch_size=2)
    model = UnusedParametersModel()
    trainer = Trainer(accelerator="cpu", devices=2)
    trainer.fit(model, train_dataloaders=train_data)


if __name__ == "__main__":
    run()

```

cc @borda @justusschock @awaelchli