### PR TITLE
Remove reference to training in checkpoint loading error message

### DIFF
--- a/src/lightning/fabric/plugins/io/torch_io.py
+++ b/src/lightning/fabric/plugins/io/torch_io.py
@@ -75,7 +75,7 @@ class TorchCheckpointIO(CheckpointIO):
         # Try to read the checkpoint at `path`. If not exist, do not restore checkpoint.
         fs = get_filesystem(path)
         if not fs.exists(path):
-            raise FileNotFoundError(f"Checkpoint at {path} not found. Aborting training.")
+            raise FileNotFoundError(f"Checkpoint file not found: {path}")
 
         return pl_load(path, map_location=map_location)
 

--- a/tests/tests_pytorch/models/test_restore.py
+++ b/tests/tests_pytorch/models/test_restore.py
@@ -260,7 +260,7 @@ def test_try_resume_from_non_existing_checkpoint(tmpdir):
     model = BoringModel()
     trainer = Trainer()
 
-    with pytest.raises(FileNotFoundError, match="Aborting training"):
+    with pytest.raises(FileNotFoundError, match="Checkpoint file not found"):
         trainer.fit(model, ckpt_path=str(tmpdir / "non_existing.ckpt"))
 
 

--- a/tests/tests_pytorch/trainer/connectors/test_checkpoint_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_checkpoint_connector.py
@@ -83,7 +83,7 @@ def test_hpc_restore_attempt(_, tmpdir):
     # case 2: explicit resume path provided, file not found
     trainer = Trainer(default_root_dir=tmpdir, max_steps=3)
 
-    with pytest.raises(FileNotFoundError, match="Checkpoint at not existing not found. Aborting training."):
+    with pytest.raises(FileNotFoundError, match="Checkpoint file not found: not existing"):
         trainer.fit(model, ckpt_path="not existing")
 
 


### PR DESCRIPTION
## What does this PR do?

Small improvement in the messaging: When loading a checkpoint fails, we reference the training stage, but loading can fail for testing etc. for the same reasons. 

cc @borda @carmocca @justusschock @awaelchli