### PR TITLE
Avoid expensive `iter()` call to dataloader in dataloader checks

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -244,6 +244,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed setting the tracking uri in `MLFlowLogger` for logging artifacts to the MLFlow server ([#18395](https://github.com/Lightning-AI/lightning/pull/18395))
 
 
+- Fixed redundant `iter()` call to dataloader when checking dataloading configuration ([#18415](https://github.com/Lightning-AI/lightning/pull/18415))
+
+
 ## [2.0.5] - 2023-07-07
 
 ### Fixed

--- a/src/lightning/pytorch/trainer/connectors/data_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/data_connector.py
@@ -393,6 +393,10 @@ def _check_dataloader_iterable(
     source: _DataLoaderSource,
     trainer_fn: TrainerFn,
 ) -> None:
+    if isinstance(dataloader, DataLoader):
+        # Fast path: `torch.utils.data.DataLoader` is always iterable, calling iter() would be expensive
+        return
+
     try:
         iter(dataloader)  # type: ignore[call-overload]
     except TypeError:

--- a/tests/tests_pytorch/loops/test_loops.py
+++ b/tests/tests_pytorch/loops/test_loops.py
@@ -818,8 +818,6 @@ def test_workers_are_shutdown(tmpdir, should_fail, persistent_workers):
         expected = [trainer.current_epoch, trainer.current_epoch]  # once epoch end, once on teardown
     elif should_fail:
         expected = [
-            # iterable check
-            0,
             # epoch ends
             1,
             # teardown
@@ -827,8 +825,6 @@ def test_workers_are_shutdown(tmpdir, should_fail, persistent_workers):
         ]
     else:
         expected = [
-            # iterable check
-            0,
             # epoch ends
             1,
             2,
@@ -843,8 +839,6 @@ def test_workers_are_shutdown(tmpdir, should_fail, persistent_workers):
         expected = [
             # sanity check
             0,
-            # iterable check
-            0,
             # epoch ends
             0,
             1,
@@ -852,8 +846,6 @@ def test_workers_are_shutdown(tmpdir, should_fail, persistent_workers):
     else:
         expected = [
             # sanity check
-            0,
-            # iterable check
             0,
             # epoch ends
             0,

--- a/tests/tests_pytorch/trainer/connectors/test_data_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_data_connector.py
@@ -26,7 +26,8 @@ from lightning.fabric.utilities.distributed import DistributedSamplerWrapper
 from lightning.fabric.utilities.warnings import PossibleUserWarning
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringDataModule, BoringModel, RandomDataset
-from lightning.pytorch.trainer.connectors.data_connector import _DataHookSelector, _DataLoaderSource, warning_cache
+from lightning.pytorch.trainer.connectors.data_connector import _DataHookSelector, _DataLoaderSource, warning_cache, \
+    _check_dataloader_iterable
 from lightning.pytorch.trainer.states import RunningStage, TrainerFn
 from lightning.pytorch.utilities.combined_loader import CombinedLoader
 from lightning.pytorch.utilities.data import _update_dataloader
@@ -643,3 +644,17 @@ def test_non_iterables_raise(tmp_path, trainer_fn_name, dataloader_name, stage, 
     setattr(model, dl_method, lambda: dataloader)
     with pytest.raises(TypeError, match=f"invalid dataloader was returned from `BoringModel.{dl_method}"):
         trainer_fn(model)
+
+
+def test_iterable_check_on_known_iterators():
+    """Test that we only call the `iter()` on the dataloader object if it isn't a known type."""
+    iterable = Mock()
+    iterable.__iter__ = Mock(return_value=iter(range(3)))
+    _check_dataloader_iterable(iterable, Mock(), Mock())
+    iterable.__iter__.assert_called_once()
+
+    # If it's a datalaoder, we don't call the expensive `__iter__` method
+    dataloader = Mock(spec=DataLoader)
+    dataloader.__iter__ = Mock()
+    _check_dataloader_iterable(dataloader, Mock(), Mock())
+    dataloader.__iter__.assert_not_called()

--- a/tests/tests_pytorch/trainer/connectors/test_data_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_data_connector.py
@@ -26,8 +26,12 @@ from lightning.fabric.utilities.distributed import DistributedSamplerWrapper
 from lightning.fabric.utilities.warnings import PossibleUserWarning
 from lightning.pytorch import Trainer
 from lightning.pytorch.demos.boring_classes import BoringDataModule, BoringModel, RandomDataset
-from lightning.pytorch.trainer.connectors.data_connector import _DataHookSelector, _DataLoaderSource, warning_cache, \
-    _check_dataloader_iterable
+from lightning.pytorch.trainer.connectors.data_connector import (
+    _check_dataloader_iterable,
+    _DataHookSelector,
+    _DataLoaderSource,
+    warning_cache,
+)
 from lightning.pytorch.trainer.states import RunningStage, TrainerFn
 from lightning.pytorch.utilities.combined_loader import CombinedLoader
 from lightning.pytorch.utilities.data import _update_dataloader


### PR DESCRIPTION
## What does this PR do?

Fixes #18414
Minor improvement on #17007
This only covers the case when the dataloader is not a combined loader.

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


cc @justusschock @awaelchli @borda