### PR TITLE
Wokarounds to avoid dynamo graph breaks with common precision settings

### DIFF
--- a/src/lightning/fabric/wrappers.py
+++ b/src/lightning/fabric/wrappers.py
@@ -113,7 +113,8 @@ class _FabricModule(_DeviceDtypeModuleMixin):
 
     def forward(self, *args: Any, **kwargs: Any) -> Any:
         """Casts all inputs to the right precision and handles autocast for operations in the module forward method."""
-        args, kwargs = self._precision.convert_input((args, kwargs))
+        args = self._precision.convert_input(args)
+        kwargs = self._precision.convert_input(kwargs)
 
         with self._precision.forward_context():
             output = self._forward_module(*args, **kwargs)

--- a/tests/tests_fabric/test_fabric.py
+++ b/tests/tests_fabric/test_fabric.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import operator
 import os
 import sys
 from re import escape
@@ -38,6 +39,7 @@ from lightning.fabric.utilities.exceptions import MisconfigurationException
 from lightning.fabric.utilities.seed import pl_worker_init_function, seed_everything
 from lightning.fabric.utilities.warnings import PossibleUserWarning
 from lightning.fabric.wrappers import _FabricDataLoader, _FabricModule, _FabricOptimizer
+from lightning_utilities import compare_version
 from lightning_utilities.test.warning import no_warning_call
 from torch import nn
 from torch.utils.data import DataLoader, DistributedSampler, RandomSampler, Sampler, SequentialSampler, TensorDataset
@@ -1204,9 +1206,14 @@ def test_verify_launch_called():
     "kwargs",
     [
         {},
-        pytest.param({"precision": "16-true"}, marks=pytest.mark.xfail(raises=RuntimeError, match="Unsupported")),
-        pytest.param({"precision": "64-true"}, marks=pytest.mark.xfail(raises=RuntimeError, match="Unsupported")),
+        pytest.param({"precision": "16-true"}, marks=RunIf(min_torch="2.2")),
+        pytest.param({"precision": "16-mixed"}, marks=RunIf(min_torch="2.2")),
+        pytest.param({"precision": "bf16-true"}, marks=RunIf(bf16_cuda=True)),
+        pytest.param({"precision": "64-true"}, marks=RunIf(min_torch="2.2")),
     ],
+)
+@pytest.mark.skipif(
+    compare_version("lightning_utilities", operator.lt, "0.10.0", use_base_version=True), reason="Requires patch"
 )
 def test_fabric_with_torchdynamo_fullgraph(kwargs):
     class MyModel(torch.nn.Module):

--- a/tests/tests_fabric/test_fabric.py
+++ b/tests/tests_fabric/test_fabric.py
@@ -1208,7 +1208,7 @@ def test_verify_launch_called():
         {},
         pytest.param({"precision": "16-true"}, marks=RunIf(min_torch="2.2")),
         pytest.param({"precision": "16-mixed"}, marks=RunIf(min_torch="2.2")),
-        pytest.param({"precision": "bf16-true"}, marks=RunIf(bf16_cuda=True)),
+        pytest.param({"precision": "bf16-true"}, marks=RunIf(min_torch="2.2", bf16_cuda=True)),
         pytest.param({"precision": "64-true"}, marks=RunIf(min_torch="2.2")),
     ],
 )


### PR DESCRIPTION
## What does this PR do?

Per title.

The main blocker is https://github.com/pytorch/pytorch/issues/112787

<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18566.org.readthedocs.build/en/18566/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca @justusschock @awaelchli