### PR TITLE
More robust FabricOptimizer/LightningOptimizer wrapping logic

### DIFF
--- a/src/lightning/fabric/wrappers.py
+++ b/src/lightning/fabric/wrappers.py
@@ -83,8 +83,6 @@ class _FabricOptimizer:
         return output
 
     def __getattr__(self, item: Any) -> Any:
-        # __getattr__ gets called as a last resort if the attribute does not exist
-        # redirect it to the wrapped optimizer
         return getattr(self._optimizer, item)
 
 

--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -1087,7 +1087,7 @@ class LightningModule(
 
         # Then iterate over the current optimizer's parameters and set its `requires_grad`
         # properties accordingly
-        for group in optimizer.param_groups:  # type: ignore[union-attr]
+        for group in optimizer.param_groups:
             for param in group["params"]:
                 param.requires_grad = param_requires_grad_state[param]
         self._param_requires_grad_state = param_requires_grad_state

--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -164,8 +164,6 @@ class LightningModule(
             opts: MODULE_OPTIMIZERS = self._fabric_optimizers
         elif use_pl_optimizer:
             opts = self.trainer.strategy._lightning_optimizers
-            for opt in opts:
-                opt.refresh()
         else:
             opts = self.trainer.optimizers
 

--- a/tests/tests_fabric/test_wrappers.py
+++ b/tests/tests_fabric/test_wrappers.py
@@ -358,6 +358,8 @@ def test_fabric_optimizer_wraps():
     fabric_optimizer = _FabricOptimizer(optimizer, Mock())
     assert fabric_optimizer.optimizer is optimizer
     assert isinstance(fabric_optimizer, optimizer_cls)
+    assert isinstance(fabric_optimizer, _FabricOptimizer)
+    assert type(fabric_optimizer).__name__ == "FabricSGD"
 
 
 def test_fabric_optimizer_state_dict():

--- a/tests/tests_pytorch/core/test_lightning_optimizer.py
+++ b/tests/tests_pytorch/core/test_lightning_optimizer.py
@@ -150,15 +150,7 @@ def test_state():
     assert isinstance(lightning_optimizer, Adam)
     assert isinstance(lightning_optimizer, Optimizer)
 
-    lightning_dict = {
-        k: v
-        for k, v in lightning_optimizer.__dict__.items()
-        if k not in {"_optimizer", "_strategy", "_lightning_module", "_on_before_step", "_on_after_step"}
-    }
-
-    assert lightning_dict == optimizer.__dict__
     assert optimizer.state_dict() == lightning_optimizer.state_dict()
-    assert optimizer.state == lightning_optimizer.state
 
 
 def test_state_mutation():
@@ -174,10 +166,6 @@ def test_state_mutation():
     optimizer1 = torch.optim.Adam(model.parameters(), lr=100)
     lightning_optimizer1 = LightningOptimizer(optimizer1)
     optimizer1.load_state_dict(state_dict0)
-
-    # LightningOptimizer needs to be refreshed to see the new state
-    assert lightning_optimizer1.param_groups[0]["lr"] != 1.0
-    lightning_optimizer1.refresh()
     assert lightning_optimizer1.param_groups[0]["lr"] == 1.0
 
     # Load state into wrapped optimizer


### PR DESCRIPTION
## What does this PR do?

#18488 was a quick fix to keep the state saved in the ``__dict__`` of the wrapper in sync with the wrapped optimizer. This PR proposes a different solution where we don't need to do that. There are no user facing changes and the tests added in #18488 show the refactor here retains the desired behavior.




<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18516.org.readthedocs.build/en/18516/

<!-- readthedocs-preview pytorch-lightning end -->

cc @justusschock @awaelchli @carmocca