### PR TITLE
Correct reload_dataloaders_every_n_epochs docstring

### DIFF
--- a/src/lightning/pytorch/trainer/trainer.py
+++ b/src/lightning/pytorch/trainer/trainer.py
@@ -287,7 +287,7 @@ class Trainer:
             sync_batchnorm: Synchronize batch norm layers between process groups/whole world.
                 Default: ``False``.
 
-            reload_dataloaders_every_n_epochs: Set to a non-negative integer to reload dataloaders every n epochs.
+            reload_dataloaders_every_n_epochs: Set to a positive integer to reload dataloaders every n epochs.
                 Default: ``0``.
 
             default_root_dir: Default path for logs and weights when no logger/ckpt_callback passed.


### PR DESCRIPTION
Sorry for the nitpick! Since 0 is a non-negative integer, I was actually briefly confused whether I should set `reload_dataloaders_every_n_epochs` to -1 to disable it.

<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18585.org.readthedocs.build/en/18585/

<!-- readthedocs-preview pytorch-lightning end -->