### PR TITLE
Improve the suggested `num_workers` warning

### DIFF
--- a/src/lightning/pytorch/trainer/connectors/data_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/data_connector.py
@@ -429,9 +429,8 @@ def _worker_check(trainer: "pl.Trainer", dataloader: object, name: str) -> None:
         # TODO
         # if changed, update the `filterwarnings` snippet in 'speed.html#num-workers'
         rank_zero_warn(
-            f"The dataloader, {name}, does not have many workers which may be a bottleneck. Consider increasing the"
-            f" value of the `num_workers` argument` to `num_workers={upper_bound}` in the `DataLoader` to improve "
-            " performance.",
+            f"The '{name}', does not have many workers which may be a bottleneck. Consider increasing the value of the"
+            f" `num_workers` argument` to `num_workers={upper_bound}` in the `DataLoader` to improve performance.",
             category=PossibleUserWarning,
         )
 

--- a/src/lightning/pytorch/trainer/connectors/data_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/data_connector.py
@@ -425,7 +425,7 @@ def _worker_check(trainer: "pl.Trainer", dataloader: object, name: str) -> None:
         return
 
     upper_bound = suggested_max_num_workers(trainer.num_devices)
-    if dataloader.num_workers <= 2 < upper_bound:
+    if dataloader.num_workers <= 2 < upper_bound or dataloader.num_workers < 2 <= upper_bound:
         # TODO
         # if changed, update the `filterwarnings` snippet in 'speed.html#num-workers'
         rank_zero_warn(

--- a/src/lightning/pytorch/trainer/connectors/data_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/data_connector.py
@@ -425,26 +425,7 @@ def _worker_check(trainer: "pl.Trainer", dataloader: object, name: str) -> None:
         return
 
     upper_bound = suggested_max_num_workers(trainer.num_devices)
-
-    # # ddp_spawn + num_workers > 0 don't mix! tell the user
-    # if dataloader.num_workers > 0 and using_spawn:
-    #     if not dataloader.persistent_workers:
-    #         rank_zero_warn(
-    #             "num_workers>0, persistent_workers=False, and strategy=ddp_spawn"
-    #             " may result in data loading bottlenecks."
-    #             " Consider setting persistent_workers=True"
-    #             " (this is a limitation of Python .spawn() and PyTorch)"
-    #         )
-
-    # elif dataloader.num_workers == 0 and using_spawn:
-    #     if not dataloader.persistent_workers:
-    #         rank_zero_warn(
-    #             "strategy=ddp_spawn and num_workers=0 may result in data loading bottlenecks."
-    #             " Consider setting num_workers>0 and persistent_workers=True"
-    #         )
-
     if dataloader.num_workers <= 2 < upper_bound:
-        # TODO: find filterwarnings
         # if changed, update the `filterwarnings` snippet in 'speed.html#num-workers'
         rank_zero_warn(
             f"The dataloader, {name}, does not have many workers which may be a bottleneck."

--- a/src/lightning/pytorch/trainer/connectors/data_connector.py
+++ b/src/lightning/pytorch/trainer/connectors/data_connector.py
@@ -426,12 +426,12 @@ def _worker_check(trainer: "pl.Trainer", dataloader: object, name: str) -> None:
 
     upper_bound = suggested_max_num_workers(trainer.num_devices)
     if dataloader.num_workers <= 2 < upper_bound:
+        # TODO
         # if changed, update the `filterwarnings` snippet in 'speed.html#num-workers'
         rank_zero_warn(
-            f"The dataloader, {name}, does not have many workers which may be a bottleneck."
-            " Consider increasing the value of the `num_workers` argument`"
-            f" (try {upper_bound} which is the number of cpus on this machine)"
-            " in the `DataLoader` init to improve performance.",
+            f"The dataloader, {name}, does not have many workers which may be a bottleneck. Consider increasing the"
+            f" value of the `num_workers` argument` to `num_workers={upper_bound}` in the `DataLoader` to improve "
+            " performance.",
             category=PossibleUserWarning,
         )
 

--- a/src/lightning/pytorch/utilities/__init__.py
+++ b/src/lightning/pytorch/utilities/__init__.py
@@ -18,6 +18,7 @@ import numpy
 from lightning.fabric.utilities import LightningEnum  # noqa: F401
 from lightning.fabric.utilities import move_data_to_device  # noqa: F401
 from lightning.pytorch.utilities.combined_loader import CombinedLoader  # noqa: F401
+from lightning.pytorch.utilities.data import suggested_max_num_workers  # noqa: F401
 from lightning.pytorch.utilities.enums import GradClipAlgorithmType  # noqa: F401
 from lightning.pytorch.utilities.grads import grad_norm  # noqa: F401
 from lightning.pytorch.utilities.imports import _OMEGACONF_AVAILABLE, _TORCHVISION_AVAILABLE  # noqa: F401

--- a/src/lightning/pytorch/utilities/data.py
+++ b/src/lightning/pytorch/utilities/data.py
@@ -40,6 +40,8 @@ warning_cache = WarningCache()
 
 
 def suggested_max_num_workers(local_world_size: int) -> int:
+    if local_world_size < 1:
+        raise ValueError(f"`local_world_size` should be >= 1, got {local_world_size}.")
     cpu_count = _num_cpus_available()
     return max(1, cpu_count // local_world_size)
 

--- a/src/lightning/pytorch/utilities/data.py
+++ b/src/lightning/pytorch/utilities/data.py
@@ -44,7 +44,7 @@ def suggested_max_num_workers(local_world_size: int) -> int:
     return max(1, cpu_count // local_world_size)
 
 
-def _num_cpus_available():
+def _num_cpus_available() -> int:
     if hasattr(os, 'sched_getaffinity'):
         return len(os.sched_getaffinity(0))
 

--- a/src/lightning/pytorch/utilities/data.py
+++ b/src/lightning/pytorch/utilities/data.py
@@ -40,6 +40,13 @@ warning_cache = WarningCache()
 
 
 def suggested_max_num_workers(local_world_size: int) -> int:
+    """Suggests an upper bound of num_workers to use in a PyTorch :class:`~torch.utils.data.DataLoader` based on
+    the number of CPU cores available on the system and the number of distributed processes in the current machine.
+
+    Args:
+        local_world_size: The number of distributed processes running on the current machine. Set this to the number
+            of devices configured in the Trainer (``trainer.num_devices``).
+    """
     if local_world_size < 1:
         raise ValueError(f"`local_world_size` should be >= 1, got {local_world_size}.")
     cpu_count = _num_cpus_available()

--- a/src/lightning/pytorch/utilities/data.py
+++ b/src/lightning/pytorch/utilities/data.py
@@ -40,7 +40,7 @@ warning_cache = WarningCache()
 
 
 def suggested_max_num_workers(local_world_size: int) -> int:
-    """Suggests an upper bound of num_workers to use in a PyTorch :class:`~torch.utils.data.DataLoader` based on
+    """Suggests an upper bound of ``num_workers`` to use in a PyTorch :class:`~torch.utils.data.DataLoader` based on
     the number of CPU cores available on the system and the number of distributed processes in the current machine.
 
     Args:

--- a/src/lightning/pytorch/utilities/data.py
+++ b/src/lightning/pytorch/utilities/data.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import inspect
+import os
 from dataclasses import fields
 from typing import Any, Dict, Generator, Iterable, Mapping, Optional, Sized, Tuple, Union
 
@@ -36,6 +37,19 @@ from lightning.pytorch.utilities.rank_zero import rank_zero_warn, WarningCache
 BType = Union[Tensor, str, Mapping[Any, "BType"], Iterable["BType"]]
 
 warning_cache = WarningCache()
+
+
+def suggested_max_num_workers(local_world_size: int) -> int:
+    cpu_count = _num_cpus_available()
+    return max(1, cpu_count // local_world_size)
+
+
+def _num_cpus_available():
+    if hasattr(os, 'sched_getaffinity'):
+        return len(os.sched_getaffinity(0))
+
+    cpu_count = os.cpu_count()
+    return 1 if cpu_count is None else cpu_count
 
 
 def _extract_batch_size(batch: BType) -> Generator[Optional[int], None, None]:

--- a/tests/tests_pytorch/trainer/connectors/test_data_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_data_connector.py
@@ -109,7 +109,16 @@ def test_replace_distributed_sampler(tmpdir, mode):
 
 @pytest.mark.parametrize("num_devices, num_workers, cpu_count, expected_warning", [
     (1, 0, 1, False),
-    (1, 0, 1, False),
+    (8, 0, 1, False),
+    (8, 0, None, False),
+    (1, 1, None, False),
+    (1, 2, 2, False),
+    (1, 1, 8, True),
+    (1, 2, 8, True),
+    (1, 3, 8, False),
+    (4, 1, 8, True),
+    (4, 2, 8, False),
+    (8, 2, 8, False),
 ])
 @mock.patch("lightning.pytorch.utilities.data.os.cpu_count")
 def test_worker_check(cpu_count_mock, num_devices, num_workers, cpu_count, expected_warning, monkeypatch):

--- a/tests/tests_pytorch/trainer/connectors/test_data_connector.py
+++ b/tests/tests_pytorch/trainer/connectors/test_data_connector.py
@@ -31,7 +31,8 @@ from lightning.pytorch.trainer.connectors.data_connector import (
     _check_dataloader_iterable,
     _DataHookSelector,
     _DataLoaderSource,
-    warning_cache, _worker_check,
+    warning_cache,
+    _worker_check,
 )
 from lightning.pytorch.trainer.states import RunningStage, TrainerFn
 from lightning.pytorch.utilities.combined_loader import CombinedLoader
@@ -107,19 +108,22 @@ def test_replace_distributed_sampler(tmpdir, mode):
     trainer.test(model)
 
 
-@pytest.mark.parametrize("num_devices, num_workers, cpu_count, expected_warning", [
-    (1, 0, 1, False),
-    (8, 0, 1, False),
-    (8, 0, None, False),
-    (1, 1, None, False),
-    (1, 2, 2, False),
-    (1, 1, 8, True),
-    (1, 2, 8, True),
-    (1, 3, 8, False),
-    (4, 1, 8, True),
-    (4, 2, 8, False),
-    (8, 2, 8, False),
-])
+@pytest.mark.parametrize(
+    "num_devices, num_workers, cpu_count, expected_warning",
+    [
+        (1, 0, 1, False),
+        (8, 0, 1, False),
+        (8, 0, None, False),
+        (1, 1, None, False),
+        (1, 2, 2, False),
+        (1, 1, 8, True),
+        (1, 2, 8, True),
+        (1, 3, 8, False),
+        (4, 1, 8, True),
+        (4, 2, 8, False),
+        (8, 2, 8, False),
+    ],
+)
 @mock.patch("lightning.pytorch.utilities.data.os.cpu_count")
 def test_worker_check(cpu_count_mock, num_devices, num_workers, cpu_count, expected_warning, monkeypatch):
     monkeypatch.delattr("lightning.pytorch.utilities.data.os", "sched_getaffinity", raising=False)


### PR DESCRIPTION
## What does this PR do?

This PR improves the warning logic to suggest the number of workers to use in a DataLoader. Previously, the warning would be raised if the `num_workers` parameter in the DataLoader was smaller or equal to 2. This check is reasonable when running on a single GPU. However, the suggested value did not take into account the multi-GPU training use case.

The ideal choice of number of workers for a dataloader per rank is in the range 0 < num_workers < cpu_count // local_world_size. This PR also ensures we never recommend more workers than visible CPU cores (#15572). 

Fixes #15572
Fixes #2196
