### PR TITLE
Avoid rewriting the metrics file in CSVLogger unless necessary

### DIFF
--- a/.azure/README.md
+++ b/.azure/README.md
@@ -44,3 +44,27 @@ done
 ```bash
 ps aux | grep start.sh
 ```
+
+# Machine maintenance
+
+Since most of our jobs/checks are running in a Docker container, the OS/machine can become polluted and fail to run with errors such as:
+
+```
+No space left on device : '/azp/agent-litGPU-21_0,1/_diag/pages/8bb191f4-a8c2-419a-8788-66e3f0522bea_1.log'
+```
+
+In such cases, you need to log in to the machine and run `docker system prune`.
+
+## Automated ways
+
+Let's explore adding a cron job for periodically removing all Docker caches:
+
+1. Open your user's cron tab for editing: `crontab -e`
+1. Schedule/add the command with the `--force` flag to force pruning without interactive confirmation:
+   ```bash
+   # every day at 2:00 AM clean docker caches
+   0 2 * * * docker system prune --force
+   ```
+1. Verify the entry: `crontab -l`
+
+Note: You may need to add yourself to the Docker group by running `sudo usermod -aG docker <your_username>` to have permission to execute this command without needing `sudo` and entering the password.

--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -206,6 +206,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed issue where unexpected exceptions would leave the default torch dtype modified when using true precision settings ([#18500](https://github.com/Lightning-AI/lightning/pull/18500))
 
+
+- Fixed redunant file writes in `CSVLogger` ([#18567](https://github.com/Lightning-AI/lightning/pull/18567))
+
+
+
 ## [2.0.7] - 2023-08-14
 
 ### Changed

--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -207,7 +207,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed issue where unexpected exceptions would leave the default torch dtype modified when using true precision settings ([#18500](https://github.com/Lightning-AI/lightning/pull/18500))
 
 
-- Fixed redunant file writes in `CSVLogger` ([#18567](https://github.com/Lightning-AI/lightning/pull/18567))
+- Fixed redundant file writes in `CSVLogger` ([#18567](https://github.com/Lightning-AI/lightning/pull/18567))
 
 
 

--- a/src/lightning/fabric/loggers/csv_logs.py
+++ b/src/lightning/fabric/loggers/csv_logs.py
@@ -188,7 +188,7 @@ class _ExperimentWriter:
 
     def __init__(self, log_dir: str) -> None:
         self.metrics: List[Dict[str, float]] = []
-        self.metrics_keys = []
+        self.metrics_keys: List[str] = []
 
         self._fs = get_filesystem(log_dir)
         self.log_dir = log_dir

--- a/src/lightning/fabric/loggers/csv_logs.py
+++ b/src/lightning/fabric/loggers/csv_logs.py
@@ -16,7 +16,7 @@ import csv
 import logging
 import os
 from argparse import Namespace
-from typing import Any, Dict, List, Optional, Union, Set
+from typing import Any, Dict, List, Optional, Set, Union
 
 from torch import Tensor
 
@@ -249,4 +249,3 @@ class _ExperimentWriter:
 def _get_keys_from_metrics(metrics: List[Dict[str, Any]]) -> Set[str]:
     key_sets = [metric_dict.keys() for metric_dict in metrics]
     return set().union(*key_sets)
-

--- a/src/lightning/fabric/loggers/csv_logs.py
+++ b/src/lightning/fabric/loggers/csv_logs.py
@@ -226,7 +226,7 @@ class _ExperimentWriter:
         self.metrics_keys.extend(new_keys)
 
         if new_keys and self._fs.isfile(self.metrics_file_path):
-            # we need to re-write the file if the keys (header) changes
+            # we need to re-write the file if the keys (header) change
             self._rewrite_with_new_header(self.metrics_keys)
 
         with self._fs.open(self.metrics_file_path, "a", newline="") as file:

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -263,6 +263,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed false positive warning about logging interval when running with `Trainer(fast_dev_run=True)` ([#18550](https://github.com/Lightning-AI/lightning/pull/18550))
 
 
+- Fixed redunant file writes in `CSVLogger` ([#18567](https://github.com/Lightning-AI/lightning/pull/18567))
+
+
 ## [2.0.7] - 2023-08-14
 
 ### Added

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -263,7 +263,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed false positive warning about logging interval when running with `Trainer(fast_dev_run=True)` ([#18550](https://github.com/Lightning-AI/lightning/pull/18550))
 
 
-- Fixed redunant file writes in `CSVLogger` ([#18567](https://github.com/Lightning-AI/lightning/pull/18567))
+- Fixed redundant file writes in `CSVLogger` ([#18567](https://github.com/Lightning-AI/lightning/pull/18567))
 
 
 ## [2.0.7] - 2023-08-14

--- a/tests/tests_fabric/loggers/test_csv.py
+++ b/tests/tests_fabric/loggers/test_csv.py
@@ -163,3 +163,21 @@ def test_append_columns(tmp_path):
     with open(logger.experiment.metrics_file_path) as file:
         header = file.readline().strip()
         assert set(header.split(",")) == {"step", "a", "b", "c"}
+
+
+def test_rewrite_with_new_header(tmp_path):
+    # write a csv file manually
+    with open(tmp_path / "metrics.csv", "w") as file:
+        file.write("step,metric1,metric2\n")
+        file.write("0,1,22\n")
+
+    writer = _ExperimentWriter(log_dir=str(tmp_path))
+    new_columns = ["step", "metric1", "metric2", "metric3"]
+    writer._rewrite_with_new_header(new_columns)
+
+    # the rewritten file should have the new columns
+    with open(tmp_path / "metrics.csv") as file:
+        header = file.readline().strip().split(",")
+        assert header == new_columns
+        logs = file.readline().strip().split(",")
+        assert logs == ["0", "1", "22", ""]

--- a/tests/tests_fabric/loggers/test_csv.py
+++ b/tests/tests_fabric/loggers/test_csv.py
@@ -120,24 +120,38 @@ def test_automatic_step_tracking(tmp_path):
     assert logger.experiment.metrics[2]["step"] == 2
 
 
+def test_append_metrics_file(tmp_path):
+    """Test that the logger appends to the file instead of rewriting it on every save."""
+    logger = CSVLogger(tmp_path, name="test", version=0, flush_logs_every_n_steps=1)
+
+    # initial metrics
+    logger.log_metrics({"a": 1, "b": 2})
+    logger.log_metrics({"a": 3, "b": 4})
+
+    # create a new logger to show we append to the existing file
+    logger = CSVLogger(tmp_path, name="test", version=0, flush_logs_every_n_steps=1)
+    logger.log_metrics({"a": 100, "b": 200})
+
+    with open(logger.experiment.metrics_file_path) as file:
+        lines = file.readlines()
+    assert len(lines) == 4  # 1 header + 3 lines of metrics
+
+
 def test_append_columns(tmp_path):
     """Test that the CSV file gets rewritten with new headers if the columns change."""
     logger = CSVLogger(tmp_path, flush_logs_every_n_steps=1)
 
     # initial metrics
-    metrics = {"a": 1, "b": 2}
-    logger.log_metrics(metrics)
+    logger.log_metrics({"a": 1, "b": 2})
 
     # new key appears
-    metrics = {"a": 1, "b": 2, "c": 3}
-    logger.log_metrics(metrics)
+    logger.log_metrics({"a": 1, "b": 2, "c": 3})
     with open(logger.experiment.metrics_file_path, "r") as file:
         header = file.readline().strip()
         assert set(header.split(",")) == {"step", "a", "b", "c"}
 
     # key disappears
-    metrics = {"a": 1, "c": 3}
-    logger.log_metrics(metrics)
+    logger.log_metrics({"a": 1, "c": 3})
     with open(logger.experiment.metrics_file_path, "r") as file:
         header = file.readline().strip()
         assert set(header.split(",")) == {"step", "a", "b", "c"}

--- a/tests/tests_fabric/loggers/test_csv.py
+++ b/tests/tests_fabric/loggers/test_csv.py
@@ -103,6 +103,15 @@ def test_flush_n_steps(tmpdir):
     logger.save.assert_called_once()
 
 
+def test_metrics_reset_after_save(tmp_path):
+    logger = CSVLogger(tmp_path, flush_logs_every_n_steps=2)
+    metrics = {"test": 1}
+    logger.log_metrics(metrics, step=0)
+    assert logger.experiment.metrics
+    logger.log_metrics(metrics, step=1)  # flush triggered
+    assert not logger.experiment.metrics
+
+
 def test_automatic_step_tracking(tmp_path):
     """Test that the logger keeps track of the step value if it isn't passed in explicitly."""
     logger = CSVLogger(tmp_path, flush_logs_every_n_steps=3)

--- a/tests/tests_fabric/loggers/test_csv.py
+++ b/tests/tests_fabric/loggers/test_csv.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 
 import pytest
 import torch
+import csv
 
 from lightning.fabric.loggers import CSVLogger
 from lightning.fabric.loggers.csv_logs import _ExperimentWriter
@@ -117,3 +118,26 @@ def test_automatic_step_tracking(tmp_path):
     logger.log_metrics(metrics, step=None)
     logger.save.assert_called_once()
     assert logger.experiment.metrics[2]["step"] == 2
+
+
+def test_append_columns(tmp_path):
+    """Test that the CSV file gets rewritten with new headers if the columns change."""
+    logger = CSVLogger(tmp_path, flush_logs_every_n_steps=1)
+
+    # initial metrics
+    metrics = {"a": 1, "b": 2}
+    logger.log_metrics(metrics)
+
+    # new key appears
+    metrics = {"a": 1, "b": 2, "c": 3}
+    logger.log_metrics(metrics)
+    with open(logger.experiment.metrics_file_path, "r") as file:
+        header = file.readline().strip()
+        assert set(header.split(",")) == {"step", "a", "b", "c"}
+
+    # key disappears
+    metrics = {"a": 1, "c": 3}
+    logger.log_metrics(metrics)
+    with open(logger.experiment.metrics_file_path, "r") as file:
+        header = file.readline().strip()
+        assert set(header.split(",")) == {"step", "a", "b", "c"}

--- a/tests/tests_fabric/loggers/test_csv.py
+++ b/tests/tests_fabric/loggers/test_csv.py
@@ -21,7 +21,7 @@ from lightning.fabric.loggers import CSVLogger
 from lightning.fabric.loggers.csv_logs import _ExperimentWriter
 
 
-def test_file_logger_automatic_versioning(tmp_path):
+def test_automatic_versioning(tmp_path):
     """Verify that automatic versioning works."""
     (tmp_path / "exp" / "version_0").mkdir(parents=True)
     (tmp_path / "exp" / "version_1").mkdir()
@@ -29,7 +29,7 @@ def test_file_logger_automatic_versioning(tmp_path):
     assert logger.version == 2
 
 
-def test_file_logger_automatic_versioning_relative_root_dir(tmp_path, monkeypatch):
+def test_automatic_versioning_relative_root_dir(tmp_path, monkeypatch):
     """Verify that automatic versioning works, when root_dir is given a relative path."""
     (tmp_path / "exp" / "logs" / "version_0").mkdir(parents=True)
     (tmp_path / "exp" / "logs" / "version_1").mkdir()
@@ -38,7 +38,7 @@ def test_file_logger_automatic_versioning_relative_root_dir(tmp_path, monkeypatc
     assert logger.version == 2
 
 
-def test_file_logger_manual_versioning(tmpdir):
+def test_manual_versioning(tmpdir):
     """Verify that manual versioning works."""
     root_dir = tmpdir.mkdir("exp")
     root_dir.mkdir("version_0")
@@ -48,7 +48,7 @@ def test_file_logger_manual_versioning(tmpdir):
     assert logger.version == 1
 
 
-def test_file_logger_named_version(tmpdir):
+def test_named_version(tmpdir):
     """Verify that manual versioning works for string versions, e.g. '2020-02-05-162402'."""
     exp_name = "exp"
     tmpdir.mkdir(exp_name)
@@ -63,7 +63,7 @@ def test_file_logger_named_version(tmpdir):
 
 
 @pytest.mark.parametrize("name", ["", None])
-def test_file_logger_no_name(tmpdir, name):
+def test_no_name(tmpdir, name):
     """Verify that None or empty name works."""
     logger = CSVLogger(root_dir=tmpdir, name=name)
     logger.log_metrics({"a": 1})
@@ -73,7 +73,7 @@ def test_file_logger_no_name(tmpdir, name):
 
 
 @pytest.mark.parametrize("step_idx", [10, None])
-def test_file_logger_log_metrics(tmpdir, step_idx):
+def test_log_metrics(tmpdir, step_idx):
     logger = CSVLogger(tmpdir)
     metrics = {"float": 0.3, "int": 1, "FloatTensor": torch.tensor(0.1), "IntTensor": torch.tensor(1)}
     logger.log_metrics(metrics, step_idx)
@@ -86,7 +86,7 @@ def test_file_logger_log_metrics(tmpdir, step_idx):
     assert all(n in lines[0] for n in metrics)
 
 
-def test_file_logger_log_hyperparams(tmpdir):
+def test_log_hyperparams(tmpdir):
     logger = CSVLogger(tmpdir)
     with pytest.raises(NotImplementedError):
         logger.log_hyperparams({})

--- a/tests/tests_pytorch/loggers/test_csv.py
+++ b/tests/tests_pytorch/loggers/test_csv.py
@@ -136,3 +136,26 @@ def test_flush_n_steps(tmpdir):
     logger.save.assert_not_called()
     logger.log_metrics(metrics, step=1)
     logger.save.assert_called_once()
+
+
+def test_append_columns(tmp_path):
+    """Test that the CSV file gets rewritten with new headers if the columns change."""
+    logger = CSVLogger(tmp_path, flush_logs_every_n_steps=1)
+
+    # initial metrics
+    metrics = {"a": 1, "b": 2}
+    logger.log_metrics(metrics)
+
+    # new key appears
+    metrics = {"a": 1, "b": 2, "c": 3}
+    logger.log_metrics(metrics)
+    with open(logger.experiment.metrics_file_path, "r") as file:
+        header = file.readline().strip()
+        assert set(header.split(",")) == {"step", "a", "b", "c"}
+
+    # key disappears
+    metrics = {"a": 1, "c": 3}
+    logger.log_metrics(metrics)
+    with open(logger.experiment.metrics_file_path, "r") as file:
+        header = file.readline().strip()
+        assert set(header.split(",")) == {"step", "a", "b", "c"}

--- a/tests/tests_pytorch/loggers/test_csv.py
+++ b/tests/tests_pytorch/loggers/test_csv.py
@@ -27,7 +27,7 @@ from tests_pytorch.helpers.runif import RunIf
 from tests_pytorch.helpers.simple_models import ClassificationModel
 
 
-def test_file_logger_automatic_versioning(tmpdir):
+def test_automatic_versioning(tmpdir):
     """Verify that automatic versioning works."""
     root_dir = tmpdir.mkdir("exp")
     root_dir.mkdir("version_0")
@@ -38,7 +38,7 @@ def test_file_logger_automatic_versioning(tmpdir):
     assert logger.version == 2
 
 
-def test_file_logger_manual_versioning(tmpdir):
+def test_manual_versioning(tmpdir):
     """Verify that manual versioning works."""
     root_dir = tmpdir.mkdir("exp")
     root_dir.mkdir("version_0")
@@ -50,7 +50,7 @@ def test_file_logger_manual_versioning(tmpdir):
     assert logger.version == 1
 
 
-def test_file_logger_named_version(tmpdir):
+def test_named_version(tmpdir):
     """Verify that manual versioning works for string versions, e.g. '2020-02-05-162402'."""
     exp_name = "exp"
     tmpdir.mkdir(exp_name)
@@ -65,7 +65,7 @@ def test_file_logger_named_version(tmpdir):
 
 
 @pytest.mark.parametrize("name", ["", None])
-def test_file_logger_no_name(tmpdir, name):
+def test_no_name(tmpdir, name):
     """Verify that None or empty name works."""
     logger = CSVLogger(save_dir=tmpdir, name=name)
     logger.save()
@@ -74,7 +74,7 @@ def test_file_logger_no_name(tmpdir, name):
 
 
 @pytest.mark.parametrize("step_idx", [10, None])
-def test_file_logger_log_metrics(tmpdir, step_idx):
+def test_log_metrics(tmpdir, step_idx):
     logger = CSVLogger(tmpdir)
     metrics = {"float": 0.3, "int": 1, "FloatTensor": torch.tensor(0.1), "IntTensor": torch.tensor(1)}
     logger.log_metrics(metrics, step_idx)
@@ -87,7 +87,7 @@ def test_file_logger_log_metrics(tmpdir, step_idx):
     assert all(n in lines[0] for n in metrics)
 
 
-def test_file_logger_log_hyperparams(tmpdir):
+def test_log_hyperparams(tmpdir):
     logger = CSVLogger(tmpdir)
     hparams = {
         "float": 0.3,

--- a/tests/tests_pytorch/loggers/test_csv.py
+++ b/tests/tests_pytorch/loggers/test_csv.py
@@ -138,6 +138,15 @@ def test_flush_n_steps(tmpdir):
     logger.save.assert_called_once()
 
 
+def test_metrics_reset_after_save(tmp_path):
+    logger = CSVLogger(tmp_path, flush_logs_every_n_steps=2)
+    metrics = {"test": 1}
+    logger.log_metrics(metrics, step=0)
+    assert logger.experiment.metrics
+    logger.log_metrics(metrics, step=1)  # flush triggered
+    assert not logger.experiment.metrics
+
+
 def test_append_metrics_file(tmp_path):
     """Test that the logger appends to the file instead of rewriting it on every save."""
     logger = CSVLogger(tmp_path, name="test", version=0, flush_logs_every_n_steps=1)


### PR DESCRIPTION
## What does this PR do?

Fixes  #17725

The CSVLogger in master accumulates all metrics in memory and writes them to a single file periodically. Naturally, this leads to an increasingly larger file, and with every write the time it takes increases. This was done for simplicity to avoid complicated optimizations, but ever since the CSVLogger was made the default, users noticed its naive implementation. 

This PR mitigates the file-write costs by appending to the file. However, a naive change from file-write mode "w" to "a" is not sufficient, because the keys in the metrics dict could change anytime (the user may log a new key in the future). Appending naively would lead to an invalid csv file. For this reason we still need to rewrite the entire file to update the new columns, which can be costly but we expect that new keys get added infrequently. When the keys don't change from one flush to the next, we simply append to the file. 

My personal recommendation is that we stop here. While we could do many more optimizations, it is probably not our intention to reinvent tools like tensorboard etc. The CSVLogger in my opinion should not be used for production training runs. 

<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18567.org.readthedocs.build/en/18567/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @tchaton @carmocca @justusschock @awaelchli