### PR TITLE
Remove unused `disallow_batch_sampler` argument

### DIFF
--- a/src/lightning/pytorch/utilities/data.py
+++ b/src/lightning/pytorch/utilities/data.py
@@ -243,71 +243,70 @@ def _dataloader_init_kwargs_resolve_sampler(
     batch_sampler = getattr(dataloader, "batch_sampler")
     batch_sampler_cls = type(batch_sampler)
 
-    if batch_sampler is not None:
-        if batch_sampler_cls is not BatchSampler or is_predicting:
-            if hasattr(batch_sampler, "__pl_saved_args"):
-                args = batch_sampler.__pl_saved_args
-                kwargs = batch_sampler.__pl_saved_kwargs
-                default_kwargs = batch_sampler.__pl_saved_default_kwargs
-                arg_names = batch_sampler.__pl_saved_arg_names
-
-                if is_predicting:
-                    success, args, kwargs = _replace_value_in_saved_args(
-                        "drop_last", False, args, kwargs, default_kwargs, arg_names
-                    )
-                    if not success:
-                        rank_zero_warn(
-                            f"Trying to inject `drop_last=False` into batch sampler since you are predicting, however "
-                            f"it seems the class `{batch_sampler_cls.__qualname__}` does not support it. "
-                            "Your predictions might be incomplete. To mitigate this, expose `drop_last` in "
-                            "the `__init__` method of your custom class."
-                        )
-
-                success, args, kwargs = _replace_value_in_saved_args(
-                    "sampler", sampler, args, kwargs, default_kwargs, arg_names
-                )
-                if not success:
-                    raise TypeError(
-                        "Trying to inject a modified sampler into the batch sampler; however, it seems the class "
-                        f"`{batch_sampler_cls.__qualname__}` does not have an argument called `sampler.` To mitigate "
-                        "this, expose an argument `sampler` in the `__init__` method of your custom class."
-                    )
-
-                batch_sampler = _reinstantiate_wrapped_cls(batch_sampler, *args, **kwargs)
-            else:
-                try:
-                    batch_sampler = batch_sampler_cls(
-                        sampler,
-                        batch_size=batch_sampler.batch_size,
-                        drop_last=(False if is_predicting else batch_sampler.drop_last),
-                    )
-                except TypeError as ex:
-                    import re
-
-                    match = re.match(r".*__init__\(\) (got multiple values)|(missing \d required)", str(ex))
-                    if not match:
-                        # an unexpected `TypeError`, continue failure
-                        raise
-
-                    # There could either be too few or too many arguments. Customizing the message based on this doesn't
-                    # make much sense since our MisconfigurationException is going to be raised from the original one.
-                    raise MisconfigurationException(
-                        "We tried to re-instantiate your custom batch sampler and failed. "
-                        "To mitigate this, either follow the API of `BatchSampler` or instantiate "
-                        "your custom batch sampler inside `*_dataloader` hooks of your module."
-                    ) from ex
+    if batch_sampler is not None and (batch_sampler_cls is not BatchSampler or is_predicting):
+        if hasattr(batch_sampler, "__pl_saved_args"):
+            args = batch_sampler.__pl_saved_args
+            kwargs = batch_sampler.__pl_saved_kwargs
+            default_kwargs = batch_sampler.__pl_saved_default_kwargs
+            arg_names = batch_sampler.__pl_saved_arg_names
 
             if is_predicting:
-                batch_sampler = _IndexBatchSamplerWrapper(batch_sampler)
+                success, args, kwargs = _replace_value_in_saved_args(
+                    "drop_last", False, args, kwargs, default_kwargs, arg_names
+                )
+                if not success:
+                    rank_zero_warn(
+                        f"Trying to inject `drop_last=False` into batch sampler since you are predicting, however "
+                        f"it seems the class `{batch_sampler_cls.__qualname__}` does not support it. "
+                        "Your predictions might be incomplete. To mitigate this, expose `drop_last` in "
+                        "the `__init__` method of your custom class."
+                    )
 
-            # batch_sampler option is mutually exclusive with batch_size, shuffle, sampler, and drop_last
-            return {
-                "sampler": None,
-                "shuffle": False,
-                "batch_sampler": batch_sampler,
-                "batch_size": 1,
-                "drop_last": False,
-            }
+            success, args, kwargs = _replace_value_in_saved_args(
+                "sampler", sampler, args, kwargs, default_kwargs, arg_names
+            )
+            if not success:
+                raise TypeError(
+                    "Trying to inject a modified sampler into the batch sampler; however, it seems the class "
+                    f"`{batch_sampler_cls.__qualname__}` does not have an argument called `sampler.` To mitigate "
+                    "this, expose an argument `sampler` in the `__init__` method of your custom class."
+                )
+
+            batch_sampler = _reinstantiate_wrapped_cls(batch_sampler, *args, **kwargs)
+        else:
+            try:
+                batch_sampler = batch_sampler_cls(
+                    sampler,
+                    batch_size=batch_sampler.batch_size,
+                    drop_last=(False if is_predicting else batch_sampler.drop_last),
+                )
+            except TypeError as ex:
+                import re
+
+                match = re.match(r".*__init__\(\) (got multiple values)|(missing \d required)", str(ex))
+                if not match:
+                    # an unexpected `TypeError`, continue failure
+                    raise
+
+                # There could either be too few or too many arguments. Customizing the message based on this doesn't
+                # make much sense since our MisconfigurationException is going to be raised from the original one.
+                raise MisconfigurationException(
+                    "We tried to re-instantiate your custom batch sampler and failed. "
+                    "To mitigate this, either follow the API of `BatchSampler` or instantiate "
+                    "your custom batch sampler inside `*_dataloader` hooks of your module."
+                ) from ex
+
+        if is_predicting:
+            batch_sampler = _IndexBatchSamplerWrapper(batch_sampler)
+
+        # batch_sampler option is mutually exclusive with batch_size, shuffle, sampler, and drop_last
+        return {
+            "sampler": None,
+            "shuffle": False,
+            "batch_sampler": batch_sampler,
+            "batch_size": 1,
+            "drop_last": False,
+        }
 
     return {"sampler": sampler, "shuffle": False, "batch_sampler": None}
 

--- a/src/lightning/pytorch/utilities/data.py
+++ b/src/lightning/pytorch/utilities/data.py
@@ -137,7 +137,6 @@ def _get_dataloader_init_args_and_kwargs(
     dataloader: DataLoader,
     sampler: Union[Sampler, Iterable],
     mode: Optional[RunningStage] = None,
-    disallow_batch_sampler: bool = False,
 ) -> Tuple[Tuple[Any], Dict[str, Any]]:
     if not isinstance(dataloader, DataLoader):
         raise ValueError(f"The dataloader {dataloader} needs to subclass `torch.utils.data.DataLoader`")
@@ -189,7 +188,7 @@ def _get_dataloader_init_args_and_kwargs(
         dl_kwargs["batch_sampler"] = None
         dl_kwargs["sampler"] = None
     else:
-        dl_kwargs.update(_dataloader_init_kwargs_resolve_sampler(dataloader, sampler, mode, disallow_batch_sampler))
+        dl_kwargs.update(_dataloader_init_kwargs_resolve_sampler(dataloader, sampler, mode))
 
     required_args = {
         p.name
@@ -232,7 +231,6 @@ def _dataloader_init_kwargs_resolve_sampler(
     dataloader: DataLoader,
     sampler: Union[Sampler, Iterable],
     mode: Optional[RunningStage] = None,
-    disallow_batch_sampler: bool = False,
 ) -> Dict[str, Any]:
     """This function is used to handle the sampler, batch_sampler arguments associated within a DataLoader for its re-
     instantiation.
@@ -240,27 +238,13 @@ def _dataloader_init_kwargs_resolve_sampler(
     If the dataloader is being used for prediction, the sampler will be wrapped into an `_IndexBatchSamplerWrapper`, so
     Lightning can keep track of its indices.
 
-    If there are multiple devices in IPU mode, it is necessary to disallow BatchSampler that isn't instantiated
-    automatically, since `poptorch.DataLoader` will try to increase the batch_size
-
     """
     is_predicting = mode == RunningStage.PREDICTING
     batch_sampler = getattr(dataloader, "batch_sampler")
     batch_sampler_cls = type(batch_sampler)
 
     if batch_sampler is not None:
-        if disallow_batch_sampler:
-            # Check that we don't have a PyTorch default batch sampler that was instantiated in DataLoader __init__
-            if not (
-                batch_sampler_cls is BatchSampler
-                and batch_sampler.sampler == sampler
-                and dataloader.batch_size == batch_sampler.batch_size
-            ):
-                raise MisconfigurationException(
-                    "It is not possible to have a batch sampler in your dataloader, "
-                    "when running on multiple IPU devices."
-                )
-        elif batch_sampler_cls is not BatchSampler or is_predicting:
+        if batch_sampler_cls is not BatchSampler or is_predicting:
             if hasattr(batch_sampler, "__pl_saved_args"):
                 args = batch_sampler.__pl_saved_args
                 kwargs = batch_sampler.__pl_saved_kwargs

--- a/tests/tests_fabric/utilities/test_data.py
+++ b/tests/tests_fabric/utilities/test_data.py
@@ -6,10 +6,9 @@ import numpy as np
 import pytest
 import torch
 from torch import Tensor
-from torch.utils.data import BatchSampler, DataLoader, RandomSampler, SequentialSampler
+from torch.utils.data import BatchSampler, DataLoader, RandomSampler
 
 from lightning.fabric.utilities.data import (
-    _dataloader_init_kwargs_resolve_sampler,
     _get_dataloader_init_args_and_kwargs,
     _replace_dunder_methods,
     _replace_value_in_saved_args,

--- a/tests/tests_fabric/utilities/test_data.py
+++ b/tests/tests_fabric/utilities/test_data.py
@@ -479,24 +479,7 @@ def test_custom_batch_sampler_no_sampler():
 
     # Assert that error is raised
     with pytest.raises(TypeError, match="sampler into the batch sampler"):
-        dataloader = _update_dataloader(dataloader, dataloader.sampler)
-
-
-def test_dataloader_disallow_batch_sampler():
-    dataset = RandomDataset(5, 100)
-    dataloader = DataLoader(dataset, batch_size=10)
-
-    # This should not raise
-    _dataloader_init_kwargs_resolve_sampler(dataloader, dataloader.sampler, disallow_batch_sampler=True)
-
-    dataset = RandomDataset(5, 100)
-    sampler = SequentialSampler(dataset)
-    batch_sampler = BatchSampler(sampler, batch_size=10, drop_last=False)
-    dataloader = DataLoader(dataset, batch_sampler=batch_sampler)
-
-    # this should raise - using batch sampler, that was not automatically instantiated by DataLoader
-    with pytest.raises(MisconfigurationException, match="when running on multiple IPU devices"):
-        _dataloader_init_kwargs_resolve_sampler(dataloader, dataloader.sampler, disallow_batch_sampler=True)
+        _ = _update_dataloader(dataloader, dataloader.sampler)
 
 
 def test_dataloader_kwargs_replacement_with_iterable_dataset():

--- a/tests/tests_pytorch/utilities/test_data.py
+++ b/tests/tests_pytorch/utilities/test_data.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 from lightning_utilities.test.warning import no_warning_call
 from torch import Tensor
-from torch.utils.data import BatchSampler, DataLoader, RandomSampler, SequentialSampler
+from torch.utils.data import BatchSampler, DataLoader, RandomSampler
 
 from lightning.fabric.utilities.data import _replace_dunder_methods
 from lightning.pytorch import Trainer
@@ -13,7 +13,6 @@ from lightning.pytorch.demos.boring_classes import RandomDataset, RandomIterable
 from lightning.pytorch.overrides.distributed import _IndexBatchSamplerWrapper
 from lightning.pytorch.trainer.states import RunningStage
 from lightning.pytorch.utilities.data import (
-    _dataloader_init_kwargs_resolve_sampler,
     _get_dataloader_init_args_and_kwargs,
     _update_dataloader,
     extract_batch_size,

--- a/tests/tests_pytorch/utilities/test_data.py
+++ b/tests/tests_pytorch/utilities/test_data.py
@@ -239,20 +239,7 @@ def test_custom_batch_sampler_no_sampler():
 
     # Assert that error is raised
     with pytest.raises(TypeError, match="sampler into the batch sampler"):
-        dataloader = _update_dataloader(dataloader, dataloader.sampler, mode=RunningStage.PREDICTING)
-
-
-def test_dataloader_disallow_batch_sampler():
-    dataset = RandomDataset(5, 100)
-    dataloader = DataLoader(dataset, batch_size=10)
-
-    # This should not raise
-    _dataloader_init_kwargs_resolve_sampler(dataloader, dataloader.sampler, disallow_batch_sampler=True)
-
-    dataset = RandomDataset(5, 100)
-    sampler = SequentialSampler(dataset)
-    batch_sampler = BatchSampler(sampler, batch_size=10, drop_last=False)
-    dataloader = DataLoader(dataset, batch_sampler=batch_sampler)
+        _ = _update_dataloader(dataloader, dataloader.sampler, mode=RunningStage.PREDICTING)
 
 
 @pytest.mark.parametrize("mode", [RunningStage.TRAINING, RunningStage.PREDICTING, RunningStage.TESTING])


### PR DESCRIPTION
## What does this PR do?

This PR removes an internal argument `disallow_batch_sampler` as it is unused within lightning and also unused by the unmaintained https://github.com/Lightning-AI/lightning-Graphcore (which was originally in Lightning). 

The argument is defined on internal protected API, there is no breaking change.



cc @borda @justusschock @awaelchli @carmocca