### PR TITLE
Avoid using the batch idx for the logger connector state

### DIFF
--- a/src/lightning/pytorch/loops/evaluation_loop.py
+++ b/src/lightning/pytorch/loops/evaluation_loop.py
@@ -342,8 +342,6 @@ class _EvaluationLoop(_Loop):
         """Runs the ``on_{validation/test}_epoch_start`` hooks."""
         trainer = self.trainer
 
-        trainer._logger_connector.on_epoch_start()
-
         hook_name = "on_test_epoch_start" if trainer.testing else "on_validation_epoch_start"
         call._call_callback_hooks(trainer, hook_name, *args, **kwargs)
         call._call_lightning_module_hook(trainer, hook_name, *args, **kwargs)
@@ -392,7 +390,9 @@ class _EvaluationLoop(_Loop):
 
         self.batch_progress.increment_ready()
 
-        trainer._logger_connector.on_batch_start(**step_kwargs)
+        trainer._logger_connector.on_batch_start(
+            batch, dataloader_idx if self._is_sequential and self.num_dataloaders > 1 else None
+        )
 
         hook_name = "on_test_batch_start" if trainer.testing else "on_validation_batch_start"
         call._call_callback_hooks(trainer, hook_name, *step_kwargs.values())

--- a/src/lightning/pytorch/loops/fit_loop.py
+++ b/src/lightning/pytorch/loops/fit_loop.py
@@ -328,8 +328,6 @@ class _FitLoop(_Loop):
 
         self.epoch_progress.increment_ready()
 
-        trainer._logger_connector.on_epoch_start()
-
         call._call_callback_hooks(trainer, "on_train_epoch_start")
         call._call_lightning_module_hook(trainer, "on_train_epoch_start")
 

--- a/src/lightning/pytorch/trainer/connectors/logger_connector/logger_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/logger_connector/logger_connector.py
@@ -166,9 +166,6 @@ class _LoggerConnector:
     Utilities and properties
     """
 
-    def on_epoch_start(self) -> None:
-        ...
-
     def on_batch_start(self, batch: Any, dataloader_idx: Optional[int] = None) -> None:
         if self._first_loop_iter is None:
             self._first_loop_iter = True

--- a/src/lightning/pytorch/trainer/connectors/logger_connector/logger_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/logger_connector/logger_connector.py
@@ -34,9 +34,9 @@ class _LoggerConnector:
         self._progress_bar_metrics: _PBAR_DICT = {}
         self._logged_metrics: _OUT_DICT = {}
         self._callback_metrics: _OUT_DICT = {}
-        self._epoch_end_reached = False
         self._current_fx: Optional[str] = None
-        self._batch_idx: Optional[int] = None
+        # None: hasn't started, True: first loop iteration, False: subsequent iterations
+        self._first_loop_iter: Optional[bool] = None
 
     def on_trainer_init(
         self,
@@ -119,12 +119,12 @@ class _LoggerConnector:
         results.dataloader_idx = None
 
     def update_eval_step_metrics(self, step: int) -> None:
-        assert not self._epoch_end_reached
+        assert isinstance(self._first_loop_iter, bool)
         # logs user requested information to logger
         self.log_metrics(self.metrics["log"], step=step)
 
     def update_eval_epoch_metrics(self) -> _OUT_DICT:
-        assert self._epoch_end_reached
+        assert self._first_loop_iter is None
         if self.trainer.sanity_checking:
             return {}
         metrics = self.metrics
@@ -134,7 +134,7 @@ class _LoggerConnector:
         return metrics["log"]
 
     def log_eval_end_metrics(self, metrics: _OUT_DICT) -> None:
-        assert self._epoch_end_reached
+        assert self._first_loop_iter is None
         if self.trainer.sanity_checking:
             return
 
@@ -150,13 +150,13 @@ class _LoggerConnector:
             return
 
         # when metrics should be logged
-        assert not self._epoch_end_reached
+        assert isinstance(self._first_loop_iter, bool)
         if self.should_update_logs or self.trainer.fast_dev_run:
             self.log_metrics(self.metrics["log"])
 
     def update_train_epoch_metrics(self) -> None:
         # add the metrics to the loggers
-        assert self._epoch_end_reached
+        assert self._first_loop_iter is None
         self.log_metrics(self.metrics["log"])
 
         # reset result collection for next epoch
@@ -167,11 +167,13 @@ class _LoggerConnector:
     """
 
     def on_epoch_start(self) -> None:
-        self._epoch_end_reached = False
+        ...
 
-    def on_batch_start(self, batch: Any, batch_idx: int, dataloader_idx: Optional[int] = None) -> None:
-        self._batch_idx = batch_idx
-        self._epoch_end_reached = False
+    def on_batch_start(self, batch: Any, dataloader_idx: Optional[int] = None) -> None:
+        if self._first_loop_iter is None:
+            self._first_loop_iter = True
+        elif self._first_loop_iter is True:
+            self._first_loop_iter = False
 
         results = self.trainer._results
         assert results is not None
@@ -181,11 +183,10 @@ class _LoggerConnector:
         results.dataloader_idx = dataloader_idx
 
     def epoch_end_reached(self) -> None:
-        self._epoch_end_reached = True
-        self._batch_idx = None
+        self._first_loop_iter = None
 
     def on_epoch_end(self) -> None:
-        assert self._epoch_end_reached
+        assert self._first_loop_iter is None
         metrics = self.metrics
         self._progress_bar_metrics.update(metrics["pbar"])
         self._callback_metrics.update(metrics["callback"])
@@ -193,7 +194,7 @@ class _LoggerConnector:
         self._current_fx = None
 
     def on_batch_end(self) -> None:
-        assert not self._epoch_end_reached
+        assert isinstance(self._first_loop_iter, bool)
         metrics = self.metrics
         self._progress_bar_metrics.update(metrics["pbar"])
         self._callback_metrics.update(metrics["callback"])
@@ -205,9 +206,7 @@ class _LoggerConnector:
         self.trainer._results.batch_size = None
 
     def should_reset_tensors(self, fx: str) -> bool:
-        is_different_fx = self._current_fx != fx
-        is_first_batch = self._batch_idx in (None, 0)
-        return is_different_fx and is_first_batch
+        return self._current_fx != fx and self._first_loop_iter in (None, True)
 
     def reset_metrics(self) -> None:
         self._progress_bar_metrics = {}
@@ -219,13 +218,13 @@ class _LoggerConnector:
         if results is not None:
             results.reset()
 
-        self._batch_idx = None
+        self._first_loop_iter = None
         self._current_fx = None
 
     @property
     def metrics(self) -> _METRICS:
-        """This function returns either batch or epoch metrics depending on ``_epoch_end_reached``."""
-        on_step = not self._epoch_end_reached
+        """This function returns either batch or epoch metrics."""
+        on_step = self._first_loop_iter is not None
         assert self.trainer._results is not None
         return self.trainer._results.metrics(on_step)
 

--- a/tests/tests_pytorch/trainer/logging_/test_train_loop_logging.py
+++ b/tests/tests_pytorch/trainer/logging_/test_train_loop_logging.py
@@ -682,7 +682,6 @@ def test_on_epoch_logging_with_sum_and_on_batch_start(tmpdir):
         def on_validation_epoch_end(self):
             self.log("on_validation_epoch_end", 3.0, reduce_fx="mean")
             assert self.trainer._results["on_validation_epoch_end.on_validation_epoch_end"].value == 3.0
-            print(self.trainer.callback_metrics)
             assert all(v == 3 for v in self.trainer.callback_metrics.values())
 
         def on_train_batch_start(self, *_):

--- a/tests/tests_pytorch/trainer/logging_/test_train_loop_logging.py
+++ b/tests/tests_pytorch/trainer/logging_/test_train_loop_logging.py
@@ -682,6 +682,7 @@ def test_on_epoch_logging_with_sum_and_on_batch_start(tmpdir):
         def on_validation_epoch_end(self):
             self.log("on_validation_epoch_end", 3.0, reduce_fx="mean")
             assert self.trainer._results["on_validation_epoch_end.on_validation_epoch_end"].value == 3.0
+            print(self.trainer.callback_metrics)
             assert all(v == 3 for v in self.trainer.callback_metrics.values())
 
         def on_train_batch_start(self, *_):
@@ -777,5 +778,5 @@ def test_unsqueezed_tensor_logging():
     trainer.state.stage = RunningStage.TRAINING
     model._current_fx_name = "training_step"
     model.trainer = trainer
-    model.log("foo", Tensor([1.2]))
+    model.log("foo", Tensor([1.2]), on_epoch=True)
     assert trainer.callback_metrics["foo"].ndim == 0


### PR DESCRIPTION
## What does this PR do?

Unblocks #18390 where we cannot rely on having the correct `batch_idx` set

cc @borda @justusschock @awaelchli @carmocca @Blaizzy