### PR TITLE
Replace LightningClient with import from lightning_cloud

### DIFF
--- a/requirements/app/app.txt
+++ b/requirements/app/app.txt
@@ -1,4 +1,4 @@
-lightning-cloud >=0.5.37
+lightning-cloud >=0.5.38
 packaging
 typing-extensions >=4.0.0, <4.8.0
 deepdiff >=5.7.0, <6.3.2

--- a/src/lightning/app/utilities/network.py
+++ b/src/lightning/app/utilities/network.py
@@ -18,10 +18,17 @@ from typing import Any, Callable, Dict, Optional
 from urllib.parse import urljoin
 
 import requests
+from lightning_cloud.rest_client import (  # noqa: F401
+    _DEFAULT_BACKOFF_MAX,
+    _get_next_backoff_time,
+    _retry_wrapper,
+    create_swagger_client,
+    GridRestClient,
+    LightningClient,
+)
 from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.exceptions import ConnectionError, ConnectTimeout, ReadTimeout
-from lightning_cloud.rest_client import create_swagger_client, GridRestClient, LightningClient, _retry_wrapper, _DEFAULT_BACKOFF_MAX, _get_next_backoff_time  # noqa: F401
 from urllib3.util.retry import Retry
 
 from lightning.app.core import constants

--- a/src/lightning/app/utilities/network.py
+++ b/src/lightning/app/utilities/network.py
@@ -20,11 +20,7 @@ from urllib.parse import urljoin
 import requests
 
 # for backwards compatibility
-from lightning_cloud.rest_client import (  # noqa: F401
-    create_swagger_client,
-    GridRestClient,
-    LightningClient,
-)
+from lightning_cloud.rest_client import create_swagger_client, GridRestClient, LightningClient  # noqa: F401
 from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.exceptions import ConnectionError, ConnectTimeout, ReadTimeout

--- a/src/lightning/app/utilities/network.py
+++ b/src/lightning/app/utilities/network.py
@@ -13,13 +13,11 @@
 # limitations under the License.
 
 import socket
-import time
 from functools import wraps
 from typing import Any, Callable, Dict, Optional
 from urllib.parse import urljoin
 
 import requests
-from lightning_cloud.rest_client import create_swagger_client, GridRestClient, LightningClient, _retry_wrapper, _DEFAULT_BACKOFF_MAX, _get_next_backoff_time  # noqa: E402
 from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.exceptions import ConnectionError, ConnectTimeout, ReadTimeout
@@ -114,6 +112,7 @@ def _check_service_url_is_ready(url: str, timeout: float = 5, metadata="") -> bo
     except (ConnectionError, ConnectTimeout, ReadTimeout):
         logger.debug(f"The url {url} is not ready. {metadata}")
         return False
+
 
 class CustomRetryAdapter(HTTPAdapter):
     def __init__(self, *args: Any, **kwargs: Any):

--- a/src/lightning/app/utilities/network.py
+++ b/src/lightning/app/utilities/network.py
@@ -21,9 +21,6 @@ import requests
 
 # for backwards compatibility
 from lightning_cloud.rest_client import (  # noqa: F401
-    _DEFAULT_BACKOFF_MAX,
-    _get_next_backoff_time,
-    _retry_wrapper,
     create_swagger_client,
     GridRestClient,
     LightningClient,

--- a/src/lightning/app/utilities/network.py
+++ b/src/lightning/app/utilities/network.py
@@ -21,6 +21,7 @@ import requests
 from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.exceptions import ConnectionError, ConnectTimeout, ReadTimeout
+from lightning_cloud.rest_client import create_swagger_client, GridRestClient, LightningClient, _retry_wrapper, _DEFAULT_BACKOFF_MAX, _get_next_backoff_time  # noqa: F401
 from urllib3.util.retry import Retry
 
 from lightning.app.core import constants

--- a/src/lightning/app/utilities/network.py
+++ b/src/lightning/app/utilities/network.py
@@ -18,6 +18,8 @@ from typing import Any, Callable, Dict, Optional
 from urllib.parse import urljoin
 
 import requests
+
+# for backwards compatibility
 from lightning_cloud.rest_client import (  # noqa: F401
     _DEFAULT_BACKOFF_MAX,
     _get_next_backoff_time,

--- a/tests/tests_app/utilities/test_network.py
+++ b/tests/tests_app/utilities/test_network.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 
 from lightning.app.core import constants
-from lightning.app.utilities.network import find_free_network_port,
+from lightning.app.utilities.network import find_free_network_port
 
 
 def test_find_free_network_port():

--- a/tests/tests_app/utilities/test_network.py
+++ b/tests/tests_app/utilities/test_network.py
@@ -1,11 +1,9 @@
-import re
 from unittest import mock
 
 import pytest
-from urllib3.exceptions import HTTPError
 
 from lightning.app.core import constants
-from lightning.app.utilities.network import _retry_wrapper, find_free_network_port, LightningClient
+from lightning.app.utilities.network import find_free_network_port,
 
 
 def test_find_free_network_port():
@@ -45,28 +43,3 @@ def test_find_free_network_port_cloudspace(_, patch_constants):
 
     # Shouldn't use the APP_SERVER_PORT
     assert constants.APP_SERVER_PORT not in ports
-
-
-def test_lightning_client_retry_enabled():
-    client = LightningClient()  # default: retry=True
-    assert hasattr(client.auth_service_get_user_with_http_info, "__wrapped__")
-
-    client = LightningClient(retry=False)
-    assert not hasattr(client.auth_service_get_user_with_http_info, "__wrapped__")
-
-    client = LightningClient(retry=True)
-    assert hasattr(client.auth_service_get_user_with_http_info, "__wrapped__")
-
-
-@mock.patch("time.sleep")
-def test_retry_wrapper_max_tries(_):
-    mock_client = mock.MagicMock()
-    mock_client.test.__name__ = "test"
-    mock_client.test.side_effect = HTTPError("failed")
-
-    wrapped_mock_client = _retry_wrapper(mock_client, mock_client.test, max_tries=3)
-
-    with pytest.raises(Exception, match=re.escape("The test request failed to reach the server, error: failed")):
-        wrapped_mock_client()
-
-    assert mock_client.test.call_count == 3


### PR DESCRIPTION
## What does this PR do?

`LightningClient` was moved to the `lightning_cloud` package. This replaces all the previously available functions with imports to avoid breaking it while still reducing code-duplication.

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18544.org.readthedocs.build/en/18544/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda