### PR TITLE
LightningModule.configure_optimizers: add type hints

### DIFF
--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -66,7 +66,7 @@ from lightning.pytorch.utilities.exceptions import MisconfigurationException
 from lightning.pytorch.utilities.imports import _TORCHMETRICS_GREATER_EQUAL_0_9_1
 from lightning.pytorch.utilities.rank_zero import rank_zero_debug, rank_zero_warn, WarningCache
 from lightning.pytorch.utilities.signature_utils import is_param_in_hook_signature
-from lightning.pytorch.utilities.types import _METRIC, LRSchedulerPLType, LRSchedulerTypeUnion, STEP_OUTPUT
+from lightning.pytorch.utilities.types import _METRIC, LRSchedulerPLType, LRSchedulerTypeUnion, OptimizerLRScheduler, STEP_OUTPUT
 
 _ONNX_AVAILABLE = RequirementCache("onnx")
 
@@ -910,7 +910,7 @@ class LightningModule(
         """
         return []
 
-    def configure_optimizers(self) -> Any:
+    def configure_optimizers(self) -> OptimizerLRScheduler:
         r"""Choose what optimizers and learning-rate schedulers to use in your optimization. Normally you'd need one.
         But in the case of GANs or similar you might have multiple. Optimization with multiple optimizers only works in
         the manual optimization mode.

--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -66,7 +66,13 @@ from lightning.pytorch.utilities.exceptions import MisconfigurationException
 from lightning.pytorch.utilities.imports import _TORCHMETRICS_GREATER_EQUAL_0_9_1
 from lightning.pytorch.utilities.rank_zero import rank_zero_debug, rank_zero_warn, WarningCache
 from lightning.pytorch.utilities.signature_utils import is_param_in_hook_signature
-from lightning.pytorch.utilities.types import _METRIC, LRSchedulerPLType, LRSchedulerTypeUnion, OptimizerLRScheduler, STEP_OUTPUT
+from lightning.pytorch.utilities.types import (
+    _METRIC,
+    LRSchedulerPLType,
+    LRSchedulerTypeUnion,
+    OptimizerLRScheduler,
+    STEP_OUTPUT,
+)
 
 _ONNX_AVAILABLE = RequirementCache("onnx")
 

--- a/src/lightning/pytorch/utilities/types.py
+++ b/src/lightning/pytorch/utilities/types.py
@@ -18,7 +18,7 @@ Convention:
 """
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Generator, Iterator, List, Mapping, Optional, Protocol, runtime_checkable, Sequence, Type, Union
+from typing import Any, Generator, Iterator, List, Mapping, Optional, Protocol, runtime_checkable, Sequence, Tuple, Type, Union
 
 import torch
 from torch import Tensor

--- a/src/lightning/pytorch/utilities/types.py
+++ b/src/lightning/pytorch/utilities/types.py
@@ -18,10 +18,11 @@ Convention:
 """
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Generator, Iterator, List, Mapping, Optional, Protocol, runtime_checkable, Type, Union
+from typing import Any, Generator, Iterator, List, Mapping, Optional, Protocol, runtime_checkable, Sequence, Type, Union
 
 import torch
 from torch import Tensor
+from torch.optim import Optimizer
 from torchmetrics import Metric
 
 from lightning.fabric.utilities.types import _TORCH_LRSCHEDULER, LRScheduler, ProcessGroup, ReduceLROnPlateau
@@ -82,6 +83,20 @@ class LRSchedulerConfig:
     monitor: Optional[str] = None
     # enforce that the monitor exists for ReduceLROnPlateau
     strict: bool = True
+
+
+@dataclass
+class OptimizerLRSchedulerConfig:
+    optimizer: Optimizer
+    lr_scheduler: Union[LRSchedulerPLType, LRSchedulerConfig]
+
+
+OptimizerLRScheduler = Optional[Union[
+    Optimizer,
+    Sequence[Optimizer],
+    Tuple[Sequence[Optimizer], Sequence[Union[LRSchedulerPLType, LRSchedulerConfig]]],
+    OptimizerLRSchedulerConfig,
+]]
 
 
 class _SizedIterable(Protocol):

--- a/src/lightning/pytorch/utilities/types.py
+++ b/src/lightning/pytorch/utilities/types.py
@@ -18,7 +18,20 @@ Convention:
 """
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Generator, Iterator, List, Mapping, Optional, Protocol, runtime_checkable, Sequence, Tuple, Type, Union
+from typing import (
+    Any,
+    Generator,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Protocol,
+    runtime_checkable,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
 
 import torch
 from torch import Tensor

--- a/src/lightning/pytorch/utilities/types.py
+++ b/src/lightning/pytorch/utilities/types.py
@@ -91,12 +91,14 @@ class OptimizerLRSchedulerConfig:
     lr_scheduler: Union[LRSchedulerPLType, LRSchedulerConfig]
 
 
-OptimizerLRScheduler = Optional[Union[
-    Optimizer,
-    Sequence[Optimizer],
-    Tuple[Sequence[Optimizer], Sequence[Union[LRSchedulerPLType, LRSchedulerConfig]]],
-    OptimizerLRSchedulerConfig,
-]]
+OptimizerLRScheduler = Optional[
+    Union[
+        Optimizer,
+        Sequence[Optimizer],
+        Tuple[Sequence[Optimizer], Sequence[Union[LRSchedulerPLType, LRSchedulerConfig]]],
+        OptimizerLRSchedulerConfig,
+    ]
+]
 
 
 class _SizedIterable(Protocol):

--- a/src/lightning/pytorch/utilities/types.py
+++ b/src/lightning/pytorch/utilities/types.py
@@ -30,6 +30,7 @@ from typing import (
     Sequence,
     Tuple,
     Type,
+    TypedDict,
     Union,
 )
 
@@ -98,17 +99,26 @@ class LRSchedulerConfig:
     strict: bool = True
 
 
-@dataclass
-class OptimizerLRSchedulerConfig:
+class LRSchedulerConfigType(TypedDict, total=False):
+    scheduler: LRSchedulerTypeUnion
+    name: Optional[str]
+    interval: str
+    frequency: int
+    reduce_on_plateau: bool
+    monitor: Optional[str]
+    scrict: bool
+
+
+class OptimizerLRSchedulerConfig(TypedDict, total=False):
     optimizer: Optimizer
-    lr_scheduler: Union[LRSchedulerPLType, LRSchedulerConfig]
+    lr_scheduler: Union[LRSchedulerTypeUnion, LRSchedulerConfigType]
 
 
 OptimizerLRScheduler = Optional[
     Union[
         Optimizer,
         Sequence[Optimizer],
-        Tuple[Sequence[Optimizer], Sequence[Union[LRSchedulerPLType, LRSchedulerConfig]]],
+        Tuple[Sequence[Optimizer], Sequence[Union[LRSchedulerTypeUnion, LRSchedulerConfig]]],
         OptimizerLRSchedulerConfig,
     ]
 ]

--- a/src/lightning/pytorch/utilities/types.py
+++ b/src/lightning/pytorch/utilities/types.py
@@ -38,6 +38,7 @@ import torch
 from torch import Tensor
 from torch.optim import Optimizer
 from torchmetrics import Metric
+from typing_extensions import NotRequired, Required
 
 from lightning.fabric.utilities.types import _TORCH_LRSCHEDULER, LRScheduler, ProcessGroup, ReduceLROnPlateau
 
@@ -100,7 +101,7 @@ class LRSchedulerConfig:
 
 
 class LRSchedulerConfigType(TypedDict, total=False):
-    scheduler: LRSchedulerTypeUnion
+    scheduler: Required[LRSchedulerTypeUnion]
     name: Optional[str]
     interval: str
     frequency: int
@@ -109,9 +110,9 @@ class LRSchedulerConfigType(TypedDict, total=False):
     scrict: bool
 
 
-class OptimizerLRSchedulerConfig(TypedDict, total=False):
+class OptimizerLRSchedulerConfig(TypedDict):
     optimizer: Optimizer
-    lr_scheduler: Union[LRSchedulerTypeUnion, LRSchedulerConfigType]
+    lr_scheduler: NotRequired[Union[LRSchedulerTypeUnion, LRSchedulerConfigType]]
 
 
 OptimizerLRScheduler = Optional[


### PR DESCRIPTION
## What does this PR do?

Adds type hints to `LightningModule.configure_optimizers`.


<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18463.org.readthedocs.build/en/18463/

<!-- readthedocs-preview pytorch-lightning end -->