### PR TITLE
[Fabric] Replace `@contextlib.contextmanager`

### DIFF
--- a/src/lightning/fabric/fabric.py
+++ b/src/lightning/fabric/fabric.py
@@ -16,7 +16,21 @@ import os
 from contextlib import contextmanager, nullcontext
 from functools import partial
 from pathlib import Path
-from typing import Any, Callable, cast, Dict, Generator, List, Mapping, Optional, overload, Sequence, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    cast,
+    ContextManager,
+    Dict,
+    Generator,
+    List,
+    Mapping,
+    Optional,
+    overload,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 import torch
 import torch.nn as nn
@@ -447,16 +461,14 @@ class Fabric:
             )
         raise ValueError("You have to specify either `clip_val` or `max_norm` to do gradient clipping!")
 
-    @contextmanager
-    def autocast(self) -> Generator[None, None, None]:
+    def autocast(self) -> ContextManager:
         """A context manager to automatically convert operations for the chosen precision.
 
         Use this only if the `forward` method of your model does not cover all operations you wish to run with the
         chosen precision setting.
 
         """
-        with self._precision.forward_context():
-            yield
+        return self._precision.forward_context()
 
     @overload
     def to_device(self, obj: nn.Module) -> nn.Module:
@@ -601,8 +613,7 @@ class Fabric:
             self.barrier()
         self.barrier()
 
-    @contextmanager
-    def no_backward_sync(self, module: _FabricModule, enabled: bool = True) -> Generator:
+    def no_backward_sync(self, module: _FabricModule, enabled: bool = True) -> ContextManager:
         r"""Skip gradient synchronization during backward to avoid redundant communication overhead.
 
         Use this context manager when performing gradient accumulation to speed up training with multiple devices.
@@ -632,24 +643,19 @@ class Fabric:
                 " `model = fabric.setup(model, ...)`"
             )
         if not enabled or isinstance(self._strategy, (SingleDeviceStrategy, XLAStrategy)):
-            context = nullcontext()
-        elif self._strategy._backward_sync_control is None:
+            return nullcontext()
+        if self._strategy._backward_sync_control is None:
             rank_zero_warn(
                 f"The `{self._strategy.__class__.__name__}` does not support skipping the gradient synchronization."
                 f" Remove `.no_backward_sync()` from your code or choose a different strategy.",
                 category=PossibleUserWarning,
             )
-            context = nullcontext()
-        else:
-            context = self._strategy._backward_sync_control.no_backward_sync(  # type: ignore[assignment]
-                module._forward_module
-            )
+            return nullcontext()
+        return self._strategy._backward_sync_control.no_backward_sync(  # type: ignore[assignment]
+            module._forward_module
+        )
 
-        with context:
-            yield
-
-    @contextmanager
-    def sharded_model(self) -> Generator:
+    def sharded_model(self) -> ContextManager:
         r"""Instantiate a model under this context manager to prepare it for model-parallel sharding.
 
         .. deprecated:: This context manager is deprecated in favor of :meth:`init_module`, use it instead.
@@ -658,13 +664,10 @@ class Fabric:
         rank_zero_deprecation("`Fabric.sharded_model()` is deprecated in favor of `Fabric.init_module()`.")
         self._validate_launched()
         if isinstance(self.strategy, _Sharded):
-            with self.strategy.module_sharded_context():
-                yield
-        else:
-            yield
+            return self.strategy.module_sharded_context()
+        return nullcontext()
 
-    @contextmanager
-    def init_tensor(self) -> Generator:
+    def init_tensor(self) -> ContextManager:
         """Tensors that you instantiate under this context manager will be created on the device right away and have
         the right data type depending on the precision setting in Fabric.
 
@@ -678,11 +681,9 @@ class Fabric:
                 " Upgrade to PyTorch >= 2.0 to fully utilize this feature.",
                 category=PossibleUserWarning,
             )
-        with self._strategy.tensor_init_context():
-            yield
+        return self._strategy.tensor_init_context()
 
-    @contextmanager
-    def init_module(self, empty_init: Optional[bool] = None) -> Generator:
+    def init_module(self, empty_init: Optional[bool] = None) -> ContextManager:
         """Instantiate the model and its parameters under this context manager to reduce peak memory usage.
 
         The parameters get created on the device and with the right data type right away without wasting memory being
@@ -703,8 +704,7 @@ class Fabric:
                 " Upgrade to PyTorch >= 2.0 to fully utilize this feature.",
                 category=PossibleUserWarning,
             )
-        with self._strategy.module_init_context(empty_init=empty_init):
-            yield
+        return self._strategy.module_init_context(empty_init=empty_init)
 
     def save(
         self,

--- a/src/lightning/fabric/plugins/precision/amp.py
+++ b/src/lightning/fabric/plugins/precision/amp.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from contextlib import contextmanager
-from typing import Any, Dict, Generator, Literal, Optional
+from typing import Any, ContextManager, Dict, Literal, Optional
 
 import torch
 from lightning_utilities.core.apply_func import apply_to_collection
@@ -59,10 +58,8 @@ class MixedPrecision(Precision):
 
         self._desired_input_dtype = torch.bfloat16 if self.precision == "bf16-mixed" else torch.float16
 
-    @contextmanager
-    def forward_context(self) -> Generator[None, None, None]:
-        with self._autocast_context_manager():
-            yield
+    def forward_context(self) -> ContextManager:
+        return self._autocast_context_manager()
 
     def convert_input(self, data: Any) -> Any:
         return apply_to_collection(data, function=_convert_fp_tensor, dtype=Tensor, dst_type=self._desired_input_dtype)

--- a/src/lightning/fabric/plugins/precision/deepspeed.py
+++ b/src/lightning/fabric/plugins/precision/deepspeed.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from contextlib import contextmanager
-from typing import Any, Generator, Literal, TYPE_CHECKING
+from contextlib import nullcontext
+from typing import Any, ContextManager, Literal, TYPE_CHECKING
 
 import torch
 from lightning_utilities.core.apply_func import apply_to_collection
@@ -21,7 +21,7 @@ from torch.nn import Module
 from typing_extensions import get_args
 
 from lightning.fabric.plugins.precision.precision import Precision
-from lightning.fabric.plugins.precision.utils import _convert_fp_tensor
+from lightning.fabric.plugins.precision.utils import _convert_fp_tensor, _DtypeContextManager
 from lightning.fabric.utilities.types import Steppable
 
 if TYPE_CHECKING:
@@ -69,18 +69,11 @@ class DeepSpeedPrecision(Precision):
             return module.to(dtype=self._desired_dtype)
         return module
 
-    @contextmanager
-    def init_context(self) -> Generator[None, None, None]:
+    @property
+    def init_context(self) -> ContextManager:
         if "true" not in self.precision:
-            yield
-            return
-
-        default_dtype = torch.get_default_dtype()
-        torch.set_default_dtype(self._desired_dtype)
-        try:
-            yield
-        finally:
-            torch.set_default_dtype(default_dtype)
+            return nullcontext()
+        return _DtypeContextManager(self._desired_dtype)
 
     def convert_input(self, data: Any) -> Any:
         return apply_to_collection(data, function=_convert_fp_tensor, dtype=Tensor, dst_type=self._desired_dtype)

--- a/src/lightning/fabric/plugins/precision/double.py
+++ b/src/lightning/fabric/plugins/precision/double.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from contextlib import contextmanager
-from typing import Any, Generator, Literal
+from typing import Any, ContextManager, Literal
 
 import torch
 from lightning_utilities.core.apply_func import apply_to_collection
@@ -20,7 +19,7 @@ from torch import Tensor
 from torch.nn import Module
 
 from lightning.fabric.plugins.precision.precision import Precision
-from lightning.fabric.plugins.precision.utils import _convert_fp_tensor
+from lightning.fabric.plugins.precision.utils import _convert_fp_tensor, _DtypeContextManager
 
 
 class DoublePrecision(Precision):
@@ -31,33 +30,11 @@ class DoublePrecision(Precision):
     def convert_module(self, module: Module) -> Module:
         return module.double()
 
-    @contextmanager
-    def init_context(self) -> Generator[None, None, None]:
-        """Instantiate module parameters or tensors in the precision type this plugin handles.
+    def init_context(self) -> ContextManager:
+        return _DtypeContextManager(torch.double)
 
-        This is optional and depends on the precision limitations during optimization.
-
-        """
-        default_dtype = torch.get_default_dtype()
-        torch.set_default_dtype(torch.float64)
-        try:
-            yield
-        finally:
-            torch.set_default_dtype(default_dtype)
-
-    @contextmanager
-    def forward_context(self) -> Generator[None, None, None]:
-        """A context manager to change the default tensor type.
-
-        See: :func:`torch.set_default_dtype`
-
-        """
-        default_dtype = torch.get_default_dtype()
-        torch.set_default_dtype(torch.float64)
-        try:
-            yield
-        finally:
-            torch.set_default_dtype(default_dtype)
+    def forward_context(self) -> ContextManager:
+        return _DtypeContextManager(torch.double)
 
     def convert_input(self, data: Any) -> Any:
         return apply_to_collection(data, function=_convert_fp_tensor, dtype=Tensor, dst_type=torch.double)

--- a/src/lightning/fabric/plugins/precision/fsdp.py
+++ b/src/lightning/fabric/plugins/precision/fsdp.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from contextlib import contextmanager
-from typing import Any, cast, Dict, Generator, Literal, Optional, TYPE_CHECKING
+from typing import Any, cast, ContextManager, Dict, Literal, Optional, TYPE_CHECKING
 
 import torch
 from lightning_utilities import apply_to_collection
@@ -23,7 +22,7 @@ from typing_extensions import get_args
 
 from lightning.fabric.plugins.precision.amp import _optimizer_handles_unscaling
 from lightning.fabric.plugins.precision.precision import Precision
-from lightning.fabric.plugins.precision.utils import _convert_fp_tensor
+from lightning.fabric.plugins.precision.utils import _convert_fp_tensor, _DtypeContextManager
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_1_12, _TORCH_GREATER_EQUAL_2_0
 from lightning.fabric.utilities.types import Optimizable
 
@@ -107,32 +106,13 @@ class FSDPPrecision(Precision):
             buffer_dtype=buffer_dtype,
         )
 
-    @contextmanager
-    def init_context(self) -> Generator[None, None, None]:
-        """A context manager to change the default tensor type when initializing module parameters or tensors.
+    def init_context(self) -> ContextManager:
+        return _DtypeContextManager(self.mixed_precision_config.param_dtype or torch.float32)
 
-        See: :func:`torch.set_default_dtype`
-
-        """
-        default_dtype = torch.get_default_dtype()
-        torch.set_default_dtype(self.mixed_precision_config.param_dtype or torch.float32)
-        try:
-            yield
-        finally:
-            torch.set_default_dtype(default_dtype)
-
-    @contextmanager
-    def forward_context(self) -> Generator:
+    def forward_context(self) -> ContextManager:
         if "mixed" in self.precision:
-            with self._autocast_context_manager():
-                yield
-        else:
-            default_dtype = torch.get_default_dtype()
-            torch.set_default_dtype(self._desired_input_dtype)
-            try:
-                yield
-            finally:
-                torch.set_default_dtype(default_dtype)
+            return self._autocast_context_manager()
+        return _DtypeContextManager(self._desired_input_dtype)
 
     def convert_input(self, data: Any) -> Any:
         return apply_to_collection(data, function=_convert_fp_tensor, dtype=Tensor, dst_type=self._desired_input_dtype)

--- a/src/lightning/fabric/plugins/precision/half.py
+++ b/src/lightning/fabric/plugins/precision/half.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from contextlib import contextmanager
-from typing import Any, Generator, Literal
+from typing import Any, ContextManager, Literal
 
 import torch
 from lightning_utilities.core.apply_func import apply_to_collection
@@ -20,7 +19,7 @@ from torch import Tensor
 from torch.nn import Module
 
 from lightning.fabric.plugins.precision.precision import Precision
-from lightning.fabric.plugins.precision.utils import _convert_fp_tensor
+from lightning.fabric.plugins.precision.utils import _convert_fp_tensor, _DtypeContextManager
 
 
 class HalfPrecision(Precision):
@@ -40,33 +39,11 @@ class HalfPrecision(Precision):
     def convert_module(self, module: Module) -> Module:
         return module.to(dtype=self._desired_input_dtype)
 
-    @contextmanager
-    def init_context(self) -> Generator[None, None, None]:
-        """A context manager to change the default tensor type when initializing module parameters or tensors.
+    def init_context(self) -> ContextManager:
+        return _DtypeContextManager(self._desired_input_dtype)
 
-        See: :func:`torch.set_default_dtype`
-
-        """
-        default_dtype = torch.get_default_dtype()
-        torch.set_default_dtype(self._desired_input_dtype)
-        try:
-            yield
-        finally:
-            torch.set_default_dtype(default_dtype)
-
-    @contextmanager
-    def forward_context(self) -> Generator[None, None, None]:
-        """A context manager to change the default tensor type when tensors get created during the module's forward.
-
-        See: :func:`torch.set_default_dtype`
-
-        """
-        default_dtype = torch.get_default_dtype()
-        torch.set_default_dtype(self._desired_input_dtype)
-        try:
-            yield
-        finally:
-            torch.set_default_dtype(default_dtype)
+    def forward_context(self) -> ContextManager:
+        return _DtypeContextManager(self._desired_input_dtype)
 
     def convert_input(self, data: Any) -> Any:
         return apply_to_collection(data, function=_convert_fp_tensor, dtype=Tensor, dst_type=self._desired_input_dtype)

--- a/src/lightning/fabric/plugins/precision/precision.py
+++ b/src/lightning/fabric/plugins/precision/precision.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from contextlib import contextmanager
-from typing import Any, Dict, Generator, Literal, Optional, Union
+from contextlib import nullcontext
+from typing import Any, ContextManager, Dict, Literal, Optional, Union
 
 from torch import Tensor
 from torch.nn import Module
@@ -46,19 +46,17 @@ class Precision:
         """
         return module
 
-    @contextmanager
-    def init_context(self) -> Generator[None, None, None]:
+    def init_context(self) -> ContextManager:
         """Instantiate module parameters or tensors in the precision type this plugin handles.
 
         This is optional and depends on the precision limitations during optimization.
 
         """
-        yield
+        return nullcontext()
 
-    @contextmanager
-    def forward_context(self) -> Generator[None, None, None]:
+    def forward_context(self) -> ContextManager:
         """A contextmanager for managing model forward/training_step/evaluation_step/predict_step."""
-        yield
+        return nullcontext()
 
     def convert_input(self, data: Any) -> Any:
         """Convert model inputs (forward) to the floating point precision type of this plugin.

--- a/src/lightning/fabric/plugins/precision/transformer_engine.py
+++ b/src/lightning/fabric/plugins/precision/transformer_engine.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-from contextlib import contextmanager
-from typing import Any, Generator, Literal, Mapping, Optional, TYPE_CHECKING, Union
+from contextlib import contextmanager, ExitStack
+from typing import Any, ContextManager, Literal, Mapping, Optional, TYPE_CHECKING, Union
 
 import torch
 from lightning_utilities import apply_to_collection
@@ -21,7 +21,11 @@ from lightning_utilities.core.imports import RequirementCache
 from torch import Tensor
 
 from lightning.fabric.plugins.precision.precision import Precision
-from lightning.fabric.plugins.precision.utils import _convert_fp_tensor
+from lightning.fabric.plugins.precision.utils import (
+    _ClassReplacementContextManager,
+    _convert_fp_tensor,
+    _DtypeContextManager,
+)
 from lightning.fabric.utilities.rank_zero import rank_zero_warn
 
 _TRANSFORMER_ENGINE_AVAILABLE = RequirementCache("transformer_engine>=0.11.0")
@@ -94,39 +98,30 @@ class TransformerEnginePrecision(Precision):
         return module
 
     @contextmanager
-    def init_context(self) -> Generator[None, None, None]:
-        import transformer_engine.pytorch as te
+    def init_context(self) -> ContextManager:
+        stack = ExitStack()
+        stack.enter_context(_DtypeContextManager(self.dtype))
 
-        default_dtype = torch.get_default_dtype()
-        torch.set_default_dtype(self.dtype)
-
-        replace_layers = self.replace_layers
-        try:
-            if replace_layers:
-                original_linear = torch.nn.Linear
-                original_layer_norm = torch.nn.LayerNorm
-                torch.nn.Linear = te.Linear  # type: ignore[misc]
-                torch.nn.LayerNorm = te.LayerNorm  # type: ignore[misc]
-            yield
-        finally:
-            if replace_layers:
-                torch.nn.Linear = original_linear  # type: ignore[misc]
-                torch.nn.LayerNorm = original_layer_norm  # type: ignore[misc]
-
-            torch.set_default_dtype(default_dtype)
-
-    @contextmanager
-    def forward_context(self) -> Generator[None, None, None]:
-        default_dtype = torch.get_default_dtype()
-        torch.set_default_dtype(self.dtype)
-
-        try:
+        if self.replace_layers:
             import transformer_engine.pytorch as te
 
-            with te.fp8_autocast(enabled=True, fp8_recipe=self.recipe):
-                yield
-        finally:
-            torch.set_default_dtype(default_dtype)
+            context_manager = _ClassReplacementContextManager(
+                {
+                    "torch.nn.Linear": te.Linear,
+                    "torch.nn.LayerNorm": te.LayerNorm,
+                }
+            )
+            stack.enter_context(context_manager)
+        return stack
+
+    def forward_context(self) -> ContextManager:
+        stack = ExitStack()
+        stack.enter_context(_DtypeContextManager(self.dtype))
+
+        import transformer_engine.pytorch as te
+
+        stack.enter_context(te.fp8_autocast(enabled=True, fp8_recipe=self.recipe))
+        return stack
 
     def convert_input(self, data: Any) -> Any:
         return apply_to_collection(data, function=_convert_fp_tensor, dtype=Tensor, dst_type=self.dtype)

--- a/src/lightning/fabric/plugins/precision/transformer_engine.py
+++ b/src/lightning/fabric/plugins/precision/transformer_engine.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-from contextlib import contextmanager, ExitStack
+from contextlib import ExitStack
 from typing import Any, ContextManager, Literal, Mapping, Optional, TYPE_CHECKING, Union
 
 import torch
@@ -97,7 +97,6 @@ class TransformerEnginePrecision(Precision):
         module = module.to(dtype=self.dtype)
         return module
 
-    @contextmanager
     def init_context(self) -> ContextManager:
         stack = ExitStack()
         stack.enter_context(_DtypeContextManager(self.dtype))

--- a/src/lightning/fabric/plugins/precision/utils.py
+++ b/src/lightning/fabric/plugins/precision/utils.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Union
+from typing import Any, Mapping, Type, Union
 
 import torch
 from torch import Tensor
@@ -19,3 +19,46 @@ from torch import Tensor
 
 def _convert_fp_tensor(tensor: Tensor, dst_type: Union[str, torch.dtype]) -> Tensor:
     return tensor.to(dst_type) if torch.is_floating_point(tensor) else tensor
+
+
+# do not support using as a decorator or else `torch.get_default_dtype` will get picked up at initialization
+class _DtypeContextManager:
+    """A context manager to change the default tensor type when tensors get created.
+
+    See: :func:`torch.set_default_dtype`
+
+    """
+
+    def __init__(self, dtype: torch.dtype) -> None:
+        self._previous_dtype: torch.dtype = torch.get_default_dtype()
+        self._new_dtype = dtype
+
+    def __enter__(self) -> None:
+        torch.set_default_dtype(self._new_dtype)
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        torch.set_default_dtype(self._previous_dtype)
+
+
+class _ClassReplacementContextManager:
+    """A context manager to monkeypatch classes."""
+
+    def __init__(self, mapping: Mapping[str, Type]) -> None:
+        self._mapping = mapping
+        self._originals = {}
+        self._modules = {}
+        for class_string in mapping:
+            module_name, class_name = class_string.rsplit(".", 1)
+            module = __import__(module_name, fromlist=[class_name])
+            self._modules[class_string] = module
+            self._originals[class_string] = getattr(module, class_name)
+
+    def __enter__(self) -> None:
+        for class_string, replacement in self._mapping.items():
+            _, class_name = class_string.rsplit(".", 1)
+            setattr(self._modules[class_string], class_name, replacement)
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        for class_string, replacement in self._mapping.items():
+            _, class_name = class_string.rsplit(".", 1)
+            setattr(self._modules[class_string], class_name, self._originals[class_string])

--- a/src/lightning/fabric/strategies/ddp.py
+++ b/src/lightning/fabric/strategies/ddp.py
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from contextlib import contextmanager, nullcontext
+from contextlib import nullcontext
 from datetime import timedelta
-from typing import Any, Dict, Generator, List, Literal, Optional, Union
+from typing import Any, ContextManager, Dict, List, Literal, Optional, Union
 
 import torch
 import torch.distributed
@@ -208,8 +208,7 @@ class DDPStrategy(ParallelStrategy):
 
 
 class _DDPBackwardSyncControl(_BackwardSyncControl):
-    @contextmanager
-    def no_backward_sync(self, module: Module) -> Generator:
+    def no_backward_sync(self, module: Module) -> ContextManager:
         """Blocks gradient synchronization inside the
         :class:`~torch.nn.parallel.distributed.DistributedDataParallel` wrapper."""
         if not isinstance(module, DistributedDataParallel):
@@ -218,5 +217,4 @@ class _DDPBackwardSyncControl(_BackwardSyncControl):
                 f" `{self.__class__.__name__}.no_backward_sync` is wrapped in `DistributedDataParallel`."
                 f" Got: {module.__class__.__name__}."
             )
-        with module.no_sync():
-            yield
+        return module.no_sync()

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -13,13 +13,14 @@
 # limitations under the License.
 import os
 import threading
-from contextlib import contextmanager, nullcontext
+from contextlib import contextmanager, ExitStack
 from datetime import timedelta
 from functools import partial
 from pathlib import Path
 from typing import (
     Any,
     Callable,
+    ContextManager,
     Dict,
     Generator,
     Iterable,
@@ -323,23 +324,20 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
     def module_to_device(self, module: Module) -> None:
         pass
 
-    @contextmanager
-    def module_init_context(self, empty_init: Optional[bool] = None) -> Generator[None, None, None]:
-        empty_init_context: Union[torch.device, _EmptyInit, nullcontext]
+    def module_init_context(self, empty_init: Optional[bool] = None) -> ContextManager:
+        stack = ExitStack()
         if _TORCH_GREATER_EQUAL_2_1 and empty_init:
             # Materialization happens in `setup`. When modules get wrapped by FSDP, the sequence of operations is:
             # 1) materialize module 2) call `reset_parameters()` 3) shard the module.
             # These operations are applied to each submodule 'bottom up' in the module hierarchy.
-            empty_init_context = torch.device("meta")
+            stack.enter_context(torch.device("meta"))
         elif _TORCH_GREATER_EQUAL_1_13:
-            empty_init_context = _EmptyInit(enabled=bool(empty_init))
-        else:
-            empty_init_context = nullcontext()
-        with empty_init_context, self.precision.init_context(), self.module_sharded_context():
-            yield
+            stack.enter_context(_EmptyInit(enabled=bool(empty_init)))
+        stack.enter_context(self.precision.init_context())
+        stack.enter_context(self.module_sharded_context())
+        return stack
 
-    @contextmanager
-    def module_sharded_context(self) -> Generator:
+    def module_sharded_context(self) -> ContextManager:
         from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel
         from torch.distributed.fsdp.wrap import enable_wrap
 
@@ -751,7 +749,6 @@ def _setup_activation_checkpointing(module: Module, activation_checkpointing_kwa
 
 
 class _FSDPBackwardSyncControl(_BackwardSyncControl):
-    @contextmanager
     def no_backward_sync(self, module: Module) -> Generator:
         """Blocks gradient synchronization inside the
         :class:`~torch.distributed.fsdp.FullyShardedDataParallel` wrapper."""
@@ -764,8 +761,7 @@ class _FSDPBackwardSyncControl(_BackwardSyncControl):
                 f" `{self.__class__.__name__}.no_backward_sync` is wrapped in `FullyShardedDataParallel`."
                 f" Got: {module.__class__.__name__}."
             )
-        with module.no_sync():
-            yield
+        return module.no_sync()
 
 
 def _init_cpu_offload(cpu_offload: Optional[Union[bool, "CPUOffload"]]) -> "CPUOffload":

--- a/src/lightning/fabric/strategies/strategy.py
+++ b/src/lightning/fabric/strategies/strategy.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 import logging
 from abc import ABC, abstractmethod
-from contextlib import contextmanager, nullcontext
-from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Tuple, TypeVar, Union
+from contextlib import ExitStack
+from typing import Any, Callable, ContextManager, Dict, Iterable, List, Optional, Tuple, TypeVar, Union
 
 import torch
 from torch import Tensor
@@ -116,15 +116,15 @@ class Strategy(ABC):
         """
         return dataloader
 
-    @contextmanager
-    def tensor_init_context(self) -> Generator:
+    def tensor_init_context(self) -> ContextManager:
         """Controls how tensors get created (device, dtype)."""
-        device_context = self.root_device if _TORCH_GREATER_EQUAL_2_0 else nullcontext()
-        with device_context, self.precision.init_context():
-            yield
+        stack = ExitStack()
+        if _TORCH_GREATER_EQUAL_2_0:
+            stack.enter_context(self.root_device)
+        stack.enter_context(self.precision.init_context())
+        return stack
 
-    @contextmanager
-    def module_init_context(self, empty_init: Optional[bool] = None) -> Generator:
+    def module_init_context(self, empty_init: Optional[bool] = None) -> ContextManager:
         """A context manager wrapping the model instantiation.
 
         Here, the strategy can control how the parameters of the model get created (device, dtype) and or apply other
@@ -135,9 +135,11 @@ class Strategy(ABC):
                 If ``None``, the strategy will decide. Some strategies may not support all options.
 
         """
-        empty_init_context = _EmptyInit(enabled=bool(empty_init)) if _TORCH_GREATER_EQUAL_1_13 else nullcontext()
-        with empty_init_context, self.tensor_init_context():
-            yield
+        stack = ExitStack()
+        if _TORCH_GREATER_EQUAL_1_13:
+            stack.enter_context(_EmptyInit(enabled=bool(empty_init)))
+        stack.enter_context(self.tensor_init_context())
+        return stack
 
     def setup_module_and_optimizers(
         self, module: Module, optimizers: List[Optimizer]
@@ -416,9 +418,8 @@ class _BackwardSyncControl(ABC):
 
     """
 
-    @contextmanager
     @abstractmethod
-    def no_backward_sync(self, module: Module) -> Generator:
+    def no_backward_sync(self, module: Module) -> ContextManager:
         """Blocks the synchronization of gradients during the backward pass.
 
         This is a context manager. It is only effective if it wraps a call to `.backward()`.
@@ -430,15 +431,13 @@ class _Sharded(ABC):
     """Mixin-interface for any :class:`Strategy` that wants to expose functionality for sharding model parameters."""
 
     @abstractmethod
-    @contextmanager
-    def module_sharded_context(self) -> Generator:
+    def module_sharded_context(self) -> ContextManager:
         """A context manager that goes over the instantiation of an :class:`torch.nn.Module` and handles sharding of
         parameters on creation.
 
         By sharding layers directly on instantiation, one can reduce peak memory usage and initialization time.
 
         """
-        yield
 
 
 def _validate_keys_for_strict_loading(

--- a/src/lightning/fabric/strategies/xla_fsdp.py
+++ b/src/lightning/fabric/strategies/xla_fsdp.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import io
-from contextlib import contextmanager, nullcontext
+from contextlib import ExitStack, nullcontext
 from functools import partial
 from pathlib import Path
-from typing import Any, Callable, Dict, Generator, List, Literal, Optional, Set, Tuple, Type, TYPE_CHECKING, Union
+from typing import Any, Callable, ContextManager, Dict, List, Literal, Optional, Set, Tuple, Type, TYPE_CHECKING, Union
 
 import torch
 from torch import Tensor
@@ -32,7 +32,12 @@ from lightning.fabric.plugins.io.xla import XLACheckpointIO
 from lightning.fabric.strategies import _StrategyRegistry, ParallelStrategy
 from lightning.fabric.strategies.fsdp import _apply_filter
 from lightning.fabric.strategies.launchers.xla import _XLALauncher
-from lightning.fabric.strategies.strategy import _BackwardSyncControl, _validate_keys_for_strict_loading, TBroadcast
+from lightning.fabric.strategies.strategy import (
+    _BackwardSyncControl,
+    _Sharded,
+    _validate_keys_for_strict_loading,
+    TBroadcast,
+)
 from lightning.fabric.utilities.cloud_io import get_filesystem
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_1_13, _TORCH_GREATER_EQUAL_2_0
 from lightning.fabric.utilities.init import _EmptyInit
@@ -46,7 +51,7 @@ _POLICY_SET = Set[Type[Module]]
 _POLICY = Union[_POLICY_SET, Callable[[Module, bool, int], bool]]
 
 
-class XLAFSDPStrategy(ParallelStrategy):
+class XLAFSDPStrategy(ParallelStrategy, _Sharded):
     r"""Strategy for training multiple XLA devices using the
     :func:`torch_xla.distributed.xla_fully_sharded_data_parallel.XlaFullyShardedDataParallel` method.
 
@@ -187,17 +192,16 @@ class XLAFSDPStrategy(ParallelStrategy):
     def module_to_device(self, module: Module) -> None:
         pass
 
-    @contextmanager
-    def module_init_context(self, empty_init: Optional[bool] = None) -> Generator[None, None, None]:
-        # TODO: Use the meta device and reset parameters after https://github.com/pytorch/pytorch/issues/90465
-        # is resolved. For now, the module will get moved to the device in `setup_module`.
-        empty_init_context = _EmptyInit(enabled=bool(empty_init)) if _TORCH_GREATER_EQUAL_1_13 else nullcontext()
-        with empty_init_context, self.precision.init_context(), self.module_sharded_context():
-            yield
+    def module_init_context(self, empty_init: Optional[bool] = None) -> ContextManager:
+        stack = ExitStack()
+        if _TORCH_GREATER_EQUAL_1_13:
+            stack.enter_context(_EmptyInit(enabled=bool(empty_init)))
+        stack.enter_context(self.precision.init_context())
+        stack.enter_context(self.module_sharded_context())
+        return stack
 
-    @contextmanager
-    def module_sharded_context(self) -> Generator:
-        yield
+    def module_sharded_context(self) -> ContextManager:
+        return nullcontext()
 
     def process_dataloader(self, dataloader: DataLoader) -> "MpDeviceLoader":
         from torch_xla.distributed.parallel_loader import MpDeviceLoader
@@ -639,8 +643,7 @@ def _activation_checkpointing_kwargs(policy: Optional[_POLICY_SET], kwargs: Dict
 
 
 class _XLAFSDPBackwardSyncControl(_BackwardSyncControl):
-    @contextmanager
-    def no_backward_sync(self, module: Module) -> Generator:
+    def no_backward_sync(self, module: Module) -> ContextManager:
         """Blocks gradient synchronization inside the
         :class:`~torch_xla.distributed.fsdp.XlaFullyShardedDataParallel` wrapper."""
         from torch_xla.distributed.fsdp import XlaFullyShardedDataParallel as XLAFSDP
@@ -651,5 +654,4 @@ class _XLAFSDPBackwardSyncControl(_BackwardSyncControl):
                 f" `{self.__class__.__name__}.no_backward_sync` is wrapped in `XlaFullyShardedDataParallel`."
                 f" Got: {module.__class__.__name__}."
             )
-        with module.no_sync():
-            yield
+        return module.no_sync()

--- a/tests/tests_fabric/conftest.py
+++ b/tests/tests_fabric/conftest.py
@@ -60,6 +60,8 @@ def restore_env_variables():
         # set by XLA FSDP on XRT
         "XRT_TORCH_DIST_ROOT",
         "XRT_MESH_SERVICE_ADDRESS",
+        # set by torchdynamo
+        "TRITON_CACHE_DIR",
     }
     leaked_vars.difference_update(allowlist)
     assert not leaked_vars, f"test is leaking environment variable(s): {set(leaked_vars)}"

--- a/tests/tests_fabric/plugins/precision/test_deepspeed.py
+++ b/tests/tests_fabric/plugins/precision/test_deepspeed.py
@@ -80,7 +80,7 @@ def test_selected_dtype(precision, expected_dtype):
 )
 def test_init_context(precision, expected_dtype):
     plugin = DeepSpeedPrecision(precision=precision)
-    with plugin.init_context():
+    with plugin.init_context:
         model = torch.nn.Linear(2, 2)
         assert torch.get_default_dtype() == expected_dtype
     assert model.weight.dtype == expected_dtype

--- a/tests/tests_fabric/plugins/precision/test_utils.py
+++ b/tests/tests_fabric/plugins/precision/test_utils.py
@@ -1,0 +1,48 @@
+import pytest
+import torch
+
+from lightning.fabric.plugins.precision.utils import _ClassReplacementContextManager, _DtypeContextManager
+
+
+def test_dtype_context_manager():
+    # regular issue
+    assert torch.get_default_dtype() is torch.float32
+    with _DtypeContextManager(torch.float16):
+        assert torch.get_default_dtype() is torch.float16
+
+    # exception
+    assert torch.get_default_dtype() is torch.float32
+    with pytest.raises(RuntimeError, match="foo"), _DtypeContextManager(torch.float16):
+        assert torch.get_default_dtype() is torch.float16
+        raise RuntimeError("foo")
+    assert torch.get_default_dtype() is torch.float32
+
+
+def test_class_replacement_context_manager():
+    original_linear = torch.nn.Linear
+    original_layernorm = torch.nn.LayerNorm
+
+    class MyLinear:
+        def __init__(self, *_, **__):
+            pass
+
+    class MyLayerNorm:
+        def __init__(self, *_, **__):
+            pass
+
+    context_manager = _ClassReplacementContextManager({"torch.nn.Linear": MyLinear, "torch.nn.LayerNorm": MyLayerNorm})
+    assert context_manager._originals == {"torch.nn.Linear": original_linear, "torch.nn.LayerNorm": original_layernorm}
+    assert context_manager._modules == {"torch.nn.Linear": torch.nn, "torch.nn.LayerNorm": torch.nn}
+
+    with context_manager:
+        linear = torch.nn.Linear(100, 100)
+        layernorm = torch.nn.LayerNorm(1)
+    assert isinstance(linear, MyLinear)
+    assert isinstance(layernorm, MyLayerNorm)
+    assert not hasattr(linear, "forward")
+
+    linear = torch.nn.Linear(100, 100)
+    layernorm = torch.nn.LayerNorm(1)
+    assert isinstance(linear, original_linear)
+    assert isinstance(layernorm, original_layernorm)
+    assert hasattr(linear, "forward")


### PR DESCRIPTION
## What does this PR do?

`torch.compile` does not understand `@contextlib.contextmanager`:

```python
import contextlib
import torch

@contextlib.contextmanager
def context():
    pass
    yield
    pass

def fn():
    with context():
        return 2

fn = torch.compile(fn, fullgraph=True)
out = fn()
assert out == 2
```

On the other hand, it does understand a regular context manager class:

```python
import torch

class context:
    def __enter__(self):
        pass

    def __exit__(self, exc_type, exc_val, exc_tb):
        pass

def fn():
    with context():
        return 2

fn = torch.compile(fn, fullgraph=True)
out = fn()
assert out == 2
```

The implementation uses our own classes, because there are no uses of the methods I updated using `@` instead of `with`. But this is believe to be important, we could also subclass https://github.com/pytorch/pytorch/blob/main/torch/utils/_contextlib.py#L120