### PR TITLE
Support saving and loading stateful objects in Fabric

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -121,6 +121,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Improved the error messaging and instructions when handling custom batch samplers in distributed settings ([#18402](https://github.com/Lightning-AI/lightning/pull/18402))
 
 
+- Added support for saving and loading stateful objects other than modules and optimizers ([#18513](https://github.com/Lightning-AI/lightning/pull/18513))
+
+
 ### Changed
 
 - Allow using iterable-style datasets with TPUs ([#17331](https://github.com/Lightning-AI/lightning/pull/17331))

--- a/src/lightning/fabric/strategies/deepspeed.py
+++ b/src/lightning/fabric/strategies/deepspeed.py
@@ -509,6 +509,8 @@ class DeepSpeedStrategy(DDPStrategy, _Sharded):
                 " or a single checkpoint file by setting `DeepSpeedStrategy(..., load_full_weights=True)`."
             )
 
+        # `Engine.load_checkpoint` adds useless keys 'optimizer' and 'lr_scheduler' to the client state; remove
+        # them to avoid name collision with user state
         keys = set(client_state.keys()) & set(state.keys()) - {"optimizer", "lr_scheduler"}
         _take_state_and_load_stateful(source=client_state, destination=state, keys=keys)
         return client_state

--- a/src/lightning/fabric/strategies/deepspeed.py
+++ b/src/lightning/fabric/strategies/deepspeed.py
@@ -33,7 +33,7 @@ from lightning.fabric.strategies.ddp import DDPStrategy
 from lightning.fabric.strategies.registry import _StrategyRegistry
 from lightning.fabric.strategies.strategy import _Sharded
 from lightning.fabric.utilities.distributed import log
-from lightning.fabric.utilities.load import _take_state_and_load_stateful
+from lightning.fabric.utilities.load import _move_state_into
 from lightning.fabric.utilities.rank_zero import rank_zero_info, rank_zero_warn
 from lightning.fabric.utilities.seed import reset_seed
 from lightning.fabric.utilities.types import _PATH
@@ -512,7 +512,7 @@ class DeepSpeedStrategy(DDPStrategy, _Sharded):
         # `Engine.load_checkpoint` adds useless keys 'optimizer' and 'lr_scheduler' to the client state; remove
         # them to avoid name collision with user state
         keys = set(client_state) & set(state) - {"optimizer", "lr_scheduler"}
-        _take_state_and_load_stateful(source=client_state, destination=state, keys=keys)
+        _move_state_into(source=client_state, destination=state, keys=keys)
         return client_state
 
     def clip_gradients_norm(

--- a/src/lightning/fabric/strategies/deepspeed.py
+++ b/src/lightning/fabric/strategies/deepspeed.py
@@ -26,7 +26,6 @@ from lightning_utilities.core.imports import RequirementCache
 from torch.nn import Module
 from torch.optim import Optimizer
 
-from lightning.fabric.utilities.load import _take_state_and_load_stateful
 from lightning.fabric.accelerators import Accelerator, CUDAAccelerator
 from lightning.fabric.plugins.environments.cluster_environment import ClusterEnvironment
 from lightning.fabric.plugins.precision import Precision
@@ -34,6 +33,7 @@ from lightning.fabric.strategies.ddp import DDPStrategy
 from lightning.fabric.strategies.registry import _StrategyRegistry
 from lightning.fabric.strategies.strategy import _Sharded
 from lightning.fabric.utilities.distributed import log
+from lightning.fabric.utilities.load import _take_state_and_load_stateful
 from lightning.fabric.utilities.rank_zero import rank_zero_info, rank_zero_warn
 from lightning.fabric.utilities.seed import reset_seed
 from lightning.fabric.utilities.types import _PATH

--- a/src/lightning/fabric/strategies/deepspeed.py
+++ b/src/lightning/fabric/strategies/deepspeed.py
@@ -26,6 +26,7 @@ from lightning_utilities.core.imports import RequirementCache
 from torch.nn import Module
 from torch.optim import Optimizer
 
+from lightning.fabric.utilities.load import _take_state_and_load_stateful
 from lightning.fabric.accelerators import Accelerator, CUDAAccelerator
 from lightning.fabric.plugins.environments.cluster_environment import ClusterEnvironment
 from lightning.fabric.plugins.precision import Precision
@@ -503,10 +504,7 @@ class DeepSpeedStrategy(DDPStrategy, _Sharded):
                 " or a single checkpoint file by setting `DeepSpeedStrategy(..., load_full_weights=True)`."
             )
 
-        for k in client_state.copy():
-            if k not in state:
-                continue
-            state[k] = client_state.pop(k)
+        _take_state_and_load_stateful(source=client_state, destination=state)
         return client_state
 
     def clip_gradients_norm(

--- a/src/lightning/fabric/strategies/deepspeed.py
+++ b/src/lightning/fabric/strategies/deepspeed.py
@@ -490,9 +490,7 @@ class DeepSpeedStrategy(DDPStrategy, _Sharded):
 
         from deepspeed.runtime import DeepSpeedOptimizer
 
-        optimzer_state_requested = bool(
-            len([item for item in state.values() if isinstance(item, (Optimizer, DeepSpeedOptimizer))])
-        )
+        optimzer_state_requested = any(isinstance(item, (Optimizer, DeepSpeedOptimizer)) for item in state.values())
 
         torch.cuda.empty_cache()
         _, client_state = engine.load_checkpoint(

--- a/src/lightning/fabric/strategies/deepspeed.py
+++ b/src/lightning/fabric/strategies/deepspeed.py
@@ -511,7 +511,7 @@ class DeepSpeedStrategy(DDPStrategy, _Sharded):
 
         # `Engine.load_checkpoint` adds useless keys 'optimizer' and 'lr_scheduler' to the client state; remove
         # them to avoid name collision with user state
-        keys = set(client_state.keys()) & set(state.keys()) - {"optimizer", "lr_scheduler"}
+        keys = set(client_state) & set(state) - {"optimizer", "lr_scheduler"}
         _take_state_and_load_stateful(source=client_state, destination=state, keys=keys)
         return client_state
 

--- a/src/lightning/fabric/strategies/deepspeed.py
+++ b/src/lightning/fabric/strategies/deepspeed.py
@@ -489,8 +489,10 @@ class DeepSpeedStrategy(DDPStrategy, _Sharded):
         engine = engines[0]
 
         from deepspeed.runtime import DeepSpeedOptimizer
-        
-        optimzer_state_requested = bool(len([item for item in state.values() if isinstance(item, (Optimizer, DeepSpeedOptimizer))]))
+
+        optimzer_state_requested = bool(
+            len([item for item in state.values() if isinstance(item, (Optimizer, DeepSpeedOptimizer))])
+        )
 
         torch.cuda.empty_cache()
         _, client_state = engine.load_checkpoint(

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -67,7 +67,7 @@ from lightning.fabric.utilities.imports import (
     _TORCH_GREATER_EQUAL_2_1,
 )
 from lightning.fabric.utilities.init import _EmptyInit
-from lightning.fabric.utilities.load import _lazy_load, _materialize_tensors, _take_state_and_load_stateful
+from lightning.fabric.utilities.load import _lazy_load, _materialize_tensors, _move_state_into
 from lightning.fabric.utilities.rank_zero import rank_zero_deprecation, rank_zero_only, rank_zero_warn
 from lightning.fabric.utilities.seed import reset_seed
 from lightning.fabric.utilities.types import _PATH, _Stateful
@@ -630,7 +630,7 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
             _validate_keys_for_strict_loading(requested_metadata_keys, checkpoint.keys(), strict=strict)
 
             # Load metadata (anything not a module or optimizer)
-            _take_state_and_load_stateful(source=checkpoint, destination=state, keys=requested_metadata_keys)
+            _move_state_into(source=checkpoint, destination=state, keys=requested_metadata_keys)
 
             # return the remaining metadata that wasn't requested as part of `state`
             return checkpoint

--- a/src/lightning/fabric/strategies/strategy.py
+++ b/src/lightning/fabric/strategies/strategy.py
@@ -268,7 +268,7 @@ class Strategy(ABC):
                 state key, where its filter will be applied to the ``state_dict`` generated.
 
         """
-        state = self._convert_stateful_objects_in_state(state, filter=filter or {})
+        state = self._convert_stateful_objects_in_state(state, filter=(filter or {}))
         if self.is_global_zero:
             self.checkpoint_io.save_checkpoint(checkpoint=state, path=path, storage_options=storage_options)
 
@@ -399,6 +399,8 @@ class Strategy(ABC):
                 converted = self.get_module_state_dict(module=obj)
             elif isinstance(obj, Optimizer):
                 converted = self.get_optimizer_state(optimizer=obj)
+            elif isinstance(obj, _Stateful):
+                converted = obj.state_dict()
             else:
                 converted = obj
             _apply_filter(key, filter, converted, converted_state)

--- a/src/lightning/fabric/utilities/load.py
+++ b/src/lightning/fabric/utilities/load.py
@@ -210,8 +210,7 @@ def _take_state_and_load_stateful(
 ) -> None:
     """Takes the state from the source destination and moves it into the destination dictionary.
 
-    If an object in
-    the destination follows the stateful protocol, it loads the source state via ``load_state_dict``.
+    If an object in the destination follows the stateful protocol, it loads the source state via ``load_state_dict``.
 
     """
     keys = set(source.keys()) if keys is None else keys

--- a/src/lightning/fabric/utilities/load.py
+++ b/src/lightning/fabric/utilities/load.py
@@ -14,7 +14,7 @@ import pickle
 import warnings
 from functools import partial
 from io import BytesIO
-from typing import Any, Callable, Dict, IO, Optional, OrderedDict, Sequence, TYPE_CHECKING, Union, Mapping, Set
+from typing import Any, Callable, Dict, IO, Optional, OrderedDict, Sequence, Set, TYPE_CHECKING, Union
 
 import torch
 from lightning_utilities.core.apply_func import apply_to_collection
@@ -208,8 +208,12 @@ def _materialize_tensors(collection: Any) -> Any:
 def _take_state_and_load_stateful(
     source: Dict[str, Any], destination: Dict[str, Union[Any, _Stateful]], keys: Optional[Set[str]] = None
 ) -> None:
-    """Takes the state from the source destination and moves it into the destination dictionary. If an object in
-    the destination follows the stateful protocol, it loads the source state via ``load_state_dict``."""
+    """Takes the state from the source destination and moves it into the destination dictionary.
+
+    If an object in
+    the destination follows the stateful protocol, it loads the source state via ``load_state_dict``.
+
+    """
     keys = set(source.keys()) if keys is None else keys
     for key in keys:
         if key not in source:

--- a/src/lightning/fabric/utilities/load.py
+++ b/src/lightning/fabric/utilities/load.py
@@ -205,7 +205,7 @@ def _materialize_tensors(collection: Any) -> Any:
     return apply_to_collection(collection, dtype=_NotYetLoadedTensor, function=_load_tensor)
 
 
-def _take_state_and_load_stateful(
+def _move_state_into(
     source: Dict[str, Any], destination: Dict[str, Union[Any, _Stateful]], keys: Optional[Set[str]] = None
 ) -> None:
     """Takes the state from the source destination and moves it into the destination dictionary.

--- a/src/lightning/fabric/utilities/load.py
+++ b/src/lightning/fabric/utilities/load.py
@@ -213,11 +213,11 @@ def _take_state_and_load_stateful(
     If an object in the destination follows the stateful protocol, it loads the source state via ``load_state_dict``.
 
     """
-    keys = source.keys() if keys is None else keys
+    keys = set(source) if keys is None else keys
+    keys = keys & set(source)
     for key in keys:
-        if key not in source:
-            continue
+        state = source.pop(key)
         if key in destination and isinstance(destination[key], _Stateful):
-            destination[key].load_state_dict(source.pop(key))
+            destination[key].load_state_dict(state)
         else:
-            destination[key] = source.pop(key)
+            destination[key] = state

--- a/src/lightning/fabric/utilities/load.py
+++ b/src/lightning/fabric/utilities/load.py
@@ -213,8 +213,7 @@ def _take_state_and_load_stateful(
     If an object in the destination follows the stateful protocol, it loads the source state via ``load_state_dict``.
 
     """
-    keys = set(source) if keys is None else keys
-    keys = keys & set(source)
+    keys = set(source) if keys is None else keys & set(source)
     for key in keys:
         state = source.pop(key)
         if key in destination and isinstance(destination[key], _Stateful):

--- a/src/lightning/fabric/utilities/load.py
+++ b/src/lightning/fabric/utilities/load.py
@@ -213,7 +213,7 @@ def _take_state_and_load_stateful(
     If an object in the destination follows the stateful protocol, it loads the source state via ``load_state_dict``.
 
     """
-    keys = set(source.keys()) if keys is None else keys
+    keys = source.keys() if keys is None else keys
     for key in keys:
         if key not in source:
             continue

--- a/tests/tests_fabric/strategies/test_deepspeed.py
+++ b/tests/tests_fabric/strategies/test_deepspeed.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
-import os
 from re import escape
 from unittest import mock
 from unittest.mock import ANY, Mock

--- a/tests/tests_fabric/strategies/test_deepspeed.py
+++ b/tests/tests_fabric/strategies/test_deepspeed.py
@@ -60,12 +60,12 @@ def test_deepspeed_with_invalid_config_path():
 
 
 @RunIf(deepspeed=True)
-def test_deepspeed_with_env_path(tmpdir, monkeypatch, deepspeed_config):
+def test_deepspeed_with_env_path(tmp_path, monkeypatch, deepspeed_config):
     """Test to ensure if we pass an env variable, we load the config from the path."""
-    config_path = os.path.join(tmpdir, "temp.json")
+    config_path = tmp_path / "temp.json"
     with open(config_path, "w") as f:
         f.write(json.dumps(deepspeed_config))
-    monkeypatch.setenv("PL_DEEPSPEED_CONFIG_PATH", config_path)
+    monkeypatch.setenv("PL_DEEPSPEED_CONFIG_PATH", str(config_path))
     strategy = DeepSpeedStrategy()
     assert strategy.config == deepspeed_config
 
@@ -80,7 +80,7 @@ def test_deepspeed_defaults():
 
 
 @RunIf(deepspeed=True)
-def test_deepspeed_custom_activation_checkpointing_params(tmpdir):
+def test_deepspeed_custom_activation_checkpointing_params():
     """Ensure if we modify the activation checkpointing parameters, the deepspeed config contains these changes."""
     ds = DeepSpeedStrategy(
         partition_activations=True,

--- a/tests/tests_fabric/strategies/test_deepspeed_integration.py
+++ b/tests/tests_fabric/strategies/test_deepspeed_integration.py
@@ -392,6 +392,7 @@ def test_deepspeed_init_module_with_stage_3(empty_init):
     with mock.patch("deepspeed.zero.Init") as zero_init_mock, fabric.init_module(empty_init=empty_init):
         BoringModel()
     zero_init_mock.assert_called_once_with(enabled=True, remote_device=None, config_dict_or_path=ANY)
+    fabric.barrier()
 
 
 @RunIf(min_cuda_gpus=2, standalone=True, deepspeed=True, bf16_cuda=True)

--- a/tests/tests_fabric/strategies/test_strategy.py
+++ b/tests/tests_fabric/strategies/test_strategy.py
@@ -18,6 +18,7 @@ import pytest
 import torch
 from torch import nn
 
+from lightning.fabric.utilities.types import _Stateful
 from lightning.fabric.plugins import DoublePrecision, HalfPrecision, Precision
 from lightning.fabric.strategies import SingleDeviceStrategy
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_0
@@ -57,16 +58,46 @@ def test_save_checkpoint_convert_stateful_objects(tmp_path):
 
     model = nn.Linear(3, 3)
     optimizer = torch.optim.Adam(model.parameters())
+    scheduler = torch.optim.lr_scheduler.ExponentialLR(optimizer, 0.99)
 
     anything = {"cocofruit": 1}
-    state = {"model": model, "optimizer": optimizer, "anything": anything}
-    expected = {"model": model.state_dict(), "optimizer": optimizer.state_dict(), "anything": anything}
+    state = {"model": model, "optimizer": optimizer, "scheduler": scheduler, "anything": anything}
+    expected = {
+        "model": model.state_dict(),
+        "optimizer": optimizer.state_dict(),
+        "scheduler": scheduler.state_dict(),
+        "anything": anything,
+    }
     strategy.save_checkpoint(tmp_path, state)
     assert save_checkpoint_mock.call_args[1]["checkpoint"].keys() == expected.keys()
     saved_model_state = save_checkpoint_mock.call_args[1]["checkpoint"]["model"]
     assert all(torch.equal(p0, p1) for p0, p1 in zip(saved_model_state.values(), expected["model"].values()))
     assert save_checkpoint_mock.call_args[1]["checkpoint"]["optimizer"] == expected["optimizer"]
+    assert save_checkpoint_mock.call_args[1]["checkpoint"]["scheduler"] == expected["scheduler"]
     assert save_checkpoint_mock.call_args[1]["checkpoint"]["anything"] == expected["anything"]
+
+
+def test_save_load_stateful_objects(tmp_path):
+    """Test that stateful objects other than modules and optimizers get converted and loaded correctly."""
+
+    class MyState:
+        count = 1
+
+        def state_dict(self):
+            return {"cocofruit": self.count}
+
+        def load_state_dict(self, state_dict):
+            self.count = state_dict["cocofruit"]
+
+    state = MyState()
+    state.count = 100
+    assert isinstance(state, _Stateful)
+    strategy = SingleDeviceStrategy()  # surrogate class to test implementation in base class
+    strategy.save_checkpoint(tmp_path / "checkpoint.ckpt", {"state": state})
+    state = MyState()
+    assert state.count == 1
+    strategy.load_checkpoint(tmp_path / "checkpoint.ckpt", {"state": state})
+    assert state.count == 100
 
 
 def test_load_module_state_dict():

--- a/tests/tests_fabric/strategies/test_strategy.py
+++ b/tests/tests_fabric/strategies/test_strategy.py
@@ -80,21 +80,21 @@ def test_save_checkpoint_convert_stateful_objects(tmp_path):
 def test_save_load_stateful_objects(tmp_path):
     """Test that stateful objects other than modules and optimizers get converted and loaded correctly."""
 
-    class MyState:
+    class Fruit:
         count = 1
 
         def state_dict(self):
-            return {"cocofruit": self.count}
+            return {"count": self.count}
 
         def load_state_dict(self, state_dict):
-            self.count = state_dict["cocofruit"]
+            self.count = state_dict["count"]
 
-    state = MyState()
+    state = Fruit()
     state.count = 100
     assert isinstance(state, _Stateful)
     strategy = SingleDeviceStrategy()  # surrogate class to test implementation in base class
     strategy.save_checkpoint(tmp_path / "checkpoint.ckpt", {"state": state})
-    state = MyState()
+    state = Fruit()
     assert state.count == 1
     strategy.load_checkpoint(tmp_path / "checkpoint.ckpt", {"state": state})
     assert state.count == 100

--- a/tests/tests_fabric/strategies/test_strategy.py
+++ b/tests/tests_fabric/strategies/test_strategy.py
@@ -18,10 +18,10 @@ import pytest
 import torch
 from torch import nn
 
-from lightning.fabric.utilities.types import _Stateful
 from lightning.fabric.plugins import DoublePrecision, HalfPrecision, Precision
 from lightning.fabric.strategies import SingleDeviceStrategy
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_0
+from lightning.fabric.utilities.types import _Stateful
 from tests_fabric.helpers.runif import RunIf
 
 

--- a/tests/tests_fabric/utilities/test_load.py
+++ b/tests/tests_fabric/utilities/test_load.py
@@ -14,12 +14,7 @@
 import torch
 import torch.nn as nn
 
-from lightning.fabric.utilities.load import (
-    _lazy_load,
-    _materialize_tensors,
-    _NotYetLoadedTensor,
-    _move_state_into,
-)
+from lightning.fabric.utilities.load import _lazy_load, _materialize_tensors, _move_state_into, _NotYetLoadedTensor
 from tests_fabric.helpers.runif import RunIf
 
 

--- a/tests/tests_fabric/utilities/test_load.py
+++ b/tests/tests_fabric/utilities/test_load.py
@@ -14,7 +14,12 @@
 import torch
 import torch.nn as nn
 
-from lightning.fabric.utilities.load import _lazy_load, _materialize_tensors, _NotYetLoadedTensor
+from lightning.fabric.utilities.load import (
+    _lazy_load,
+    _materialize_tensors,
+    _NotYetLoadedTensor,
+    _take_state_and_load_stateful,
+)
 from tests_fabric.helpers.runif import RunIf
 
 
@@ -98,3 +103,37 @@ def test_materialize_tensors(tmp_path):
     assert torch.equal(materialized["nested"]["list"][0], collection["nested"]["list"][0])
     assert torch.equal(materialized["nested"]["list"][1], collection["nested"]["list"][1])
     assert materialized["nested"]["int"] == 1
+
+
+def test_take_state_and_load_stateful():
+    # all keys from the source
+    source = {"apple": 1, "cocofruit": 2}
+    destination = {"banana": 100}
+    _take_state_and_load_stateful(source, destination)
+    assert source == {}
+    assert destination == {"apple": 1, "cocofruit": 2, "banana": 100}
+
+    # subset of keys from the source
+    source = {"apple": 1, "cocofruit": 2}
+    destination = {"banana": 100}
+    keys = {"apple"}
+    _take_state_and_load_stateful(source, destination, keys=keys)
+    assert source == {"cocofruit": 2}
+    assert destination == {"apple": 1, "banana": 100}
+
+    # with stateful objects in destination
+    class Fruit:
+        count = 1
+
+        def state_dict(self):
+            return {"count": self.count}
+
+        def load_state_dict(self, state_dict):
+            self.count = state_dict["count"]
+
+    source = {"cocofruit": 2, "banana": {"count": 100}}
+    destination = {"banana": Fruit()}
+    _take_state_and_load_stateful(source, destination)
+    assert source == {}
+    assert destination["cocofruit"] == 2
+    assert destination["banana"].count == 100

--- a/tests/tests_fabric/utilities/test_load.py
+++ b/tests/tests_fabric/utilities/test_load.py
@@ -18,7 +18,7 @@ from lightning.fabric.utilities.load import (
     _lazy_load,
     _materialize_tensors,
     _NotYetLoadedTensor,
-    _take_state_and_load_stateful,
+    _move_state_into,
 )
 from tests_fabric.helpers.runif import RunIf
 
@@ -105,11 +105,11 @@ def test_materialize_tensors(tmp_path):
     assert materialized["nested"]["int"] == 1
 
 
-def test_take_state_and_load_stateful():
+def test_move_state_into():
     # all keys from the source
     source = {"apple": 1, "cocofruit": 2}
     destination = {"banana": 100}
-    _take_state_and_load_stateful(source, destination)
+    _move_state_into(source, destination)
     assert source == {}
     assert destination == {"apple": 1, "cocofruit": 2, "banana": 100}
 
@@ -117,7 +117,7 @@ def test_take_state_and_load_stateful():
     source = {"apple": 1, "cocofruit": 2}
     destination = {"banana": 100}
     keys = {"apple"}
-    _take_state_and_load_stateful(source, destination, keys=keys)
+    _move_state_into(source, destination, keys=keys)
     assert source == {"cocofruit": 2}
     assert destination == {"apple": 1, "banana": 100}
 
@@ -133,7 +133,7 @@ def test_take_state_and_load_stateful():
 
     source = {"cocofruit": 2, "banana": {"count": 100}}
     destination = {"banana": Fruit()}
-    _take_state_and_load_stateful(source, destination)
+    _move_state_into(source, destination)
     assert source == {}
     assert destination["cocofruit"] == 2
     assert destination["banana"].count == 100


### PR DESCRIPTION
## What does this PR do?

Fixes #18493

Sofar we've handled `state_dict()` and `load_state_dict()` automatically for the user on the module and optimizer(s) when saving and loading a state with Fabric. This PR extends this to any object in the state that is "stateful", for example learning rate schedulers:

```py
state = {"model": ..., "lr_scheduler": my_torch_scheduler}

# auomatically saves my_torch_scheduler.state_dict() now
fabric.save(path, state)

# auomatically calls my_torch_scheduler.load_state_dict() now
fabric.load(path, state)
```



cc @borda @justusschock @awaelchli @carmocca