### PR TITLE
Disallow fabric save with filter and an object

### DIFF
--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -728,6 +728,8 @@ class Fabric:
 
         """
         if filter is not None:
+            if not isinstance(state, dict):
+                raise NotImplementedError("Filtering is not supported when a dictionary state is not passed.")
             if not isinstance(filter, dict):
                 raise TypeError(f"Filter should be a dictionary, given {filter!r}")
             if not set(filter).issubset(state):


### PR DESCRIPTION
## What does this PR do?

Filtering was implemented before we supported loading raw objects, and the addition of raw objects didn't consider filtering.

Since this isn't supported and tested, adding this block

cc @carmocca @justusschock @awaelchli