### PR TITLE
Lazily import dependencies for CometLogger

### DIFF
--- a/requirements/pytorch/loggers.info
+++ b/requirements/pytorch/loggers.info
@@ -1,6 +1,6 @@
 # all supported loggers. this list is here as a reference, but they are not installed in CI
 neptune
-comet-ml
+comet-ml >=3.31.0
 mlflow >=1.0.0
 wandb >=0.12.10
 tensorboard >=2.9.1

--- a/src/lightning/pytorch/loggers/__init__.py
+++ b/src/lightning/pytorch/loggers/__init__.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-
-from lightning.pytorch.loggers.comet import _COMET_AVAILABLE, CometLogger  # noqa: F401
+from lightning.pytorch.loggers.comet import CometLogger
 from lightning.pytorch.loggers.csv_logs import CSVLogger
 from lightning.pytorch.loggers.logger import Logger
 from lightning.pytorch.loggers.mlflow import MLFlowLogger
@@ -21,9 +19,4 @@ from lightning.pytorch.loggers.neptune import NeptuneLogger
 from lightning.pytorch.loggers.tensorboard import TensorBoardLogger
 from lightning.pytorch.loggers.wandb import WandbLogger
 
-__all__ = ["CSVLogger", "Logger", "MLFlowLogger", "TensorBoardLogger", "WandbLogger", "NeptuneLogger"]
-
-if _COMET_AVAILABLE:
-    __all__.append("CometLogger")
-    # needed to prevent ModuleNotFoundError and duplicated logs.
-    os.environ["COMET_DISABLE_AUTO_LOGGING"] = "1"
+__all__ = ["CometLogger", "CSVLogger", "Logger", "MLFlowLogger", "TensorBoardLogger", "WandbLogger", "NeptuneLogger"]

--- a/src/lightning/pytorch/loggers/comet.py
+++ b/src/lightning/pytorch/loggers/comet.py
@@ -217,10 +217,10 @@ class CometLogger(Logger):
         self._save_dir: Optional[str]
         self.rest_api_key: Optional[str]
 
-        import comet_ml
-
-        # needed to prevent ModuleNotFoundError and duplicated logs.
+        # needs to be set before the first `comet_ml` import
         os.environ["COMET_DISABLE_AUTO_LOGGING"] = "1"
+
+        import comet_ml
 
         # Determine online or offline mode based on which arguments were passed to CometLogger
         api_key = api_key or comet_ml.config.get_api_key(None, comet_ml.config.get_config())

--- a/src/lightning/pytorch/loggers/comet.py
+++ b/src/lightning/pytorch/loggers/comet.py
@@ -19,7 +19,7 @@ Comet Logger
 import logging
 import os
 from argparse import Namespace
-from typing import Any, Dict, Mapping, Optional, TYPE_CHECKING, Union
+from typing import Any, Dict, Mapping, Optional, Union
 
 from lightning_utilities.core.imports import RequirementCache
 from torch import Tensor
@@ -29,12 +29,6 @@ from lightning.fabric.utilities.logger import _add_prefix, _convert_params, _fla
 from lightning.pytorch.loggers.logger import Logger, rank_zero_experiment
 from lightning.pytorch.utilities.exceptions import MisconfigurationException
 from lightning.pytorch.utilities.rank_zero import rank_zero_only
-
-if TYPE_CHECKING:
-    from comet_ml import ExistingExperiment, Experiment, OfflineExperiment
-else:
-    # Required for docs generation
-    Experiment, ExistingExperiment, OfflineExperiment = None, None, None
 
 log = logging.getLogger(__name__)
 _COMET_AVAILABLE = RequirementCache("comet-ml>=3.31.0", module="comet_ml")
@@ -261,7 +255,7 @@ class CometLogger(Logger):
 
     @property
     @rank_zero_experiment
-    def experiment(self) -> Union[Experiment, ExistingExperiment, OfflineExperiment]:
+    def experiment(self) -> Any:
         r"""
         Actual Comet object. To use Comet features in your
         :class:`~lightning.pytorch.core.module.LightningModule` do the following.

--- a/src/lightning/pytorch/loggers/comet.py
+++ b/src/lightning/pytorch/loggers/comet.py
@@ -33,7 +33,7 @@ from lightning.pytorch.utilities.rank_zero import rank_zero_only
 if TYPE_CHECKING:
     from comet_ml import ExistingExperiment, Experiment, OfflineExperiment
 else:
-    # needed for Sphinx auto-documentation
+    # Required for docs generation
     Experiment, ExistingExperiment, OfflineExperiment = None, None, None
 
 log = logging.getLogger(__name__)

--- a/src/lightning/pytorch/loggers/comet.py
+++ b/src/lightning/pytorch/loggers/comet.py
@@ -19,9 +19,9 @@ Comet Logger
 import logging
 import os
 from argparse import Namespace
-from typing import Any, Dict, Mapping, Optional, Union
+from typing import Any, Dict, Mapping, Optional, Union, TYPE_CHECKING
 
-from lightning_utilities.core.imports import module_available
+from lightning_utilities.core.imports import RequirementCache
 from torch import Tensor
 from torch.nn import Module
 
@@ -30,25 +30,14 @@ from lightning.pytorch.loggers.logger import Logger, rank_zero_experiment
 from lightning.pytorch.utilities.exceptions import MisconfigurationException
 from lightning.pytorch.utilities.rank_zero import rank_zero_only
 
-log = logging.getLogger(__name__)
-_COMET_AVAILABLE = module_available("comet_ml")
-
-if _COMET_AVAILABLE:
-    import comet_ml
-    from comet_ml import ExistingExperiment as CometExistingExperiment
-    from comet_ml import Experiment as CometExperiment
-    from comet_ml import OfflineExperiment as CometOfflineExperiment
-
-    try:
-        from comet_ml.api import API
-    except ModuleNotFoundError:
-        # For more information, see: https://www.comet.ml/docs/python-sdk/releases/#release-300
-        from comet_ml.papi import API
+if TYPE_CHECKING:
+    from comet_ml import Experiment, ExistingExperiment, OfflineExperiment
 else:
-    # needed for test mocks, these tests shall be updated
-    comet_ml = None
-    CometExperiment, CometExistingExperiment, CometOfflineExperiment = None, None, None
-    API = None
+    # needed for Sphinx auto-documentation
+    Experiment, ExistingExperiment, OfflineExperiment = None, None, None
+
+log = logging.getLogger(__name__)
+_COMET_AVAILABLE = RequirementCache("comet-ml>=3.31.0", module="comet_ml")
 
 
 class CometLogger(Logger):
@@ -221,14 +210,17 @@ class CometLogger(Logger):
         prefix: str = "",
         **kwargs: Any,
     ):
-        if comet_ml is None:
-            raise ModuleNotFoundError(
-                "You want to use `comet_ml` logger which is not installed yet, install it with `pip install comet-ml`."
-            )
+        if not _COMET_AVAILABLE:
+            raise ModuleNotFoundError(str(_COMET_AVAILABLE))
         super().__init__()
         self._experiment = None
         self._save_dir: Optional[str]
         self.rest_api_key: Optional[str]
+
+        import comet_ml
+
+        # needed to prevent ModuleNotFoundError and duplicated logs.
+        os.environ["COMET_DISABLE_AUTO_LOGGING"] = "1"
 
         # Determine online or offline mode based on which arguments were passed to CometLogger
         api_key = api_key or comet_ml.config.get_api_key(None, comet_ml.config.get_config())
@@ -258,6 +250,8 @@ class CometLogger(Logger):
         self._future_experiment_key: Optional[str] = None
 
         if rest_api_key is not None:
+            from comet_ml.api import API
+
             # Comet.ml rest API, used to determine version number
             self.rest_api_key = rest_api_key
             self.comet_api = API(self.rest_api_key)
@@ -267,7 +261,7 @@ class CometLogger(Logger):
 
     @property
     @rank_zero_experiment
-    def experiment(self) -> Union[CometExperiment, CometExistingExperiment, CometOfflineExperiment]:
+    def experiment(self) -> Union[Experiment, ExistingExperiment, OfflineExperiment]:
         r"""
         Actual Comet object. To use Comet features in your
         :class:`~lightning.pytorch.core.module.LightningModule` do the following.
@@ -283,22 +277,24 @@ class CometLogger(Logger):
         if self._future_experiment_key is not None:
             os.environ["COMET_EXPERIMENT_KEY"] = self._future_experiment_key
 
+        from comet_ml import Experiment, ExistingExperiment, OfflineExperiment
+
         try:
             if self.mode == "online":
                 if self._experiment_key is None:
-                    self._experiment = CometExperiment(
+                    self._experiment = Experiment(
                         api_key=self.api_key, project_name=self._project_name, **self._kwargs
                     )
                     self._experiment_key = self._experiment.get_key()
                 else:
-                    self._experiment = CometExistingExperiment(
+                    self._experiment = ExistingExperiment(
                         api_key=self.api_key,
                         project_name=self._project_name,
                         previous_experiment=self._experiment_key,
                         **self._kwargs,
                     )
             else:
-                self._experiment = CometOfflineExperiment(
+                self._experiment = OfflineExperiment(
                     offline_directory=self.save_dir, project_name=self._project_name, **self._kwargs
                 )
             self._experiment.log_other("Created from", "pytorch-lightning")
@@ -406,6 +402,8 @@ class CometLogger(Logger):
 
         if self._future_experiment_key is not None:
             return self._future_experiment_key
+
+        import comet_ml
 
         # Pre-generate an experiment key
         self._future_experiment_key = comet_ml.generate_guid()

--- a/src/lightning/pytorch/loggers/comet.py
+++ b/src/lightning/pytorch/loggers/comet.py
@@ -19,7 +19,7 @@ Comet Logger
 import logging
 import os
 from argparse import Namespace
-from typing import Any, Dict, Mapping, Optional, Union, TYPE_CHECKING
+from typing import Any, Dict, Mapping, Optional, TYPE_CHECKING, Union
 
 from lightning_utilities.core.imports import RequirementCache
 from torch import Tensor
@@ -31,7 +31,7 @@ from lightning.pytorch.utilities.exceptions import MisconfigurationException
 from lightning.pytorch.utilities.rank_zero import rank_zero_only
 
 if TYPE_CHECKING:
-    from comet_ml import Experiment, ExistingExperiment, OfflineExperiment
+    from comet_ml import ExistingExperiment, Experiment, OfflineExperiment
 else:
     # needed for Sphinx auto-documentation
     Experiment, ExistingExperiment, OfflineExperiment = None, None, None
@@ -277,14 +277,12 @@ class CometLogger(Logger):
         if self._future_experiment_key is not None:
             os.environ["COMET_EXPERIMENT_KEY"] = self._future_experiment_key
 
-        from comet_ml import Experiment, ExistingExperiment, OfflineExperiment
+        from comet_ml import ExistingExperiment, Experiment, OfflineExperiment
 
         try:
             if self.mode == "online":
                 if self._experiment_key is None:
-                    self._experiment = Experiment(
-                        api_key=self.api_key, project_name=self._project_name, **self._kwargs
-                    )
+                    self._experiment = Experiment(api_key=self.api_key, project_name=self._project_name, **self._kwargs)
                     self._experiment_key = self._experiment.get_key()
                 else:
                     self._experiment = ExistingExperiment(

--- a/tests/tests_pytorch/loggers/conftest.py
+++ b/tests/tests_pytorch/loggers/conftest.py
@@ -25,3 +25,22 @@ def mlflow_mock(monkeypatch):
     mlflow.tracking = mlflow_tracking
     mlflow.entities = mlflow_entities
     return mlflow
+
+
+@pytest.fixture()
+def comet_mock(monkeypatch):
+    comet = ModuleType("comet_ml")
+    monkeypatch.setitem(sys.modules, "comet_ml", comet)
+
+    comet.Experiment = Mock()
+    comet.ExistingExperiment = Mock()
+    comet.OfflineExperiment = Mock()
+    comet.API = Mock()
+    comet.config = Mock()
+
+    comet_api = ModuleType("api")
+    comet_api.API = Mock()
+    monkeypatch.setitem(sys.modules, "comet_ml.api", comet_api)
+
+    comet.api = comet_api
+    return comet

--- a/tests/tests_pytorch/loggers/test_all.py
+++ b/tests/tests_pytorch/loggers/test_all.py
@@ -82,15 +82,15 @@ def _instantiate_logger(logger_class, save_dir, **override_kwargs):
 @mock.patch("lightning.pytorch.loggers.wandb._WANDB_AVAILABLE", True)
 @mock.patch("lightning.pytorch.loggers.comet._COMET_AVAILABLE", True)
 @pytest.mark.parametrize("logger_class", ALL_LOGGER_CLASSES)
-def test_loggers_fit_test_all(logger_class, mlflow_mock, wandb_mock, comet_mock, tmpdir):
+def test_loggers_fit_test_all(logger_class, mlflow_mock, wandb_mock, comet_mock, tmp_path):
     """Verify that basic functionality of all loggers."""
     with contextlib.ExitStack() as stack:
         for mgr in LOGGER_CTX_MANAGERS:
             stack.enter_context(mgr)
-        _test_loggers_fit_test(tmpdir, logger_class)
+        _test_loggers_fit_test(tmp_path, logger_class)
 
 
-def _test_loggers_fit_test(tmpdir, logger_class):
+def _test_loggers_fit_test(tmp_path, logger_class):
     class CustomModel(BoringModel):
         def training_step(self, batch, batch_idx):
             loss = self.step(batch)
@@ -112,7 +112,7 @@ def _test_loggers_fit_test(tmpdir, logger_class):
             super().log_metrics(metrics, step)
             self.history.append((step, metrics))
 
-    logger_args = _get_logger_args(logger_class, tmpdir)
+    logger_args = _get_logger_args(logger_class, tmp_path)
     logger = StoreHistoryLogger(**logger_args)
 
     if logger_class == WandbLogger:
@@ -139,7 +139,7 @@ def _test_loggers_fit_test(tmpdir, logger_class):
         limit_train_batches=1,
         limit_val_batches=1,
         log_every_n_steps=1,
-        default_root_dir=tmpdir,
+        default_root_dir=tmp_path,
     )
     trainer.fit(model)
     trainer.test()
@@ -165,7 +165,7 @@ def _test_loggers_fit_test(tmpdir, logger_class):
 @pytest.mark.parametrize(
     "logger_class", ALL_LOGGER_CLASSES_WO_NEPTUNE
 )  # WandbLogger and NeptuneLogger get tested separately
-def test_loggers_pickle_all(tmpdir, monkeypatch, logger_class):
+def test_loggers_pickle_all(tmp_path, monkeypatch, logger_class):
     """Test that the logger objects can be pickled.
 
     This test only makes sense if the packages are installed.
@@ -173,16 +173,16 @@ def test_loggers_pickle_all(tmpdir, monkeypatch, logger_class):
     """
     _patch_comet_atexit(monkeypatch)
     try:
-        _test_loggers_pickle(tmpdir, monkeypatch, logger_class)
+        _test_loggers_pickle(tmp_path, monkeypatch, logger_class)
     except (ImportError, ModuleNotFoundError):
         pytest.xfail(f"pickle test requires {logger_class.__class__} dependencies to be installed.")
 
 
-def _test_loggers_pickle(tmpdir, monkeypatch, logger_class):
+def _test_loggers_pickle(tmp_path, monkeypatch, logger_class):
     """Verify that pickling trainer with logger works."""
     _patch_comet_atexit(monkeypatch)
 
-    logger_args = _get_logger_args(logger_class, tmpdir)
+    logger_args = _get_logger_args(logger_class, tmp_path)
     logger = logger_class(**logger_args)
 
     # this can cause pickle error if the experiment object is not picklable
@@ -208,7 +208,7 @@ def _test_loggers_pickle(tmpdir, monkeypatch, logger_class):
 
 
 @pytest.mark.parametrize("tuner_method", ["lr_find", "scale_batch_size"])
-def test_logger_reset_correctly(tmpdir, tuner_method):
+def test_logger_reset_correctly(tmp_path, tuner_method):
     """Test that the tuners do not alter the logger reference."""
 
     class CustomModel(BoringModel):
@@ -217,7 +217,7 @@ def test_logger_reset_correctly(tmpdir, tuner_method):
             self.save_hyperparameters()
 
     model = CustomModel()
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1)
+    trainer = Trainer(default_root_dir=tmp_path, max_epochs=1)
     tuner = Tuner(trainer)
 
     logger1 = trainer.logger
@@ -270,18 +270,18 @@ class CustomLoggerWithoutExperiment(Logger):
 @mock.patch.dict(os.environ, {})
 @pytest.mark.parametrize("logger_class", [*ALL_LOGGER_CLASSES_WO_NEPTUNE, CustomLoggerWithoutExperiment])
 @RunIf(skip_windows=True)
-def test_logger_initialization(tmpdir, monkeypatch, logger_class):
+def test_logger_initialization(tmp_path, monkeypatch, logger_class):
     """Test that loggers get replaced by dummy loggers on global rank > 0 and that the experiment object is available
     at the right time in Trainer."""
     _patch_comet_atexit(monkeypatch)
     try:
-        _test_logger_initialization(tmpdir, logger_class)
+        _test_logger_initialization(tmp_path, logger_class)
     except (ImportError, ModuleNotFoundError):
         pytest.xfail(f"multi-process test requires {logger_class.__class__} dependencies to be installed.")
 
 
-def _test_logger_initialization(tmpdir, logger_class):
-    logger_args = _get_logger_args(logger_class, tmpdir)
+def _test_logger_initialization(tmp_path, logger_class):
+    logger_args = _get_logger_args(logger_class, tmp_path)
     logger = logger_class(**logger_args)
     callbacks = [LazyInitExperimentCheck()]
     if not isinstance(logger, CustomLoggerWithoutExperiment):
@@ -289,7 +289,7 @@ def _test_logger_initialization(tmpdir, logger_class):
     model = BoringModel()
     trainer = Trainer(
         logger=logger,
-        default_root_dir=tmpdir,
+        default_root_dir=tmp_path,
         strategy="ddp_spawn",
         accelerator="cpu",
         devices=2,
@@ -300,14 +300,14 @@ def _test_logger_initialization(tmpdir, logger_class):
 
 
 @mock.patch.dict(os.environ, {})
-def test_logger_with_prefix_all(mlflow_mock, wandb_mock, comet_mock, monkeypatch, tmpdir):
+def test_logger_with_prefix_all(mlflow_mock, wandb_mock, comet_mock, monkeypatch, tmp_path):
     """Test that prefix is added at the beginning of the metric keys."""
     prefix = "tmp"
 
     # Comet
     with mock.patch("lightning.pytorch.loggers.comet._COMET_AVAILABLE", return_value=True):
         _patch_comet_atexit(monkeypatch)
-        logger = _instantiate_logger(CometLogger, save_dir=tmpdir, prefix=prefix)
+        logger = _instantiate_logger(CometLogger, save_dir=tmp_path, prefix=prefix)
         logger.log_metrics({"test": 1.0}, step=0)
         logger.experiment.log_metrics.assert_called_once_with({"tmp-test": 1.0}, epoch=None, step=0)
 
@@ -316,7 +316,7 @@ def test_logger_with_prefix_all(mlflow_mock, wandb_mock, comet_mock, monkeypatch
         "lightning.pytorch.loggers.mlflow._get_resolve_tags", Mock()
     ):
         Metric = mlflow_mock.entities.Metric
-        logger = _instantiate_logger(MLFlowLogger, save_dir=tmpdir, prefix=prefix)
+        logger = _instantiate_logger(MLFlowLogger, save_dir=tmp_path, prefix=prefix)
         logger.log_metrics({"test": 1.0}, step=0)
         logger.experiment.log_batch.assert_called_once_with(
             run_id=ANY, metrics=[Metric(key="tmp-test", value=1.0, timestamp=ANY, step=0)]
@@ -326,7 +326,7 @@ def test_logger_with_prefix_all(mlflow_mock, wandb_mock, comet_mock, monkeypatch
     with mock.patch("lightning.pytorch.loggers.neptune.neptune"), mock.patch(
         "lightning.pytorch.loggers.neptune._NEPTUNE_AVAILABLE", return_value=True
     ), mock.patch("lightning.pytorch.loggers.neptune.Handler", new=mock.Mock):
-        logger = _instantiate_logger(NeptuneLogger, api_key="test", project="project", save_dir=tmpdir, prefix=prefix)
+        logger = _instantiate_logger(NeptuneLogger, api_key="test", project="project", save_dir=tmp_path, prefix=prefix)
         assert logger.experiment.__getitem__.call_count == 0
         logger.log_metrics({"test": 1.0}, step=0)
         assert logger.experiment.__getitem__.call_count == 1
@@ -340,23 +340,23 @@ def test_logger_with_prefix_all(mlflow_mock, wandb_mock, comet_mock, monkeypatch
         import tensorboardX as tb
 
     monkeypatch.setattr(tb, "SummaryWriter", Mock())
-    logger = _instantiate_logger(TensorBoardLogger, save_dir=tmpdir, prefix=prefix)
+    logger = _instantiate_logger(TensorBoardLogger, save_dir=tmp_path, prefix=prefix)
     logger.log_metrics({"test": 1.0}, step=0)
     logger.experiment.add_scalar.assert_called_once_with("tmp-test", 1.0, 0)
 
     # WandB
     with mock.patch("lightning.pytorch.loggers.wandb._WANDB_AVAILABLE", True):
-        logger = _instantiate_logger(WandbLogger, save_dir=tmpdir, prefix=prefix)
+        logger = _instantiate_logger(WandbLogger, save_dir=tmp_path, prefix=prefix)
         wandb_mock.run = None
         wandb_mock.init().step = 0
         logger.log_metrics({"test": 1.0}, step=0)
         logger.experiment.log.assert_called_once_with({"tmp-test": 1.0, "trainer/global_step": 0})
 
 
-def test_logger_default_name(mlflow_mock, monkeypatch, tmpdir):
+def test_logger_default_name(mlflow_mock, monkeypatch, tmp_path):
     """Test that the default logger name is lightning_logs."""
     # CSV
-    logger = CSVLogger(save_dir=tmpdir)
+    logger = CSVLogger(save_dir=tmp_path)
     assert logger.name == "lightning_logs"
 
     # TensorBoard
@@ -366,7 +366,7 @@ def test_logger_default_name(mlflow_mock, monkeypatch, tmpdir):
         import tensorboardX as tb
 
     monkeypatch.setattr(tb, "SummaryWriter", Mock())
-    logger = _instantiate_logger(TensorBoardLogger, save_dir=tmpdir)
+    logger = _instantiate_logger(TensorBoardLogger, save_dir=tmp_path)
     assert logger.name == "lightning_logs"
 
     # MLflow
@@ -375,7 +375,7 @@ def test_logger_default_name(mlflow_mock, monkeypatch, tmpdir):
     ):
         client = mlflow_mock.tracking.MlflowClient()
         client.get_experiment_by_name.return_value = None
-        logger = _instantiate_logger(MLFlowLogger, save_dir=tmpdir)
+        logger = _instantiate_logger(MLFlowLogger, save_dir=tmp_path)
 
         _ = logger.experiment
         logger._mlflow_client.create_experiment.assert_called_with(name="lightning_logs", artifact_location=ANY)

--- a/tests/tests_pytorch/loggers/test_comet.py
+++ b/tests/tests_pytorch/loggers/test_comet.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from unittest.mock import DEFAULT, patch
+from unittest import mock
+from unittest.mock import DEFAULT, patch, Mock
 
 import pytest
 from torch import tensor
@@ -30,75 +31,68 @@ def _patch_comet_atexit(monkeypatch):
     monkeypatch.setattr(atexit, "register", lambda _: None)
 
 
-@patch("lightning.pytorch.loggers.comet.comet_ml")
-def test_comet_logger_online(comet):
+@mock.patch.dict(os.environ, {})
+def test_comet_logger_online(comet_mock):
     """Test comet online with mocks."""
     # Test api_key given
-    with patch("lightning.pytorch.loggers.comet.CometExperiment") as comet_experiment:
-        logger = CometLogger(api_key="key", workspace="dummy-test", project_name="general")
-
-        _ = logger.experiment
-
-        comet_experiment.assert_called_once_with(api_key="key", workspace="dummy-test", project_name="general")
+    comet_experiment = comet_mock.Experiment
+    logger = CometLogger(api_key="key", workspace="dummy-test", project_name="general")
+    _ = logger.experiment
+    comet_experiment.assert_called_once_with(api_key="key", workspace="dummy-test", project_name="general")
 
     # Test both given
-    with patch("lightning.pytorch.loggers.comet.CometExperiment") as comet_experiment:
-        logger = CometLogger(save_dir="test", api_key="key", workspace="dummy-test", project_name="general")
-
-        _ = logger.experiment
-
-        comet_experiment.assert_called_once_with(api_key="key", workspace="dummy-test", project_name="general")
+    comet_experiment.reset_mock()
+    logger = CometLogger(save_dir="test", api_key="key", workspace="dummy-test", project_name="general")
+    _ = logger.experiment
+    comet_experiment.assert_called_once_with(api_key="key", workspace="dummy-test", project_name="general")
 
     # Test already exists
-    with patch("lightning.pytorch.loggers.comet.CometExistingExperiment") as comet_existing:
-        logger = CometLogger(
-            experiment_key="test",
-            experiment_name="experiment",
-            api_key="key",
-            workspace="dummy-test",
-            project_name="general",
-        )
+    comet_existing = comet_mock.ExistingExperiment
+    logger = CometLogger(
+        experiment_key="test",
+        experiment_name="experiment",
+        api_key="key",
+        workspace="dummy-test",
+        project_name="general",
+    )
+    _ = logger.experiment
+    comet_existing.assert_called_once_with(
+        api_key="key", workspace="dummy-test", project_name="general", previous_experiment="test"
+    )
+    comet_existing().set_name.assert_called_once_with("experiment")
 
-        _ = logger.experiment
-
-        comet_existing.assert_called_once_with(
-            api_key="key", workspace="dummy-test", project_name="general", previous_experiment="test"
-        )
-
-        comet_existing().set_name.assert_called_once_with("experiment")
-
-    with patch("lightning.pytorch.loggers.comet.API") as api:
-        CometLogger(api_key="key", workspace="dummy-test", project_name="general", rest_api_key="rest")
-
-        api.assert_called_once_with("rest")
+    # API experiment
+    api = comet_mock.api.API
+    CometLogger(api_key="key", workspace="dummy-test", project_name="general", rest_api_key="rest")
+    api.assert_called_once_with("rest")
 
 
-@patch("lightning.pytorch.loggers.comet.comet_ml")
-def test_comet_logger_no_api_key_given(comet):
+@mock.patch.dict(os.environ, {})
+def test_comet_logger_no_api_key_given(comet_mock):
     """Test that CometLogger fails to initialize if both api key and save_dir are missing."""
     with pytest.raises(MisconfigurationException, match="requires either api_key or save_dir"):
-        comet.config.get_api_key.return_value = None
+        comet_mock.config.get_api_key.return_value = None
         CometLogger(workspace="dummy-test", project_name="general")
 
 
-@patch("lightning.pytorch.loggers.comet.comet_ml")
-def test_comet_logger_experiment_name(comet):
+@mock.patch.dict(os.environ, {})
+def test_comet_logger_experiment_name(comet_mock):
     """Test that Comet Logger experiment name works correctly."""
     api_key = "key"
     experiment_name = "My Name"
 
     # Test api_key given
-    with patch("lightning.pytorch.loggers.comet.CometExperiment") as comet_experiment:
-        logger = CometLogger(api_key=api_key, experiment_name=experiment_name)
-        assert logger._experiment is None
+    comet_experiment = comet_mock.Experiment
+    logger = CometLogger(api_key=api_key, experiment_name=experiment_name)
+    assert logger._experiment is None
 
-        _ = logger.experiment
-        comet_experiment.assert_called_once_with(api_key=api_key, project_name=None)
-        comet_experiment().set_name.assert_called_once_with(experiment_name)
+    _ = logger.experiment
+    comet_experiment.assert_called_once_with(api_key=api_key, project_name=None)
+    comet_experiment().set_name.assert_called_once_with(experiment_name)
 
 
-@patch("lightning.pytorch.loggers.comet.comet_ml")
-def test_comet_logger_manual_experiment_key(comet):
+@mock.patch.dict(os.environ, {})
+def test_comet_logger_manual_experiment_key(comet_mock):
     """Test that Comet Logger respects manually set COMET_EXPERIMENT_KEY."""
     api_key = "key"
     experiment_key = "96346da91469407a85641afe5766b554"
@@ -111,10 +105,11 @@ def test_comet_logger_manual_experiment_key(comet):
 
         return DEFAULT
 
+    comet_experiment = comet_mock.Experiment
+    comet_experiment.side_effect = save_os_environ
+
     # Test api_key given
-    with patch.dict(os.environ, {"COMET_EXPERIMENT_KEY": experiment_key}), patch(
-        "lightning.pytorch.loggers.comet.CometExperiment", side_effect=save_os_environ
-    ) as comet_experiment:
+    with patch.dict(os.environ, {"COMET_EXPERIMENT_KEY": experiment_key}):
         logger = CometLogger(api_key=api_key)
         assert logger.version == experiment_key
         assert logger._experiment is None
@@ -125,106 +120,100 @@ def test_comet_logger_manual_experiment_key(comet):
     assert instantiation_environ["COMET_EXPERIMENT_KEY"] == experiment_key
 
 
-@patch("lightning.pytorch.loggers.comet.CometOfflineExperiment")
-@patch("lightning.pytorch.loggers.comet.comet_ml")
-def test_comet_logger_dirs_creation(comet, comet_experiment, tmpdir, monkeypatch):
+@mock.patch.dict(os.environ, {})
+def test_comet_logger_dirs_creation(comet_mock, tmp_path, monkeypatch):
     """Test that the logger creates the folders and files in the right place."""
     _patch_comet_atexit(monkeypatch)
+    comet_experiment = comet_mock.OfflineExperiment
 
-    comet.config.get_api_key.return_value = None
-    comet.generate_guid.return_value = "4321"
+    comet_mock.config.get_api_key.return_value = None
+    comet_mock.generate_guid = Mock()
+    comet_mock.generate_guid.return_value = "4321"
 
-    logger = CometLogger(project_name="test", save_dir=tmpdir)
-    assert not os.listdir(tmpdir)
+    logger = CometLogger(project_name="test", save_dir=str(tmp_path))
+    assert not os.listdir(tmp_path)
     assert logger.mode == "offline"
-    assert logger.save_dir == tmpdir
+    assert logger.save_dir == str(tmp_path)
     assert logger.name == "test"
     assert logger.version == "4321"
 
     _ = logger.experiment
-
-    comet_experiment.assert_called_once_with(offline_directory=tmpdir, project_name="test")
+    comet_experiment.assert_called_once_with(offline_directory=str(tmp_path), project_name="test")
 
     # mock return values of experiment
     logger.experiment.id = "1"
     logger.experiment.project_name = "test"
 
     model = BoringModel()
-    trainer = Trainer(default_root_dir=tmpdir, logger=logger, max_epochs=1, limit_train_batches=3, limit_val_batches=3)
+    trainer = Trainer(default_root_dir=tmp_path, logger=logger, max_epochs=1, limit_train_batches=3, limit_val_batches=3)
     assert trainer.log_dir == logger.save_dir
     trainer.fit(model)
 
-    assert trainer.checkpoint_callback.dirpath == (tmpdir / "test" / "1" / "checkpoints")
+    assert trainer.checkpoint_callback.dirpath == str(tmp_path / "test" / "1" / "checkpoints")
     assert set(os.listdir(trainer.checkpoint_callback.dirpath)) == {"epoch=0-step=3.ckpt"}
     assert trainer.log_dir == logger.save_dir
 
 
-@patch("lightning.pytorch.loggers.comet.comet_ml")
-def test_comet_name_default(comet):
+@mock.patch.dict(os.environ, {})
+def test_comet_name_default(comet_mock):
     """Test that CometLogger.name don't create an Experiment and returns a default value."""
     api_key = "key"
-
-    with patch("lightning.pytorch.loggers.comet.CometExperiment"):
-        logger = CometLogger(api_key=api_key)
-        assert logger._experiment is None
-        assert logger.name == "comet-default"
-        assert logger._experiment is None
+    logger = CometLogger(api_key=api_key)
+    assert logger._experiment is None
+    assert logger.name == "comet-default"
+    assert logger._experiment is None
 
 
-@patch("lightning.pytorch.loggers.comet.comet_ml")
-def test_comet_name_project_name(comet):
+@mock.patch.dict(os.environ, {})
+def test_comet_name_project_name(comet_mock):
     """Test that CometLogger.name does not create an Experiment and returns project name if passed."""
     api_key = "key"
     project_name = "My Project Name"
-
-    with patch("lightning.pytorch.loggers.comet.CometExperiment"):
-        logger = CometLogger(api_key=api_key, project_name=project_name)
-        assert logger._experiment is None
-        assert logger.name == project_name
-        assert logger._experiment is None
+    logger = CometLogger(api_key=api_key, project_name=project_name)
+    assert logger._experiment is None
+    assert logger.name == project_name
+    assert logger._experiment is None
 
 
-@patch("lightning.pytorch.loggers.comet.comet_ml")
-def test_comet_version_without_experiment(comet):
+@mock.patch.dict(os.environ, {})
+def test_comet_version_without_experiment(comet_mock):
     """Test that CometLogger.version does not create an Experiment."""
     api_key = "key"
     experiment_name = "My Name"
-    comet.generate_guid.return_value = "1234"
+    comet_mock.generate_guid = Mock()
+    comet_mock.generate_guid.return_value = "1234"
 
-    with patch("lightning.pytorch.loggers.comet.CometExperiment"):
-        logger = CometLogger(api_key=api_key, experiment_name=experiment_name)
-        assert logger._experiment is None
+    logger = CometLogger(api_key=api_key, experiment_name=experiment_name)
+    assert logger._experiment is None
 
-        first_version = logger.version
-        assert first_version is not None
-        assert logger.version == first_version
-        assert logger._experiment is None
+    first_version = logger.version
+    assert first_version is not None
+    assert logger.version == first_version
+    assert logger._experiment is None
 
-        _ = logger.experiment
+    _ = logger.experiment
 
-        logger.reset_experiment()
+    logger.reset_experiment()
 
-        second_version = logger.version == "1234"
-        assert second_version is not None
-        assert second_version != first_version
+    second_version = logger.version == "1234"
+    assert second_version is not None
+    assert second_version != first_version
 
 
-@patch("lightning.pytorch.loggers.comet.CometExperiment")
-@patch("lightning.pytorch.loggers.comet.comet_ml")
-def test_comet_epoch_logging(comet, comet_experiment, tmpdir, monkeypatch):
+@mock.patch.dict(os.environ, {})
+def test_comet_epoch_logging(comet_mock, tmp_path, monkeypatch):
     """Test that CometLogger removes the epoch key from the metrics dict and passes it as argument."""
     _patch_comet_atexit(monkeypatch)
-    logger = CometLogger(project_name="test", save_dir=tmpdir)
+    logger = CometLogger(project_name="test", save_dir=str(tmp_path))
     logger.log_metrics({"test": 1, "epoch": 1}, step=123)
     logger.experiment.log_metrics.assert_called_once_with({"test": 1}, epoch=1, step=123)
 
 
-@patch("lightning.pytorch.loggers.comet.CometExperiment")
-@patch("lightning.pytorch.loggers.comet.comet_ml")
-def test_comet_metrics_safe(comet, tmpdir, monkeypatch):
+@mock.patch.dict(os.environ, {})
+def test_comet_metrics_safe(comet_mock, tmp_path, monkeypatch):
     """Test that CometLogger.log_metrics doesn't do inplace modification of metrics."""
     _patch_comet_atexit(monkeypatch)
-    logger = CometLogger(project_name="test", save_dir=tmpdir)
+    logger = CometLogger(project_name="test", save_dir=str(tmp_path))
     metrics = {"tensor": tensor([[1.0, 0.0], [0.0, 1.0]], requires_grad=True), "epoch": 1}
     logger.log_metrics(metrics)
     assert metrics["tensor"].requires_grad

--- a/tests/tests_pytorch/loggers/test_comet.py
+++ b/tests/tests_pytorch/loggers/test_comet.py
@@ -32,6 +32,7 @@ def _patch_comet_atexit(monkeypatch):
 
 
 @mock.patch.dict(os.environ, {})
+@mock.patch("lightning.pytorch.loggers.comet._COMET_AVAILABLE", True)
 def test_comet_logger_online(comet_mock):
     """Test comet online with mocks."""
     # Test api_key given
@@ -68,6 +69,7 @@ def test_comet_logger_online(comet_mock):
 
 
 @mock.patch.dict(os.environ, {})
+@mock.patch("lightning.pytorch.loggers.comet._COMET_AVAILABLE", True)
 def test_comet_logger_no_api_key_given(comet_mock):
     """Test that CometLogger fails to initialize if both api key and save_dir are missing."""
     with pytest.raises(MisconfigurationException, match="requires either api_key or save_dir"):
@@ -76,6 +78,7 @@ def test_comet_logger_no_api_key_given(comet_mock):
 
 
 @mock.patch.dict(os.environ, {})
+@mock.patch("lightning.pytorch.loggers.comet._COMET_AVAILABLE", True)
 def test_comet_logger_experiment_name(comet_mock):
     """Test that Comet Logger experiment name works correctly."""
     api_key = "key"
@@ -92,6 +95,7 @@ def test_comet_logger_experiment_name(comet_mock):
 
 
 @mock.patch.dict(os.environ, {})
+@mock.patch("lightning.pytorch.loggers.comet._COMET_AVAILABLE", True)
 def test_comet_logger_manual_experiment_key(comet_mock):
     """Test that Comet Logger respects manually set COMET_EXPERIMENT_KEY."""
     api_key = "key"
@@ -121,6 +125,7 @@ def test_comet_logger_manual_experiment_key(comet_mock):
 
 
 @mock.patch.dict(os.environ, {})
+@mock.patch("lightning.pytorch.loggers.comet._COMET_AVAILABLE", True)
 def test_comet_logger_dirs_creation(comet_mock, tmp_path, monkeypatch):
     """Test that the logger creates the folders and files in the right place."""
     _patch_comet_atexit(monkeypatch)
@@ -155,6 +160,7 @@ def test_comet_logger_dirs_creation(comet_mock, tmp_path, monkeypatch):
 
 
 @mock.patch.dict(os.environ, {})
+@mock.patch("lightning.pytorch.loggers.comet._COMET_AVAILABLE", True)
 def test_comet_name_default(comet_mock):
     """Test that CometLogger.name don't create an Experiment and returns a default value."""
     api_key = "key"
@@ -165,6 +171,7 @@ def test_comet_name_default(comet_mock):
 
 
 @mock.patch.dict(os.environ, {})
+@mock.patch("lightning.pytorch.loggers.comet._COMET_AVAILABLE", True)
 def test_comet_name_project_name(comet_mock):
     """Test that CometLogger.name does not create an Experiment and returns project name if passed."""
     api_key = "key"
@@ -176,6 +183,7 @@ def test_comet_name_project_name(comet_mock):
 
 
 @mock.patch.dict(os.environ, {})
+@mock.patch("lightning.pytorch.loggers.comet._COMET_AVAILABLE", True)
 def test_comet_version_without_experiment(comet_mock):
     """Test that CometLogger.version does not create an Experiment."""
     api_key = "key"
@@ -201,6 +209,7 @@ def test_comet_version_without_experiment(comet_mock):
 
 
 @mock.patch.dict(os.environ, {})
+@mock.patch("lightning.pytorch.loggers.comet._COMET_AVAILABLE", True)
 def test_comet_epoch_logging(comet_mock, tmp_path, monkeypatch):
     """Test that CometLogger removes the epoch key from the metrics dict and passes it as argument."""
     _patch_comet_atexit(monkeypatch)
@@ -210,6 +219,7 @@ def test_comet_epoch_logging(comet_mock, tmp_path, monkeypatch):
 
 
 @mock.patch.dict(os.environ, {})
+@mock.patch("lightning.pytorch.loggers.comet._COMET_AVAILABLE", True)
 def test_comet_metrics_safe(comet_mock, tmp_path, monkeypatch):
     """Test that CometLogger.log_metrics doesn't do inplace modification of metrics."""
     _patch_comet_atexit(monkeypatch)

--- a/tests/tests_pytorch/loggers/test_comet.py
+++ b/tests/tests_pytorch/loggers/test_comet.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import os
 from unittest import mock
-from unittest.mock import DEFAULT, patch, Mock
+from unittest.mock import DEFAULT, Mock, patch
 
 import pytest
 from torch import tensor
@@ -150,7 +150,9 @@ def test_comet_logger_dirs_creation(comet_mock, tmp_path, monkeypatch):
     logger.experiment.project_name = "test"
 
     model = BoringModel()
-    trainer = Trainer(default_root_dir=tmp_path, logger=logger, max_epochs=1, limit_train_batches=3, limit_val_batches=3)
+    trainer = Trainer(
+        default_root_dir=tmp_path, logger=logger, max_epochs=1, limit_train_batches=3, limit_val_batches=3
+    )
     assert trainer.log_dir == logger.save_dir
     trainer.fit(model)
 

--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -48,7 +48,7 @@ from lightning.pytorch.cli import (
     SaveConfigCallback,
 )
 from lightning.pytorch.demos.boring_classes import BoringDataModule, BoringModel
-from lightning.pytorch.loggers import TensorBoardLogger, CSVLogger
+from lightning.pytorch.loggers import CSVLogger, TensorBoardLogger
 from lightning.pytorch.loggers.comet import _COMET_AVAILABLE
 from lightning.pytorch.loggers.neptune import _NEPTUNE_AVAILABLE
 from lightning.pytorch.loggers.wandb import _WANDB_AVAILABLE

--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -48,8 +48,8 @@ from lightning.pytorch.cli import (
     SaveConfigCallback,
 )
 from lightning.pytorch.demos.boring_classes import BoringDataModule, BoringModel
-from lightning.pytorch.loggers import _COMET_AVAILABLE, TensorBoardLogger
-from lightning.pytorch.loggers.csv_logs import CSVLogger
+from lightning.pytorch.loggers import TensorBoardLogger, CSVLogger
+from lightning.pytorch.loggers.comet import _COMET_AVAILABLE
 from lightning.pytorch.loggers.neptune import _NEPTUNE_AVAILABLE
 from lightning.pytorch.loggers.wandb import _WANDB_AVAILABLE
 from lightning.pytorch.strategies import DDPStrategy


### PR DESCRIPTION
## What does this PR do?

Refactors the comet logger module to lazily import its dependencies only when the CometLogger instance is requested.
Same idea as https://github.com/Lightning-AI/lightning/pull/18528
Part of https://github.com/Lightning-AI/lightning/issues/12786


<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18540.org.readthedocs.build/en/18540/

<!-- readthedocs-preview pytorch-lightning end -->

cc @justusschock @awaelchli @borda