### PR TITLE
Support hybrid-shard in FSDP

### DIFF
--- a/docs/source-fabric/advanced/model_parallel/fsdp.rst
+++ b/docs/source-fabric/advanced/model_parallel/fsdp.rst
@@ -216,6 +216,8 @@ You can configure the following options to trade-off memory for speed:
         sharding_strategy="FULL_SHARD",
         # Shard gradients, optimizer state (2 + 3)
         sharding_strategy="SHARD_GRAD_OP",
+        # Full-shard within a machine, replicate across machines
+        sharding_strategy="HYBRID_SHARD",
         # Don't shard anything (similar to DDP)
         sharding_strategy="NO_SHARD",
     )
@@ -226,6 +228,7 @@ You can configure the following options to trade-off memory for speed:
 
 1. Try the default settings first (FULL_SHARD). This is the slowest but will save you the most memory.
 2. Try SHARD_GRAD_OP. If you run out of memory, revert back to the default (FULL_SHARD). Otherwise you should expect to see an increase in iteration speed.
+3. If you are training across many machines, try HYBRID_SHARD.
 
 |
 

--- a/docs/source-pytorch/advanced/model_parallel/fsdp.rst
+++ b/docs/source-pytorch/advanced/model_parallel/fsdp.rst
@@ -246,6 +246,8 @@ You can configure the following options to trade-off memory for speed:
         sharding_strategy="FULL_SHARD",
         # Shard gradients, optimizer state (2 + 3)
         sharding_strategy="SHARD_GRAD_OP",
+        # Full-shard within a machine, replicate across machines
+        sharding_strategy="HYBRID_SHARD",
         # Don't shard anything (similar to DDP)
         sharding_strategy="NO_SHARD",
     )
@@ -256,6 +258,7 @@ You can configure the following options to trade-off memory for speed:
 
 1. Try the default settings first (FULL_SHARD). This is the slowest but will save you the most memory.
 2. Try SHARD_GRAD_OP. If you run out of memory, revert back to the default (FULL_SHARD). Otherwise you should expect to see an increase in iteration speed.
+3. If you are training across many machines, try HYBRID_SHARD.
 
 |
 

--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -124,6 +124,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support for saving and loading stateful objects other than modules and optimizers ([#18513](https://github.com/Lightning-AI/lightning/pull/18513))
 
 
+- Added support for passing the process group to the `FSDPStrategy` ([#18562](https://github.com/Lightning-AI/lightning/pull/18562))
+
+
+- Added default process group configuration for `FSDPStrategy(sharding_strategy="HYBRID_SHARD")` ([#18562](https://github.com/Lightning-AI/lightning/pull/18562))
+
+
 ### Changed
 
 - Allow using iterable-style datasets with TPUs ([#17331](https://github.com/Lightning-AI/lightning/pull/17331))

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -169,7 +169,7 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
             precision=precision,
         )
         self._num_nodes = 1
-        self._process_group = None
+        self._process_group: Optional[Union[ProcessGroup, Tuple[ProcessGroup, ProcessGroup]]] = None
         self._process_group_backend: Optional[str] = process_group_backend
         self._timeout: Optional[timedelta] = timeout
         self._backward_sync_control = _FSDPBackwardSyncControl()

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -675,9 +675,7 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
         _init_dist_connection(self.cluster_environment, self._process_group_backend, timeout=self._timeout)
         if self._process_group is None:
             self._process_group = _get_process_group(
-                sharding_strategy=self.sharding_strategy,
-                node_rank=self.node_rank,
-                local_world_size=self.num_processes
+                sharding_strategy=self.sharding_strategy, node_rank=self.node_rank, local_world_size=self.num_processes
             )
 
     def _get_process_group_backend(self) -> str:

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -218,6 +218,10 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
         return {"num_replicas": (self.num_nodes * self.num_processes), "rank": self.global_rank}
 
     @property
+    def process_group(self) -> _PROCESS_GROUP:
+        return self._process_group
+
+    @property
     def process_group_backend(self) -> Optional[str]:
         return self._process_group_backend
 

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -218,7 +218,7 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
         return {"num_replicas": (self.num_nodes * self.num_processes), "rank": self.global_rank}
 
     @property
-    def process_group(self) -> _PROCESS_GROUP:
+    def process_group(self) -> Optional[_PROCESS_GROUP]:
         return self._process_group
 
     @property

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -124,6 +124,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added support for mixed 8-bit precision as `Trainer(precision="transformer-engine")` using [Nvidia's Transformer Engine](https://docs.nvidia.com/deeplearning/transformer-engine) ([#18459](https://github.com/Lightning-AI/lightning/pull/18459))
 
+
+- Added support for passing the process group to the `FSDPStrategy` ([#18562](https://github.com/Lightning-AI/lightning/pull/18562))
+
+
+- Added default process group configuration for `FSDPStrategy(sharding_strategy="HYBRID_SHARD")` ([#18562](https://github.com/Lightning-AI/lightning/pull/18562))
+
+
 ### Changed
 
 - Removed the limitation to call `self.trainer.model.parameters()` in `LightningModule.configure_optimizers()` ([#17309](https://github.com/Lightning-AI/lightning/pull/17309))

--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -205,7 +205,7 @@ class FSDPStrategy(ParallelStrategy):
         return len(self.parallel_devices) if self.parallel_devices is not None else 0
 
     @property
-    def process_group(self) -> _PROCESS_GROUP:
+    def process_group(self) -> Optional[_PROCESS_GROUP]:
         return self._process_group
 
     @property

--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -16,20 +16,7 @@ import os
 from contextlib import contextmanager, nullcontext
 from datetime import timedelta
 from pathlib import Path
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Generator,
-    List,
-    Literal,
-    Mapping,
-    Optional,
-    Set,
-    Type,
-    TYPE_CHECKING,
-    Union,
-)
+from typing import Any, Callable, Dict, Generator, List, Literal, Mapping, Optional, Set, Type, TYPE_CHECKING, Union
 
 import torch
 from torch import Tensor

--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -26,7 +26,6 @@ from typing import (
     Mapping,
     Optional,
     Set,
-    Tuple,
     Type,
     TYPE_CHECKING,
     Union,
@@ -55,7 +54,8 @@ from lightning.fabric.strategies.fsdp import (
     _load_raw_module_state,
     _METADATA_FILENAME,
     _optimizer_has_flat_params,
-    _setup_activation_checkpointing, _PROCESS_GROUP,
+    _PROCESS_GROUP,
+    _setup_activation_checkpointing,
 )
 from lightning.fabric.utilities.distributed import (
     _get_default_process_group_backend_for_device,
@@ -73,7 +73,7 @@ from lightning.fabric.utilities.init import _EmptyInit
 from lightning.fabric.utilities.load import _lazy_load, _materialize_tensors
 from lightning.fabric.utilities.optimizer import _optimizers_to_device
 from lightning.fabric.utilities.seed import reset_seed
-from lightning.fabric.utilities.types import _PATH, ProcessGroup, ReduceOp
+from lightning.fabric.utilities.types import _PATH, ReduceOp
 from lightning.pytorch.core.optimizer import LightningOptimizer
 from lightning.pytorch.plugins.precision import PrecisionPlugin
 from lightning.pytorch.plugins.precision.fsdp import FSDPPrecisionPlugin

--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -208,6 +208,14 @@ class FSDPStrategy(ParallelStrategy):
 
             # The strategy should have already initilized process group in setup_environment()
             self._process_group = _get_default_group()
+        
+        from torch.distributed.fsdp.fully_sharded_data_parallel import ShardingStrategy
+
+        if self.sharding_strategy in (ShardingStrategy.HYBRID_SHARD, ):
+            start = self.node_rank * self.num_processes
+            local_ranks = list(range(start, start + self.num_processes))
+            group = torch.distributed.new_group(ranks=local_ranks, backend=self._process_group_backend)
+            return (self._process_group, group)
         return self._process_group
 
     @property

--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -170,7 +170,7 @@ class FSDPStrategy(ParallelStrategy):
             precision_plugin=precision_plugin,
         )
         self.num_nodes = 1
-        self._process_group = None
+        self._process_group: Optional[Union[ProcessGroup, Tuple[ProcessGroup, ProcessGroup]]] = None
         self._process_group_backend = process_group_backend
         self._timeout: Optional[timedelta] = timeout
         self.cpu_offload = _init_cpu_offload(cpu_offload)

--- a/tests/tests_fabric/strategies/test_fsdp.py
+++ b/tests/tests_fabric/strategies/test_fsdp.py
@@ -383,8 +383,9 @@ def test_fsdp_load_raw_checkpoint_optimizer_unsupported(tmp_path):
 
 
 @RunIf(min_torch="1.12")
+@mock.patch("lightning.fabric.strategies.fsdp._get_process_group")
 @mock.patch("torch.distributed.init_process_group")
-def test_set_timeout(init_process_group_mock):
+def test_set_timeout(init_process_group_mock, _):
     """Test that the timeout gets passed to the ``torch.distributed.init_process_group`` function."""
     test_timedelta = timedelta(seconds=30)
     strategy = FSDPStrategy(timeout=test_timedelta, parallel_devices=[torch.device("cpu")])
@@ -397,6 +398,41 @@ def test_set_timeout(init_process_group_mock):
     init_process_group_mock.assert_called_with(
         process_group_backend, rank=global_rank, world_size=world_size, timeout=test_timedelta
     )
+
+
+@RunIf(min_torch="2.0")
+@mock.patch("torch.distributed.init_process_group", Mock())
+@mock.patch("torch.distributed.distributed_c10d._get_default_group")
+@mock.patch("torch.distributed.new_group")
+def test_process_group(new_group_mock, get_default_group_mock):
+    """Test that the default process group gets set up according to the requested sharding strategy."""
+    parallel_devices = [torch.device("cpu")] * 4
+    cluster_environment = Mock(
+        node_rank=Mock(return_value=1),
+        local_rank=Mock(return_value=1),
+        global_rank=Mock(return_value=4),
+        world_size=Mock(return_value=8),
+        main_address="test",
+        main_port=1234,
+    )
+
+    # Default sharding strategy
+    strategy = FSDPStrategy(parallel_devices=parallel_devices)
+    strategy.cluster_environment = cluster_environment
+    strategy.accelerator = Mock()
+    assert strategy.process_group is None
+    strategy.setup_environment()
+    assert strategy.process_group == get_default_group_mock()
+
+    # Hybrid shard
+    strategy = FSDPStrategy(parallel_devices=parallel_devices, sharding_strategy="HYBRID_SHARD")
+    strategy.cluster_environment = cluster_environment
+    strategy.accelerator = Mock()
+    assert strategy.process_group is None
+    strategy.setup_environment()
+    new_group_mock.assert_called_with(ranks=[4, 5, 6, 7])
+    assert isinstance(strategy.process_group, tuple)
+    assert strategy.process_group == (get_default_group_mock(), new_group_mock())
 
 
 def test_has_meta_device_parameters():

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -487,6 +487,7 @@ def test_fsdp_use_orig_params():
         assert not strategy.kwargs["use_orig_params"]
 
 
+@RunIf(min_torch="1.12")
 @mock.patch("lightning.pytorch.strategies.fsdp._get_process_group")
 @mock.patch("torch.distributed.init_process_group")
 def test_set_timeout(init_process_group_mock, _):


### PR DESCRIPTION
## What does this PR do?

Fixes #18552

This PR configures a default process group pair when `FSDPStrategy(sharding_strategy="HYBRID_SHARD")` is chosen. In such a case, we default to sharding within the note and replicating across the nodes. The user can also pass in a custom process group pair to choose different rank groupings. We keep _HYBRID_SHARD_ZERO2 undocumented because it is experimental.

Tested this on two nodes in the Lightning AI cloud.



<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18562.org.readthedocs.build/en/18562/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca @justusschock @awaelchli