### PR TITLE
Support the TransformerEngine precision plugin with the Trainer

### DIFF
--- a/docs/source-fabric/api/precision.rst
+++ b/docs/source-fabric/api/precision.rst
@@ -8,8 +8,6 @@ lightning.fabric.plugins.precision
 Precision
 ^^^^^^^^^
 
-.. TODO(fabric): include DeepSpeedPrecision
-
 .. currentmodule:: lightning.fabric.plugins.precision
 
 .. autosummary::
@@ -20,6 +18,8 @@ Precision
     Precision
     DoublePrecision
     MixedPrecision
+    HalfPrecision
     XLAPrecision
-    XLABf16Precision
     FSDPPrecision
+    DeepSpeedPrecision
+    TransformerEnginePrecision

--- a/docs/source-fabric/fundamentals/precision.rst
+++ b/docs/source-fabric/fundamentals/precision.rst
@@ -152,7 +152,7 @@ the model and inputs can be kept in true full or half precision.
     fabric = Fabric(precision="transformer-engine")
 
     # Customize the fp8 recipe or set a different base precision:
-    from lightning.fabric.plugins.precision import TransformerEnginePrecision
+    from lightning.fabric.plugins import TransformerEnginePrecision
 
     recipe = {"fp8_format": "HYBRID", "amax_history_len": 16, "amax_compute_algo": "max"}
     precision = TransformerEnginePrecision(dtype=torch.bfloat16, recipe=recipe)

--- a/docs/source-fabric/fundamentals/precision.rst
+++ b/docs/source-fabric/fundamentals/precision.rst
@@ -143,7 +143,7 @@ and :class:`torch.nn.LayerNorm` layers in your model with their TE alternatives,
 to squeeze out all the possible performance. If Fabric detects that any layer has been replaced already, automatic
 replacement is not done.
 
-This plugin is a mix of "mixed" and "true" precision. The computation is downcasted to FP8 precision on the fly, but
+This plugin is a combination of "mixed" and "true" precision. The computation is downcasted to FP8 precision on the fly, but
 the model and inputs can be kept in true full or half precision.
 
 .. code-block:: python

--- a/docs/source-pytorch/api_references.rst
+++ b/docs/source-pytorch/api_references.rst
@@ -114,12 +114,12 @@ precision
 
     DeepSpeedPrecisionPlugin
     DoublePrecisionPlugin
-    FSDPPrecisionPlugin
     HalfPrecisionPlugin
+    FSDPPrecisionPlugin
     MixedPrecisionPlugin
     PrecisionPlugin
-    XLABf16PrecisionPlugin
     XLAPrecisionPlugin
+    TransformerEnginePrecisionPlugin
 
 environments
 """"""""""""

--- a/docs/source-pytorch/common/precision.rst
+++ b/docs/source-pytorch/common/precision.rst
@@ -23,7 +23,7 @@ N-Bit Precision
 
 .. displayitem::
    :header: Intermediate
-   :description: Enable state-of-the-art scaling with advanced mix-precision settings.
+   :description: Enable state-of-the-art scaling with advanced mixed-precision settings.
    :col_css: col-md-4
    :button_link: precision_intermediate.html
    :height: 150

--- a/docs/source-pytorch/common/precision_basic.rst
+++ b/docs/source-pytorch/common/precision_basic.rst
@@ -28,6 +28,10 @@ If your GPUs are [`Tensor Core <https://docs.nvidia.com/deeplearning/performance
     Trainer(precision="16-mixed")
 
 
+In most cases, mixed precision uses FP16. Supported `PyTorch operations <https://pytorch.org/docs/stable/amp.html#op-specific-behavior>`__ automatically run in FP16, saving memory and improving throughput on the supported accelerators.
+Since computation happens in FP16, which has a very limited "dynamic range", there is a chance of numerical instability during training. This is handled internally by a dynamic grad scaler which skips invalid steps and adjusts the scaler to ensure subsequent steps fall within a finite range. For more information `see the autocast docs <https://pytorch.org/docs/stable/amp.html#gradient-scaling>`__.
+
+
 With true 16-bit precision you can additionally lower your memory consumption by up to half so that you can train and deploy larger models.
 However, this setting can sometimes lead to unstable training.
 
@@ -49,10 +53,10 @@ However, this setting can sometimes lead to unstable training.
 
     Trainer(precision="32-true")
 
-    # or
+    # or (legacy)
     Trainer(precision="32")
 
-    # or
+    # or (legacy)
     Trainer(precision=32)
 
 ----
@@ -67,10 +71,10 @@ For certain scientific computations, 64-bit precision enables more accurate mode
 
     Trainer(precision="64-true")
 
-    # or
+    # or (legacy)
     Trainer(precision="64")
 
-    # or
+    # or (legacy)
     Trainer(precision=64)
 
 Since in deep learning, memory is always a bottleneck, especially when dealing with a large volume of data and with limited resources.

--- a/docs/source-pytorch/common/precision_intermediate.rst
+++ b/docs/source-pytorch/common/precision_intermediate.rst
@@ -132,7 +132,7 @@ and :class:`torch.nn.LayerNorm` layers in your model with their TE alternatives,
 to squeeze out all the possible performance. If Fabric detects that any layer has been replaced already, automatic
 replacement is not done.
 
-This plugin is a mix of "mixed" and "true" precision. The computation is downcasted to FP8 precision on the fly, but
+This plugin is a combination of "mixed" and "true" precision. The computation is downcasted to FP8 precision on the fly, but
 the model and inputs can be kept in true full or half precision.
 
 .. code-block:: python

--- a/docs/source-pytorch/common/precision_intermediate.rst
+++ b/docs/source-pytorch/common/precision_intermediate.rst
@@ -54,27 +54,6 @@ delivers all of these benefits while ensuring that no task-specific accuracy is 
 ----
 
 
-********************
-FP16 Mixed Precision
-********************
-
-In most cases, mixed precision uses FP16. Supported `PyTorch operations <https://pytorch.org/docs/stable/amp.html#op-specific-behavior>`__ automatically run in FP16, saving memory and improving throughput on the supported accelerators.
-Since computation happens in FP16, there is a chance of numerical instability during training. This is handled internally by a dynamic grad scaler which skips invalid steps and adjusts the scaler to ensure subsequent steps fall within a finite range. For more information `see the autocast docs <https://pytorch.org/docs/stable/amp.html#gradient-scaling>`__.
-
-
-.. note::
-
-    When using TPUs, setting ``precision='16-mixed'`` will enable bfloat16, the only supported half precision type on TPUs.
-
-.. testcode::
-    :skipif: not torch.cuda.is_available()
-
-    Trainer(accelerator="gpu", devices=1, precision="16-mixed")
-
-
-----
-
-
 ************************
 BFloat16 Mixed Precision
 ************************
@@ -82,7 +61,7 @@ BFloat16 Mixed Precision
 .. warning::
 
     BFloat16 may not provide significant speedups or memory improvements or offer better numerical stability.
-    Do note for GPUs, the most significant benefits require `Ampere <https://en.wikipedia.org/wiki/Ampere_(microarchitecture)>`__ based GPUs, such as A100s or 3090s.
+    For GPUs, the most significant benefits require `Ampere <https://en.wikipedia.org/wiki/Ampere_(microarchitecture)>`__ based GPUs or newer, such as A100s or 3090s.
 
 BFloat16 Mixed precision is similar to FP16 mixed precision, however, it maintains more of the "dynamic range" that FP32 offers. This means it is able to improve numerical stability than FP16 mixed precision. For more information, see `this TPU performance blogpost <https://cloud.google.com/blog/products/ai-machine-learning/bfloat16-the-secret-to-high-performance-on-cloud-tpus>`__.
 
@@ -139,12 +118,52 @@ See also: :doc:`../advanced/model_init`
 ----
 
 
+*****************************************************
+Float8 Mixed Precision via Nvidia's TransformerEngine
+*****************************************************
+
+`Transformer Engine <https://github.com/NVIDIA/TransformerEngine>`__ (TE) is a library for accelerating models on the
+latest NVIDIA GPUs using 8-bit floating point (FP8) precision on Hopper GPUs, to provide better performance with lower
+memory utilization in both training and inference. It offers improved performance over half precision with no degradation in accuracy.
+
+Using TE requires replacing some of the layers in your model. Fabric automatically replaces the :class:`torch.nn.Linear`
+and :class:`torch.nn.LayerNorm` layers in your model with their TE alternatives, however, TE also offers
+`fused layers <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/pytorch.html>`__
+to squeeze out all the possible performance. If Fabric detects that any layer has been replaced already, automatic
+replacement is not done.
+
+This plugin is a mix of "mixed" and "true" precision. The computation is downcasted to FP8 precision on the fly, but
+the model and inputs can be kept in true full or half precision.
+
+.. code-block:: python
+
+    # Select 8bit mixed precision via TransformerEngine
+    fabric = Trainer(precision="transformer-engine")
+
+    # Customize the fp8 recipe or set a different base precision:
+    from lightning.trainer.plugins import TransformerEnginePrecision
+
+    recipe = {"fp8_format": "HYBRID", "amax_history_len": 16, "amax_compute_algo": "max"}
+    precision = TransformerEnginePrecision(dtype=torch.bfloat16, recipe=recipe)
+    fabric = Trainer(plugins=precision)
+
+
+Under the hood, we use `transformer_engine.pytorch.fp8_autocast <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/pytorch.html#transformer_engine.pytorch.fp8_autocast>`__ with the default fp8 recipe.
+
+.. note::
+
+    This requires `Hopper <https://en.wikipedia.org/wiki/Hopper_(microarchitecture)>`_ based GPUs or newer, such the H100.
+
+
+----
+
+
 ***************
 8-bit Optimizer
 ***************
 
-It is possible to further reduce the precision using third-party libraries like `bitsandbytes <https://github.com/TimDettmers/bitsandbytes>`_. Although,
-Lightning doesn't support it out of the box yet but you can still use it by configuring it in your LightningModule and setting ``Trainer(precision=32)``.
+It is possible to further reduce the memory usage of the optimizer states by using third-party libraries like `bitsandbytes <https://github.com/TimDettmers/bitsandbytes>`_.
+You can configure it in your LightningModule by overriding ``configure_optimizers``.
 
 .. code-block:: python
 

--- a/docs/source-pytorch/common/trainer.rst
+++ b/docs/source-pytorch/common/trainer.rst
@@ -809,35 +809,40 @@ To define your own behavior, subclass the relevant class and pass it in. Here's 
 precision
 ^^^^^^^^^
 
-Lightning supports either double (64), float (32), bfloat16 (bf16), or half (16) precision training.
-Half precision is using 16 bit floating point operations while mixed precision is the combined use of 32 and 16 bit floating points to reduce memory footprint during model training. Since not all operations (like batchnorm) are numerically stable in lower bit precisions, these operations will still be carried out in fp32 whereas half precision unconditionally performs all operations in 16 bit.
-This can result in improved performance, achieving +3X speedups on modern GPUs.
+There are two different techniques to set the mixed precision. "True" precision and "Mixed" precision.
 
-.. testcode::
-    :skipif: not torch.cuda.is_available()
+Lightning supports doing floating point operations in 64-bit precision ("double"), 32-bit precision ("full"), or 16-bit ("half") with both regular and `bfloat16 <https://pytorch.org/docs/1.10.0/generated/torch.Tensor.bfloat16.html>`_).
+This selected precision will have a direct impact in the performance and memory usage based on your hardware.
+Automatic mixed precision settings are denoted by a ``"-mixed"`` suffix, while "true" precision settings have a ``"-true"`` suffix:
 
-    # default used by the Trainer
-    trainer = Trainer(precision=32)
+.. code-block:: python
 
-    # 16-bit mixed precision
-    trainer = Trainer(precision="16-mixed")
+    # Default used by the Trainer
+    fabric = Fabric(precision="32-true", devices=1)
 
-    # bfloat16 mixed precision
-    trainer = Trainer(precision="bf16-mixed")
+    # the same as:
+    fabric = Trainer(precision="32", devices=1)
 
-    # 16-bit true precision
-    trainer = Trainer(precision="16-true")
+    # 16-bit mixed precision (model weights remain in torch.float32)
+    fabric = Trainer(precision="16-mixed", devices=1)
 
-    # bfloat16 true precision
-    trainer = Trainer(precision="bf16-true")
+    # 16-bit bfloat mixed precision (model weights remain in torch.float32)
+    fabric = Trainer(precision="bf16-mixed", devices=1)
 
-    # 64-bit precision
-    trainer = Trainer(precision=64)
+    # 8-bit mixed precision via TransformerEngine (model weights remain in torch.float32)
+    fabric = Trainer(precision="transformer-engine", devices=1)
+
+    # 16-bit precision (model weights get cast to torch.float16)
+    fabric = Trainer(precision="16-true", devices=1)
+
+    # 16-bit bfloat precision (model weights get cast to torch.bfloat16)
+    fabric = Trainer(precision="bf16-true", devices=1)
+
+    # 64-bit (double) precision (model weights get cast to torch.float64)
+    fabric = Trainer(precision="64-true", devices=1)
 
 
 See the :doc:`N-bit precision guide <../common/precision>` for more details.
-
-.. note:: When running on TPUs, torch.bfloat16 will be used but tensor printing will still show torch.float32.
 
 
 profiler

--- a/docs/source-pytorch/extensions/plugins.rst
+++ b/docs/source-pytorch/extensions/plugins.rst
@@ -54,11 +54,12 @@ The full list of built-in precision plugins is listed below.
 
     DeepSpeedPrecisionPlugin
     DoublePrecisionPlugin
+    HalfPrecisionPlugin
     FSDPPrecisionPlugin
     MixedPrecisionPlugin
     PrecisionPlugin
-    XLABf16PrecisionPlugin
     XLAPrecisionPlugin
+    TransformerEnginePrecisionPlugin
 
 More information regarding precision with Lightning can be found :ref:`here <precision>`
 

--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -58,10 +58,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Run the DDP wrapper in a CUDA stream ([#17334](https://github.com/Lightning-AI/lightning/pull/17334))
 
 
-- Added support for true half-precision as `L.Fabric(precision="16-true"|"bf16-true")` ([#17287](https://github.com/Lightning-AI/lightning/pull/17287))
+- Added support for true half-precision as `Fabric(precision="16-true"|"bf16-true")` ([#17287](https://github.com/Lightning-AI/lightning/pull/17287))
 
 
-- Added support for mixed 8-bit precision as `L.Fabric(precision="transformer-engine")` using [Nvidia's Transformer Engine](https://docs.nvidia.com/deeplearning/transformer-engine) ([#17597](https://github.com/Lightning-AI/lightning/pull/17597))
+- Added support for mixed 8-bit precision as `Fabric(precision="transformer-engine")` using [Nvidia's Transformer Engine](https://docs.nvidia.com/deeplearning/transformer-engine) ([#17597](https://github.com/Lightning-AI/lightning/pull/17597))
 
 
 - Added error messaging for missed `.launch()` when it is required ([#17570](https://github.com/Lightning-AI/lightning/pull/17570))

--- a/src/lightning/fabric/plugins/__init__.py
+++ b/src/lightning/fabric/plugins/__init__.py
@@ -21,6 +21,7 @@ from lightning.fabric.plugins.precision.double import DoublePrecision
 from lightning.fabric.plugins.precision.fsdp import FSDPPrecision
 from lightning.fabric.plugins.precision.half import HalfPrecision
 from lightning.fabric.plugins.precision.precision import Precision
+from lightning.fabric.plugins.precision.transformer_engine import TransformerEnginePrecision
 from lightning.fabric.plugins.precision.xla import XLAPrecision
 
 __all__ = [
@@ -33,6 +34,7 @@ __all__ = [
     "DoublePrecision",
     "HalfPrecision",
     "MixedPrecision",
+    "TransformerEnginePrecision",
     "XLAPrecision",
     "FSDPPrecision",
 ]

--- a/src/lightning/fabric/plugins/precision/transformer_engine.py
+++ b/src/lightning/fabric/plugins/precision/transformer_engine.py
@@ -44,7 +44,7 @@ class TransformerEnginePrecision(Precision):
     Args:
         dtype: The base dtype to use.
         recipe: Recipe for the DelayedScaling
-            `configuration <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html#transformer_engine.common.recipe.DelayedScaling`__.
+            `configuration <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html#transformer_engine.common.recipe.DelayedScaling>`__.
             In dict format or the dataclass format.
         replace_layers: Whether to replace ``Linear`` and ``LayerNorm`` layers automatically with their Transformer
             Engine alternatives. Note that they don't subclass the torch equivalents so checks like

--- a/src/lightning/fabric/plugins/precision/transformer_engine.py
+++ b/src/lightning/fabric/plugins/precision/transformer_engine.py
@@ -28,6 +28,8 @@ _TRANSFORMER_ENGINE_AVAILABLE = RequirementCache("transformer_engine>=0.11.0")
 
 if TYPE_CHECKING and _TRANSFORMER_ENGINE_AVAILABLE:
     from transformer_engine.common.recipe import DelayedScaling
+else:
+    DelayedScaling = None
 
 
 log = logging.getLogger(__name__)

--- a/src/lightning/fabric/plugins/precision/transformer_engine.py
+++ b/src/lightning/fabric/plugins/precision/transformer_engine.py
@@ -36,8 +36,8 @@ log = logging.getLogger(__name__)
 
 
 class TransformerEnginePrecision(Precision):
-    """Plugin for training with fp8 precision via nvidia's `Transformer Engine
-    <https://docs.nvidia.com/deeplearning/transformer-engine`__.
+    """Plugin for training with fp8 precision via nvidia's
+    `Transformer Engine <https://docs.nvidia.com/deeplearning/transformer-engine>`__.
 
     .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
 

--- a/src/lightning/fabric/plugins/precision/transformer_engine.py
+++ b/src/lightning/fabric/plugins/precision/transformer_engine.py
@@ -44,17 +44,17 @@ class TransformerEnginePrecision(Precision):
     Args:
         dtype: The base dtype to use.
         recipe: Recipe for the DelayedScaling
-            `configuration <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html#transform
-            er_engine.common.recipe.DelayedScaling`__. In dict format or the dataclass format.
+            `configuration <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html#transformer_engine.common.recipe.DelayedScaling`__.
+            In dict format or the dataclass format.
         replace_layers: Whether to replace ``Linear`` and ``LayerNorm`` layers automatically with their Transformer
             Engine alternatives. Note that they don't subclass the torch equivalents so checks like
             ``isinstance(l, torch.nn.Linear)`` will not pass.
 
     .. note::
 
-        Support for FP8 in the linear layers with `precision='transformer-engine'` is currently limited to tensors with
-        shapes where the dimensions are divisible by 8 and 16 respectively. You might want to add padding to your inputs
-        to conform to this restriction.
+        Support for FP8 in the linear layers with ``precision='transformer-engine'`` is currently limited to tensors
+        with shapes where the dimensions are divisible by 8 and 16 respectively. You might want to add padding to your
+        inputs to conform to this restriction.
 
     """
 

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -117,6 +117,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Improved the error messaging and instructions when handling custom batch samplers in distributed settings ([#18402](https://github.com/Lightning-AI/lightning/pull/18402))
 
 
+- Added support for mixed 8-bit precision as `Trainer(precision="transformer-engine")` using [Nvidia's Transformer Engine](https://docs.nvidia.com/deeplearning/transformer-engine) ([#18459](https://github.com/Lightning-AI/lightning/pull/18459))
 
 ### Changed
 

--- a/src/lightning/pytorch/plugins/__init__.py
+++ b/src/lightning/pytorch/plugins/__init__.py
@@ -9,6 +9,7 @@ from lightning.pytorch.plugins.precision.double import DoublePrecisionPlugin
 from lightning.pytorch.plugins.precision.fsdp import FSDPMixedPrecisionPlugin, FSDPPrecisionPlugin
 from lightning.pytorch.plugins.precision.half import HalfPrecisionPlugin
 from lightning.pytorch.plugins.precision.precision_plugin import PrecisionPlugin
+from lightning.pytorch.plugins.precision.transformer_engine import TransformerEnginePrecisionPlugin
 from lightning.pytorch.plugins.precision.xla import XLAPrecisionPlugin
 
 PLUGIN = Union[PrecisionPlugin, ClusterEnvironment, CheckpointIO, LayerSync]
@@ -24,6 +25,7 @@ __all__ = [
     "HalfPrecisionPlugin",
     "MixedPrecisionPlugin",
     "PrecisionPlugin",
+    "TransformerEnginePrecisionPlugin",
     "FSDPMixedPrecisionPlugin",
     "FSDPPrecisionPlugin",
     "XLAPrecisionPlugin",

--- a/src/lightning/pytorch/plugins/precision/__init__.py
+++ b/src/lightning/pytorch/plugins/precision/__init__.py
@@ -17,6 +17,7 @@ from lightning.pytorch.plugins.precision.double import DoublePrecisionPlugin
 from lightning.pytorch.plugins.precision.fsdp import FSDPMixedPrecisionPlugin, FSDPPrecisionPlugin
 from lightning.pytorch.plugins.precision.half import HalfPrecisionPlugin
 from lightning.pytorch.plugins.precision.precision_plugin import PrecisionPlugin
+from lightning.pytorch.plugins.precision.transformer_engine import TransformerEnginePrecisionPlugin
 from lightning.pytorch.plugins.precision.xla import XLAPrecisionPlugin
 
 __all__ = [
@@ -27,5 +28,6 @@ __all__ = [
     "HalfPrecisionPlugin",
     "MixedPrecisionPlugin",
     "PrecisionPlugin",
+    "TransformerEnginePrecisionPlugin",
     "XLAPrecisionPlugin",
 ]

--- a/src/lightning/pytorch/plugins/precision/transformer_engine.py
+++ b/src/lightning/pytorch/plugins/precision/transformer_engine.py
@@ -1,0 +1,19 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from lightning.fabric.plugins.precision.transformer_engine import TransformerEnginePrecision as FabricTEPrecision
+from lightning.pytorch.plugins.precision.precision_plugin import PrecisionPlugin
+
+
+class TransformerEnginePrecisionPlugin(PrecisionPlugin, FabricTEPrecision):
+    pass

--- a/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/accelerator_connector.py
@@ -44,6 +44,7 @@ from lightning.pytorch.plugins import (
     MixedPrecisionPlugin,
     PLUGIN_INPUT,
     PrecisionPlugin,
+    TransformerEnginePrecisionPlugin,
     XLAPrecisionPlugin,
 )
 from lightning.pytorch.plugins.layer_sync import LayerSync, TorchSyncBatchNorm
@@ -525,6 +526,8 @@ class _AcceleratorConnector:
             return PrecisionPlugin()
         if self._precision_flag == "64-true":
             return DoublePrecisionPlugin()
+        if self._precision_flag == "transformer-engine":
+            return TransformerEnginePrecisionPlugin()
 
         if self._precision_flag == "16-mixed" and self._accelerator_flag == "cpu":
             rank_zero_warn(

--- a/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
@@ -24,7 +24,6 @@ import torch.distributed
 from lightning_utilities.core.imports import package_available
 
 import lightning.pytorch
-from lightning.fabric.plugins import TransformerEnginePrecision
 from lightning.fabric.plugins.environments import (
     KubeflowEnvironment,
     LightningEnvironment,
@@ -35,6 +34,7 @@ from lightning.fabric.plugins.environments import (
 from lightning.fabric.utilities.imports import _IS_WINDOWS
 from lightning.pytorch import Trainer
 from lightning.pytorch.accelerators import Accelerator, CPUAccelerator, CUDAAccelerator, MPSAccelerator, XLAAccelerator
+from lightning.pytorch.plugins import TransformerEnginePrecisionPlugin
 from lightning.pytorch.plugins.io import TorchCheckpointIO
 from lightning.pytorch.plugins.layer_sync import LayerSync, TorchSyncBatchNorm
 from lightning.pytorch.plugins.precision import (
@@ -1048,4 +1048,8 @@ def test_connector_transformer_engine(monkeypatch):
     monkeypatch.setitem(sys.modules, "transformer_engine.common.recipe", recipe_mock)
 
     connector = _AcceleratorConnector(precision="transformer-engine")
-    assert isinstance(connector.precision_plugin, TransformerEnginePrecision)
+    assert isinstance(connector.precision_plugin, TransformerEnginePrecisionPlugin)
+
+    precision = TransformerEnginePrecisionPlugin()
+    connector = _AcceleratorConnector(plugins=precision)
+    assert connector.precision_plugin is precision

--- a/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_accelerator_connector.py
@@ -1039,6 +1039,8 @@ def test_precision_selection(precision_str, strategy_str, expected_precision_cls
 
 
 def test_connector_transformer_engine(monkeypatch):
+    import lightning.fabric  # avoid breakage with standalone package
+
     monkeypatch.setattr(
         lightning.fabric.plugins.precision.transformer_engine, "_TRANSFORMER_ENGINE_AVAILABLE", lambda: True
     )


### PR DESCRIPTION
## What does this PR do?

The Trainer can now support this plugin easily.

Fixes https://github.com/Lightning-AI/lightning/issues/17172

cc @borda @carmocca @justusschock @awaelchli @sabetAI


<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18459.org.readthedocs.build/en/18459/

<!-- readthedocs-preview pytorch-lightning end -->