### PR TITLE
Avoid warning about logging interval for fast dev run

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -257,6 +257,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed visual glitch with the TQDM progress bar leaving the validation bar incomplete before switching back to the training display ([#18503](https://github.com/Lightning-AI/lightning/pull/18503))
 
 
+- Fixed false positive warning about logging interval when running with `Trainer(fast_dev_run=True)` ([#18550](https://github.com/Lightning-AI/lightning/pull/18550))
+
+
 ## [2.0.7] - 2023-08-14
 
 ### Added

--- a/src/lightning/pytorch/loops/fit_loop.py
+++ b/src/lightning/pytorch/loops/fit_loop.py
@@ -289,7 +289,7 @@ class _FitLoop(_Loop):
                 trainer.val_check_batch = int(self.max_batches * trainer.val_check_interval)
                 trainer.val_check_batch = max(1, trainer.val_check_batch)
 
-        if trainer.loggers and self.max_batches < trainer.log_every_n_steps:
+        if trainer.loggers and self.max_batches < trainer.log_every_n_steps and not trainer.fast_dev_run:
             rank_zero_warn(
                 f"The number of training batches ({self.max_batches}) is smaller than the logging interval"
                 f" Trainer(log_every_n_steps={trainer.log_every_n_steps}). Set a lower value for log_every_n_steps if"

--- a/tests/tests_pytorch/trainer/test_dataloaders.py
+++ b/tests/tests_pytorch/trainer/test_dataloaders.py
@@ -24,6 +24,7 @@ from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data.sampler import SequentialSampler
 
 import lightning.pytorch
+from lightning_utilities.test.warning import no_warning_call
 from lightning.fabric.utilities.data import _auto_add_worker_init_fn, has_iterable_dataset
 from lightning.pytorch import Callback, seed_everything, Trainer
 from lightning.pytorch.callbacks import ModelCheckpoint
@@ -683,6 +684,10 @@ def test_warning_with_small_dataloader_and_logging_interval(tmpdir):
         trainer = Trainer(
             default_root_dir=tmpdir, max_epochs=1, log_every_n_steps=2, limit_train_batches=1, logger=CSVLogger(".")
         )
+        trainer.fit(model)
+
+    with no_warning_call(UserWarning, match="The number of training batches"):
+        trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=True, log_every_n_steps=2)
         trainer.fit(model)
 
 

--- a/tests/tests_pytorch/trainer/test_dataloaders.py
+++ b/tests/tests_pytorch/trainer/test_dataloaders.py
@@ -17,6 +17,7 @@ from unittest.mock import call, Mock, patch
 import numpy
 import pytest
 import torch
+from lightning_utilities.test.warning import no_warning_call
 from torch.utils.data import RandomSampler
 from torch.utils.data.dataloader import DataLoader
 from torch.utils.data.dataset import Dataset, IterableDataset
@@ -24,7 +25,6 @@ from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data.sampler import SequentialSampler
 
 import lightning.pytorch
-from lightning_utilities.test.warning import no_warning_call
 from lightning.fabric.utilities.data import _auto_add_worker_init_fn, has_iterable_dataset
 from lightning.pytorch import Callback, seed_everything, Trainer
 from lightning.pytorch.callbacks import ModelCheckpoint


### PR DESCRIPTION
## What does this PR do?

This PR removes the following warning call in case you are running with fast-dev-run:
```
PossibleUserWarning: The number of training batches (1) is smaller than the logging interval Trainer(log_every_n_steps=50). Set a lower value for log_every_n_steps if you want to see logs for the training epoch.
```

Noticed in https://github.com/Lightning-AI/lightning/issues/18545 by @adamjstewart




<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18550.org.readthedocs.build/en/18550/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca @Blaizzy @justusschock @awaelchli