### PR TITLE
Improve default metric formatting for RichProgressBar

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Changed default metric formatting from round(., 3) to ".3f" format string in "MetricsTextColumn" class ([#18483])(https://github.com/Lightning-AI/lightning/pull/18483)
+- Changed default metric formatting from `round(..., 3)` to `".3f"` format string in `MetricsTextColumn` class ([#18483])(https://github.com/Lightning-AI/lightning/pull/18483)
 
 - Added `metrics_format` attribute to `RichProgressBarTheme` class ([#18373](https://github.com/Lightning-AI/lightning/pull/18373))
 

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Changed default metric formatting from round(., 3) to ".3f" format string in "MetricsTextColumn" class ([#18483])(https://github.com/Lightning-AI/lightning/pull/18483)
+
 - Added `metrics_format` attribute to `RichProgressBarTheme` class ([#18373](https://github.com/Lightning-AI/lightning/pull/18373))
 
 - Added `CHECKPOINT_EQUALS_CHAR` attribute to `ModelCheckpoint` class ([#17999](https://github.com/Lightning-AI/lightning/pull/17999))

--- a/src/lightning/pytorch/callbacks/progress/rich_progress.py
+++ b/src/lightning/pytorch/callbacks/progress/rich_progress.py
@@ -141,7 +141,7 @@ if _RICH_AVAILABLE:
             trainer: "pl.Trainer",
             style: Union[str, "Style"],
             text_delimiter: str,
-            metrics_format: Union[str, None],
+            metrics_format: str,
         ):
             self._trainer = trainer
             self._tasks: Dict[Union[int, TaskID], Any] = {}
@@ -182,7 +182,7 @@ if _RICH_AVAILABLE:
         def _generate_metrics_texts(self) -> Generator[str, None, None]:
             for name, value in self._metrics.items():
                 if not isinstance(value, str):
-                    value = round(value, 3) if self._metrics_format is None else f"{value:{self._metrics_format}}"
+                    value = f"{value:{self._metrics_format}}"
                 yield f"{name}: {value}"
 
 else:
@@ -216,7 +216,7 @@ class RichProgressBarTheme:
     processing_speed: Union[str, Style] = "grey70"
     metrics: Union[str, Style] = "white"
     metrics_text_delimiter: str = " "
-    metrics_format: Union[str, None] = None
+    metrics_format: str = ".3f"
 
 
 class RichProgressBar(ProgressBar):


### PR DESCRIPTION
## What does this PR do?

Fixes #18367

This PR changes the default metric formatting from round(., 3) to using a ".3f" format string in "MetricsTextColumn" class, as discussed in https://github.com/Lightning-AI/lightning/pull/18373#discussion_r1309321063.

The PR comes with a unit test that tests the configurability of the metrics theme and a unit test that verifies the metric formatting behavior.

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18483.org.readthedocs.build/en/18483/

<!-- readthedocs-preview pytorch-lightning end -->