### PR TITLE
Add dedicated docs page for init-module

### DIFF
--- a/docs/source-fabric/advanced/model_init.rst
+++ b/docs/source-fabric/advanced/model_init.rst
@@ -29,8 +29,8 @@ To speed up initialization, you can force PyTorch to create the model directly o
 
 The larger the model, the more noticeable is the impact on
 
-- speed: avoids redundant transfer of model parameters from CPU to device, avoids redundant casting from float32 to half precision
-- memory: reduced peak memory usage since model parameters are never stored in float32
+- **speed:** avoids redundant transfer of model parameters from CPU to device, avoids redundant casting from float32 to half precision
+- **memory:** reduced peak memory usage since model parameters are never stored in float32
 
 
 ----

--- a/docs/source-fabric/advanced/model_init.rst
+++ b/docs/source-fabric/advanced/model_init.rst
@@ -53,6 +53,11 @@ When loading a model from a checkpoint, for example when fine-tuning, set ``empt
     model.load_state_dict(checkpoint["state_dict"])
 
 
+.. warning::
+    This is safe if you are loading a checkpoint that includes all parameters in the model.
+    If you are loading a partial checkpoint (``strict=False``), you may end up with a subset of parameters that have uninitialized weights, unless you handle them accordingly.
+
+
 ----
 
 
@@ -72,4 +77,4 @@ When training sharded models with :doc:`FSDP <model_parallel/fsdp>` or DeepSpeed
 
 .. note::
     Empty-init is experimental and the behavior may change in the future.
-    For FSDP, it is required that all user-defined modules that manage parameters implement a ``reset_parameters()`` method (all PyTorch built-in modules have this too).
+    For FSDP on PyTorch 2.1+, it is required that all user-defined modules that manage parameters implement a ``reset_parameters()`` method (all PyTorch built-in modules have this too).

--- a/docs/source-fabric/advanced/model_init.rst
+++ b/docs/source-fabric/advanced/model_init.rst
@@ -1,0 +1,75 @@
+:orphan:
+
+.. _model_init:
+
+########################
+Efficient initialization
+########################
+
+Here are common use cases where you should use :meth:`~lightning.fabric.fabric.Fabric.init_module` to avoid major speed and memory bottlenecks when initializing your model.
+
+
+----
+
+
+**************
+Half-precision
+**************
+
+Instantiating a ``nn.Module`` in PyTorch creates all parameters on CPU in float32 precision by default.
+To speed up initialization, you can force PyTorch to create the model directly on the target device and with the desired precision without changing your model code.
+
+.. code-block:: python
+
+    fabric = Fabric(accelerator="cuda", precision="16-true")
+
+    with fabric.init_module():
+        # models created here will be on GPU and in float16
+        model = MyModel()
+
+The larger the model, the more noticeable is the impact on
+
+- speed: avoids redundant transfer of model parameters from CPU to device, avoids redundant casting from float32 to half precision
+- memory: reduced peak memory usage since model parameters are never stored in float32
+
+
+----
+
+
+***********************************************
+Loading checkpoints for inference or finetuning
+***********************************************
+
+When loading a model from a checkpoint, for example when fine-tuning, set ``empty_init=True`` to avoid expensive and redundant memory initialization:
+
+.. code-block:: python
+
+    with fabric.init_module(empty_init=True):
+        # creation of the model is fast
+        # and depending on the strategy allocates no memory, or uninitialized memory
+        model = MyModel()
+
+    # weights get loaded into the model
+    model.load_state_dict(checkpoint["state_dict"])
+
+
+----
+
+
+********************************************
+Model-parallel training (FSDP and DeepSpeed)
+********************************************
+
+When training sharded models with :doc:`FSDP <model_parallel/fsdp>` or DeepSpeed, using :meth:`~lightning.fabric.fabric.Fabric.init_module` is necessary in most cases because otherwise model initialization gets very slow (minutes) or (and that's more likely) you run out of CPU memory due to the size of the model.
+
+.. code-block:: python
+
+    # Recommended for FSDP and DeepSpeed
+    with fabric.init_module(empty_init=True):
+        model = GPT3()  # parameters are placed on the meta-device
+
+    model = fabric.setup(model)  # parameters get sharded and initialized at once
+
+.. note::
+    Empty-init is experimental and the behavior may change in the future.
+    For FSDP, it is required that all user-defined modules that manage parameters implement a ``reset_parameters()`` method (all PyTorch built-in modules have this too).

--- a/docs/source-fabric/advanced/model_parallel/fsdp.rst
+++ b/docs/source-fabric/advanced/model_parallel/fsdp.rst
@@ -84,9 +84,11 @@ Here is a full code example:
 
     # 1B parameters
     model = Transformer(vocab_size=dataset.vocab_size, nlayers=32, nhid=4096, ninp=1024, nhead=64)
-    optimizer = torch.optim.Adam(model.parameters(), lr=0.1)
 
-    model, optimizer = fabric.setup(model, optimizer)
+    model = fabric.setup(model)
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.1)
+    optimizer = fabric.setup_optimizers(optimizer)
+
 
     for i in range(10):
         input, target = fabric.to_device(dataset[i])
@@ -187,6 +189,17 @@ After:
     # Fast: Creates the model on the GPU directly
     with fabric.init_module():
         model = Transformer(vocab_size=dataset.vocab_size)
+
+For FSDP specifically, we recommend setting ``empty_init=True`` as it will allow you to initialize even larger models:
+
+.. code-block:: python
+
+    # Recommended for FSDP:
+    with fabric.init_module(empty_init=True):
+        model = Transformer(vocab_size=dataset.vocab_size)
+
+Empty-init creates fake parameters that don't allocate any memory, their actual initialization gets delayed until ``Fabric.setup()`` where FSDP will shard and recreate the real parameters.
+For more use cases of ``empty_init=True`` outside of FSDP, read the guide on :doc:`model initialization <../model_init>`.
 
 
 ----

--- a/docs/source-fabric/advanced/model_parallel/fsdp.rst
+++ b/docs/source-fabric/advanced/model_parallel/fsdp.rst
@@ -190,14 +190,11 @@ After:
     with fabric.init_module():
         model = Transformer(vocab_size=dataset.vocab_size)
 
-For FSDP specifically, we recommend setting ``empty_init=True`` as it will allow you to initialize even larger models:
-
-.. code-block:: python
-
     # Recommended for FSDP:
     with fabric.init_module(empty_init=True):
         model = Transformer(vocab_size=dataset.vocab_size)
 
+For FSDP specifically, we recommend setting ``empty_init=True`` as it will allow you to initialize even larger models.
 Empty-init creates fake parameters that don't allocate any memory, their actual initialization gets delayed until ``Fabric.setup()`` where FSDP will shard and recreate the real parameters.
 For more use cases of ``empty_init=True`` outside of FSDP, read the guide on :doc:`model initialization <../model_init>`.
 

--- a/docs/source-fabric/api/fabric_methods.rst
+++ b/docs/source-fabric/api/fabric_methods.rst
@@ -157,18 +157,7 @@ This eliminates the waiting time to transfer the model parameters from the CPU t
 For strategies that handle large sharded models (FSDP, DeepSpeed), the :meth:`~lightning.fabric.fabric.Fabric.init_module` method will allocate the model parameters on the meta device first before sharding.
 This makes it possible to work with models that are larger than the memory of a single device.
 
-When loading a model from a checkpoint, for example when fine-tuning, set `empty_init=True` to avoid expensive
-and redundant memory initialization:
-
-.. code-block:: python
-
-    with fabric.init_module(empty_init=True):
-        # creation of the model is very fast
-        # and depending on the strategy allocates no memory, or uninitialized memory
-        model = MyModel()
-
-    # weights get loaded into the model
-    model.load_state_dict(checkpoint["state_dict"])
+See also: :doc:`../advanced/model_init`
 
 
 autocast

--- a/docs/source-fabric/examples/index.rst
+++ b/docs/source-fabric/examples/index.rst
@@ -41,8 +41,8 @@ Examples
 
 .. displayitem::
     :header: Large Language Models
-    :description: Pre-train a GPT-2 language model on OpenWebText data
-    :button_link: https://github.com/Lightning-AI/nanoGPT/blob/master/train_fabric.py
+    :description: Pre-train a GPT language model on OpenWebText data
+    :button_link: https://github.com/Lightning-AI/lit-gpt/blob/main/pretrain/openwebtext.py
     :col_css: col-md-4
     :height: 150
     :tag: advanced

--- a/docs/source-fabric/fundamentals/precision.rst
+++ b/docs/source-fabric/fundamentals/precision.rst
@@ -201,6 +201,9 @@ Tip: For faster initialization, you can create model parameters with the desired
     model = fabric.setup(model)
 
 
+See also: :doc:`../advanced/model_init`
+
+
 ----
 
 

--- a/docs/source-fabric/glossary/index.rst
+++ b/docs/source-fabric/glossary/index.rst
@@ -84,6 +84,11 @@ Glossary
     :col_css: col-md-4
 
 .. displayitem::
+    :header: Initialization
+    :button_link: ../advanced/model_init.html
+    :col_css: col-md-4
+
+.. displayitem::
     :header: Jypyter
     :button_link: ../launch/notebooks.html
     :col_css: col-md-4

--- a/docs/source-fabric/guide/checkpoint.rst
+++ b/docs/source-fabric/guide/checkpoint.rst
@@ -75,6 +75,8 @@ If you want to be in complete control of how states get restored, you can omit p
     optimizer.load_state_dict(full_checkpoint["optimizer"])
     ...
 
+See also: :doc:`../advanced/model_init`
+
 
 From a raw state-dict file
 ==========================

--- a/docs/source-fabric/guide/index.rst
+++ b/docs/source-fabric/guide/index.rst
@@ -165,6 +165,14 @@ Advanced Topics
     :height: 160
     :tag: advanced
 
+.. displayitem::
+    :header: Initialize models efficiently
+    :description: Reduce the time and peak memory usage for model initialization
+    :button_link: ../advanced/model_init.html
+    :col_css: col-md-4
+    :height: 160
+    :tag: advanced
+
 .. raw:: html
 
         </div>

--- a/docs/source-pytorch/advanced/model_init.rst
+++ b/docs/source-pytorch/advanced/model_init.rst
@@ -47,7 +47,7 @@ When loading a model from a checkpoint, for example when fine-tuning, set ``empt
     with trainer.init_module(empty_init=True):
         # creation of the model is fast
         # and depending on the strategy allocates no memory, or uninitialized memory
-        model = MyLightningModule.load_from_checkpoint("my/checkpoint/path.ckpt)
+        model = MyLightningModule.load_from_checkpoint("my/checkpoint/path.ckpt")
 
     trainer.fit(model)
 

--- a/docs/source-pytorch/advanced/model_init.rst
+++ b/docs/source-pytorch/advanced/model_init.rst
@@ -29,8 +29,8 @@ To speed up initialization, you can force PyTorch to create the model directly o
 
 The larger the model, the more noticeable is the impact on
 
-- speed: avoids redundant transfer of model parameters from CPU to device, avoids redundant casting from float32 to half precision
-- memory: reduced peak memory usage since model parameters are never stored in float32
+- **speed:** avoids redundant transfer of model parameters from CPU to device, avoids redundant casting from float32 to half precision
+- **memory:** reduced peak memory usage since model parameters are never stored in float32
 
 
 ----

--- a/docs/source-pytorch/advanced/model_init.rst
+++ b/docs/source-pytorch/advanced/model_init.rst
@@ -21,8 +21,7 @@ To speed up initialization, you can force PyTorch to create the model directly o
 
 This eliminates the waiting time to transfer the model parameters from the CPU to the device.
 
-When loading a model from a checkpoint, for example when fine-tuning, set `empty_init=True` to avoid expensive
-and redundant memory initialization:
+When loading a model from a checkpoint, for example when fine-tuning, set `empty_init=True` to avoid expensive and redundant memory initialization:
 
 .. code-block:: python
 
@@ -32,8 +31,7 @@ and redundant memory initialization:
 
     trainer.fit(model)
 
-For strategies that handle large sharded models (:ref:`FSDP <fully-sharded-training>`, :ref:`DeepSpeed <deepspeed_advanced>`), the :meth:`~lightning.pytorch.trainer.trainer.Trainer.init_module`
-should not be used, instead override the :meth:`~lightning.pytorch.core.hooks.ModelHooks.configure_model` hook:
+For strategies that handle large sharded models (:ref:`FSDP <fully-sharded-training>`, :ref:`DeepSpeed <deepspeed_advanced>`), the :meth:`~lightning.pytorch.trainer.trainer.Trainer.init_module` should not be used, instead override the :meth:`~lightning.pytorch.core.hooks.ModelHooks.configure_model` hook:
 
 .. code-block:: python
 

--- a/docs/source-pytorch/advanced/model_init.rst
+++ b/docs/source-pytorch/advanced/model_init.rst
@@ -52,6 +52,11 @@ When loading a model from a checkpoint, for example when fine-tuning, set ``empt
     trainer.fit(model)
 
 
+.. warning::
+    This is safe if you are loading a checkpoint that includes all parameters in the model.
+    If you are loading a partial checkpoint (``strict=False``), you may end up with a subset of parameters that have uninitialized weights, unless you handle them accordingly.
+
+
 ----
 
 

--- a/docs/source-pytorch/advanced/model_parallel/deepspeed.rst
+++ b/docs/source-pytorch/advanced/model_parallel/deepspeed.rst
@@ -248,6 +248,9 @@ This reduces the time taken to initialize very large models, as well as ensure w
     trainer.predict()
 
 
+See also: See also: :doc:`../model_init`
+
+
 .. _deepspeed-zero-stage-3-offload:
 
 DeepSpeed ZeRO Stage 3 Offload

--- a/docs/source-pytorch/common/index.rst
+++ b/docs/source-pytorch/common/index.rst
@@ -23,6 +23,8 @@
    Use a pretrained model <../advanced/pretrained>
    ../data/data
    ../model/own_your_loop
+   ../advanced/model_init
+
 
 #############
 How-to Guides
@@ -128,6 +130,13 @@ How-to Guides
     :header: Save memory with half-precision
     :description: Use precision techniques to train faster and save memory
     :button_link: ../common/precision.html
+    :col_css: col-md-4
+    :height: 180
+
+.. displayitem::
+    :header: Set up large models efficiently
+    :description: Avoid memory peaks and speed up the initialization of large models
+    :button_link: ../advanced/model_init.html
     :col_css: col-md-4
     :height: 180
 

--- a/docs/source-pytorch/common/precision_basic.rst
+++ b/docs/source-pytorch/common/precision_basic.rst
@@ -83,7 +83,7 @@ is properly selected.
 
 .. code-block:: python
 
-    fabric = Trainer(precision="64-true")
+    trainer = Trainer(precision="64-true")
 
     # init the model directly on the device and with parameters in full-precision
     with trainer.init_module():

--- a/docs/source-pytorch/common/precision_intermediate.rst
+++ b/docs/source-pytorch/common/precision_intermediate.rst
@@ -133,6 +133,9 @@ Tip: For faster initialization, you can create model parameters with the desired
     trainer.fit(model)
 
 
+See also: :doc:`../advanced/model_init`
+
+
 ----
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes #18083 
Fixes #18216

Adds a standalone documentation guide for `init_module` and its use cases.
Covered for both Fabric and Trainer.
Linked in pages where appropriate.

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


cc @borda @carmocca @justusschock @awaelchli