### PR TITLE
Avoid redundant input-type casting in FSDP precision

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -199,6 +199,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed issue where unexpected exceptions would leave the default torch dtype modified when using true precision settings ([#18500](https://github.com/Lightning-AI/lightning/pull/18500))
 
 
+- Fixed redundant input-type casting in FSDP precision ([#18630](https://github.com/Lightning-AI/lightning/pull/18630))
+
+
+
 ## [2.0.9] - 2023-09-14
 
 ### Fixed

--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -202,7 +202,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed redundant input-type casting in FSDP precision ([#18630](https://github.com/Lightning-AI/lightning/pull/18630))
 
 
-
 ## [2.0.9] - 2023-09-14
 
 ### Fixed

--- a/src/lightning/fabric/plugins/precision/fsdp.py
+++ b/src/lightning/fabric/plugins/precision/fsdp.py
@@ -69,8 +69,8 @@ class FSDPPrecision(Precision):
         self.precision = precision
 
         precision_to_type = {
-            "bf16-mixed": torch.bfloat16,
-            "16-mixed": torch.float16,
+            "bf16-mixed": torch.float32,
+            "16-mixed": torch.float32,
             "bf16-true": torch.bfloat16,
             "16-true": torch.float16,
             "32-true": torch.float32,

--- a/src/lightning/fabric/plugins/precision/fsdp.py
+++ b/src/lightning/fabric/plugins/precision/fsdp.py
@@ -111,7 +111,7 @@ class FSDPPrecision(Precision):
 
     def forward_context(self) -> ContextManager:
         if "mixed" in self.precision:
-            return self._autocast_context_manager()
+            return torch.autocast("cuda", dtype=(torch.bfloat16 if self.precision == "bf16-mixed" else torch.float16))
         return _DtypeContextManager(self._desired_input_dtype)
 
     def convert_input(self, data: Any) -> Any:
@@ -153,8 +153,3 @@ class FSDPPrecision(Precision):
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         if self.scaler is not None:
             self.scaler.load_state_dict(state_dict)
-
-    def _autocast_context_manager(self) -> torch.autocast:
-        # the dtype could be automatically inferred but we need to manually set it due to a bug upstream
-        # https://github.com/pytorch/pytorch/issues/67233
-        return torch.autocast("cuda", dtype=self._desired_input_dtype)

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -260,6 +260,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `Trainer.log_dir` not returning the correct directory for the `CSVLogger` ([#18548](https://github.com/Lightning-AI/lightning/pull/18548))
 
 
+- Fixed redundant input-type casting in FSDP precision ([#18630](https://github.com/Lightning-AI/lightning/pull/18630))
+
+
 
 ## [2.0.9] - 2023-09-14
 

--- a/src/lightning/pytorch/plugins/precision/fsdp.py
+++ b/src/lightning/pytorch/plugins/precision/fsdp.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from contextlib import contextmanager
-from typing import Any, Callable, Dict, Generator, Literal, Optional, TYPE_CHECKING, ContextManager
+from typing import Any, Callable, ContextManager, Dict, Generator, Literal, Optional, TYPE_CHECKING
 
 import torch
 from lightning_utilities import apply_to_collection

--- a/src/lightning/pytorch/plugins/precision/fsdp.py
+++ b/src/lightning/pytorch/plugins/precision/fsdp.py
@@ -133,7 +133,7 @@ class FSDPPrecisionPlugin(PrecisionPlugin):
     @contextmanager
     def forward_context(self) -> Generator:
         if "mixed" in self.precision:
-            with self._autocast_context_manager():
+            with torch.autocast("cuda", dtype=(torch.bfloat16 if self.precision == "bf16-mixed" else torch.float16)):
                 yield
         else:
             default_dtype = torch.get_default_dtype()
@@ -190,11 +190,6 @@ class FSDPPrecisionPlugin(PrecisionPlugin):
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         if self.scaler is not None:
             self.scaler.load_state_dict(state_dict)
-
-    def _autocast_context_manager(self) -> torch.autocast:
-        # the dtype could be automatically inferred but we need to manually set it due to a bug upstream
-        # https://github.com/pytorch/pytorch/issues/67233
-        return torch.autocast("cuda", dtype=self._desired_input_dtype)
 
 
 class FSDPMixedPrecisionPlugin(FSDPPrecisionPlugin):

--- a/src/lightning/pytorch/plugins/precision/fsdp.py
+++ b/src/lightning/pytorch/plugins/precision/fsdp.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from contextlib import contextmanager
-from typing import Any, Callable, Dict, Generator, Literal, Optional, TYPE_CHECKING
+from typing import Any, Callable, Dict, Generator, Literal, Optional, TYPE_CHECKING, ContextManager
 
 import torch
 from lightning_utilities import apply_to_collection
@@ -22,7 +22,7 @@ from typing_extensions import get_args
 import lightning.pytorch as pl
 from lightning.fabric.plugins.precision.amp import _optimizer_handles_unscaling
 from lightning.fabric.plugins.precision.fsdp import _PRECISION_INPUT
-from lightning.fabric.plugins.precision.utils import _convert_fp_tensor
+from lightning.fabric.plugins.precision.utils import _convert_fp_tensor, _DtypeContextManager
 from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_1_12, _TORCH_GREATER_EQUAL_2_0
 from lightning.fabric.utilities.rank_zero import rank_zero_deprecation
 from lightning.fabric.utilities.types import Optimizable
@@ -130,18 +130,10 @@ class FSDPPrecisionPlugin(PrecisionPlugin):
         finally:
             torch.set_default_dtype(default_dtype)
 
-    @contextmanager
-    def forward_context(self) -> Generator:
+    def forward_context(self) -> ContextManager:
         if "mixed" in self.precision:
-            with torch.autocast("cuda", dtype=(torch.bfloat16 if self.precision == "bf16-mixed" else torch.float16)):
-                yield
-        else:
-            default_dtype = torch.get_default_dtype()
-            torch.set_default_dtype(self._desired_input_dtype)
-            try:
-                yield
-            finally:
-                torch.set_default_dtype(default_dtype)
+            return torch.autocast("cuda", dtype=(torch.bfloat16 if self.precision == "bf16-mixed" else torch.float16))
+        return _DtypeContextManager(self._desired_input_dtype)
 
     def convert_input(self, data: Any) -> Any:
         return apply_to_collection(data, function=_convert_fp_tensor, dtype=Tensor, dst_type=self._desired_input_dtype)

--- a/src/lightning/pytorch/plugins/precision/fsdp.py
+++ b/src/lightning/pytorch/plugins/precision/fsdp.py
@@ -70,8 +70,8 @@ class FSDPPrecisionPlugin(PrecisionPlugin):
         self.precision = precision
 
         precision_to_type = {
-            "bf16-mixed": torch.bfloat16,
-            "16-mixed": torch.float16,
+            "bf16-mixed": torch.float32,
+            "16-mixed": torch.float32,
             "bf16-true": torch.bfloat16,
             "16-true": torch.float16,
             "32-true": torch.float32,

--- a/tests/tests_fabric/plugins/precision/test_fsdp.py
+++ b/tests/tests_fabric/plugins/precision/test_fsdp.py
@@ -92,22 +92,21 @@ def test_fsdp_precision_forward_context():
     precision = FSDPPrecision(precision="16-true")
     assert precision.scaler is None
     assert torch.get_default_dtype() == torch.float32
-    with precision.forward_context():
-        assert torch.get_autocast_gpu_dtype() == torch.float16
+    with precision.forward_context():  # forward context is not using autocast ctx manager
+        assert torch.get_default_dtype() == torch.float16
 
     precision = FSDPPrecision(precision="bf16-mixed")
     assert precision.scaler is None
     with precision.forward_context():
         assert torch.get_autocast_gpu_dtype() == torch.float32
-
-    precision = FSDPPrecision(precision="bf16-true")
-    assert precision.scaler is None
-    with precision.forward_context():
-        assert torch.get_autocast_gpu_dtype() == torch.bfloat16
-
     context_manager = precision._autocast_context_manager()
     assert isinstance(context_manager, torch.autocast)
     assert context_manager.fast_dtype == torch.bfloat16
+
+    precision = FSDPPrecision(precision="bf16-true")
+    assert precision.scaler is None
+    with precision.forward_context():  # forward context is not using autocast ctx manager
+        assert torch.get_default_dtype() == torch.bfloat16
 
 
 @RunIf(min_torch="1.12")

--- a/tests/tests_fabric/plugins/precision/test_fsdp.py
+++ b/tests/tests_fabric/plugins/precision/test_fsdp.py
@@ -98,7 +98,7 @@ def test_fsdp_precision_forward_context():
     precision = FSDPPrecision(precision="bf16-mixed")
     assert precision.scaler is None
     with precision.forward_context():
-        assert torch.get_autocast_gpu_dtype() == torch.bfloat16
+        assert torch.get_autocast_gpu_dtype() == torch.float32
 
     precision = FSDPPrecision(precision="bf16-true")
     assert precision.scaler is None

--- a/tests/tests_fabric/plugins/precision/test_fsdp.py
+++ b/tests/tests_fabric/plugins/precision/test_fsdp.py
@@ -83,14 +83,14 @@ def test_fsdp_precision_scaler_with_bf16():
 @RunIf(min_torch="1.12", min_cuda_gpus=1)
 def test_fsdp_precision_forward_context():
     """Test to ensure that the context manager correctly is set to bfloat16."""
-    precision = FSDPPrecision(precision="16-mixed")
+    precision = FSDPPrecision(precision="16-true")
     assert isinstance(precision.scaler, torch.cuda.amp.GradScaler)
     assert torch.get_default_dtype() == torch.float32
     with precision.forward_context():
         # check with str due to a bug upstream: https://github.com/pytorch/pytorch/issues/65786
         assert str(torch.get_autocast_gpu_dtype()) in ("torch.float16", "torch.half")
 
-    precision = FSDPPrecision(precision="bf16-mixed")
+    precision = FSDPPrecision(precision="bf16-true")
     assert precision.scaler is None
     with precision.forward_context():
         # check with str due to a bug upstream: https://github.com/pytorch/pytorch/issues/65786

--- a/tests/tests_fabric/plugins/precision/test_fsdp.py
+++ b/tests/tests_fabric/plugins/precision/test_fsdp.py
@@ -83,23 +83,31 @@ def test_fsdp_precision_scaler_with_bf16():
 @RunIf(min_torch="1.12", min_cuda_gpus=1)
 def test_fsdp_precision_forward_context():
     """Test to ensure that the context manager correctly is set to bfloat16."""
-    precision = FSDPPrecision(precision="16-true")
+    precision = FSDPPrecision(precision="16-mixed")
     assert isinstance(precision.scaler, torch.cuda.amp.GradScaler)
     assert torch.get_default_dtype() == torch.float32
     with precision.forward_context():
-        # check with str due to a bug upstream: https://github.com/pytorch/pytorch/issues/65786
-        assert str(torch.get_autocast_gpu_dtype()) in ("torch.float16", "torch.half")
+        assert torch.get_autocast_gpu_dtype() == torch.float32
+
+    precision = FSDPPrecision(precision="16-true")
+    assert precision.scaler is None
+    assert torch.get_default_dtype() == torch.float32
+    with precision.forward_context():
+        assert torch.get_autocast_gpu_dtype() == torch.float16
+
+    precision = FSDPPrecision(precision="bf16-mixed")
+    assert precision.scaler is None
+    with precision.forward_context():
+        assert torch.get_autocast_gpu_dtype() == torch.bfloat16
 
     precision = FSDPPrecision(precision="bf16-true")
     assert precision.scaler is None
     with precision.forward_context():
-        # check with str due to a bug upstream: https://github.com/pytorch/pytorch/issues/65786
-        assert str(torch.get_autocast_gpu_dtype()) == str(torch.bfloat16)
+        assert torch.get_autocast_gpu_dtype() == torch.bfloat16
 
     context_manager = precision._autocast_context_manager()
     assert isinstance(context_manager, torch.autocast)
-    # check with str due to a bug upstream: https://github.com/pytorch/pytorch/issues/65786
-    assert str(context_manager.fast_dtype) == str(torch.bfloat16)
+    assert context_manager.fast_dtype == torch.bfloat16
 
 
 @RunIf(min_torch="1.12")

--- a/tests/tests_fabric/plugins/precision/test_fsdp.py
+++ b/tests/tests_fabric/plugins/precision/test_fsdp.py
@@ -88,7 +88,7 @@ def test_fsdp_precision_forward_context():
     assert isinstance(precision.scaler, torch.cuda.amp.GradScaler)
     assert torch.get_default_dtype() == torch.float32
     with precision.forward_context():
-        assert torch.get_autocast_gpu_dtype() == torch.float32
+        assert torch.get_autocast_gpu_dtype() == torch.float16
     assert isinstance(precision.forward_context(), torch.autocast)
     assert precision.forward_context().fast_dtype == torch.float16
 
@@ -98,12 +98,12 @@ def test_fsdp_precision_forward_context():
     with precision.forward_context():
         assert torch.get_default_dtype() == torch.float16
     assert isinstance(precision.forward_context(), _DtypeContextManager)
-    assert precision.forward_context()._new_type == torch.float16
+    assert precision.forward_context()._new_dtype == torch.float16
 
     precision = FSDPPrecision(precision="bf16-mixed")
     assert precision.scaler is None
     with precision.forward_context():
-        assert torch.get_autocast_gpu_dtype() == torch.float32
+        assert torch.get_autocast_gpu_dtype() == torch.bfloat16
     assert isinstance(precision.forward_context(), torch.autocast)
     assert precision.forward_context().fast_dtype == torch.bfloat16
 
@@ -112,7 +112,7 @@ def test_fsdp_precision_forward_context():
     with precision.forward_context():  # forward context is not using autocast ctx manager
         assert torch.get_default_dtype() == torch.bfloat16
     assert isinstance(precision.forward_context(), _DtypeContextManager)
-    assert precision.forward_context()._new_type == torch.bfloat16
+    assert precision.forward_context()._new_dtype == torch.bfloat16
 
 
 @RunIf(min_torch="1.12")

--- a/tests/tests_pytorch/plugins/precision/test_fsdp.py
+++ b/tests/tests_pytorch/plugins/precision/test_fsdp.py
@@ -98,7 +98,7 @@ def test_fsdp_precision_forward_context():
     precision = FSDPPrecisionPlugin(precision="bf16-mixed")
     assert precision.scaler is None
     with precision.forward_context():
-        assert torch.get_autocast_gpu_dtype() == torch.bfloat16
+        assert torch.get_autocast_gpu_dtype() == torch.float32
 
     precision = FSDPPrecisionPlugin(precision="bf16-true")
     assert precision.scaler is None

--- a/tests/tests_pytorch/plugins/precision/test_fsdp.py
+++ b/tests/tests_pytorch/plugins/precision/test_fsdp.py
@@ -17,6 +17,7 @@ from unittest.mock import ANY, MagicMock, Mock
 import pytest
 import torch
 
+from lightning.fabric.plugins.precision.utils import _DtypeContextManager
 from lightning.pytorch.plugins.precision.fsdp import FSDPPrecisionPlugin
 from tests_pytorch.helpers.runif import RunIf
 
@@ -87,26 +88,31 @@ def test_fsdp_precision_forward_context():
     assert isinstance(precision.scaler, torch.cuda.amp.GradScaler)
     assert torch.get_default_dtype() == torch.float32
     with precision.forward_context():
-        assert torch.get_autocast_gpu_dtype() == torch.float32
+        assert torch.get_autocast_gpu_dtype() == torch.float16
+    assert isinstance(precision.forward_context(), torch.autocast)
+    assert precision.forward_context().fast_dtype == torch.float16
 
     precision = FSDPPrecisionPlugin(precision="16-true")
     assert precision.scaler is None
     assert torch.get_default_dtype() == torch.float32
-    with precision.forward_context():  # forward context is not using autocast ctx manager
+    with precision.forward_context():
         assert torch.get_default_dtype() == torch.float16
+    assert isinstance(precision.forward_context(), _DtypeContextManager)
+    assert precision.forward_context()._new_dtype == torch.float16
 
     precision = FSDPPrecisionPlugin(precision="bf16-mixed")
     assert precision.scaler is None
     with precision.forward_context():
-        assert torch.get_autocast_gpu_dtype() == torch.float32
-    context_manager = precision._autocast_context_manager()
-    assert isinstance(context_manager, torch.autocast)
-    assert context_manager.fast_dtype == torch.bfloat16
+        assert torch.get_autocast_gpu_dtype() == torch.bfloat16
+    assert isinstance(precision.forward_context(), torch.autocast)
+    assert precision.forward_context().fast_dtype == torch.bfloat16
 
     precision = FSDPPrecisionPlugin(precision="bf16-true")
     assert precision.scaler is None
     with precision.forward_context():  # forward context is not using autocast ctx manager
         assert torch.get_default_dtype() == torch.bfloat16
+    assert isinstance(precision.forward_context(), _DtypeContextManager)
+    assert precision.forward_context()._new_dtype == torch.bfloat16
 
 
 @RunIf(min_torch="1.12")

--- a/tests/tests_pytorch/plugins/precision/test_fsdp.py
+++ b/tests/tests_pytorch/plugins/precision/test_fsdp.py
@@ -83,14 +83,14 @@ def test_fsdp_precision_scaler_with_bf16():
 @RunIf(min_torch="1.12", min_cuda_gpus=1)
 def test_fsdp_precision_forward_context():
     """Test to ensure that the context manager correctly is set to bfloat16."""
-    precision = FSDPPrecisionPlugin(precision="16-mixed")
+    precision = FSDPPrecisionPlugin(precision="16-true")
     assert isinstance(precision.scaler, torch.cuda.amp.GradScaler)
     assert torch.get_default_dtype() == torch.float32
     with precision.forward_context():
         # check with str due to a bug upstream: https://github.com/pytorch/pytorch/issues/65786
         assert str(torch.get_autocast_gpu_dtype()) in ("torch.float16", "torch.half")
 
-    precision = FSDPPrecisionPlugin(precision="bf16-mixed")
+    precision = FSDPPrecisionPlugin(precision="bf16-true")
     assert precision.scaler is None
     with precision.forward_context():
         # check with str due to a bug upstream: https://github.com/pytorch/pytorch/issues/65786

--- a/tests/tests_pytorch/plugins/precision/test_fsdp.py
+++ b/tests/tests_pytorch/plugins/precision/test_fsdp.py
@@ -83,23 +83,31 @@ def test_fsdp_precision_scaler_with_bf16():
 @RunIf(min_torch="1.12", min_cuda_gpus=1)
 def test_fsdp_precision_forward_context():
     """Test to ensure that the context manager correctly is set to bfloat16."""
-    precision = FSDPPrecisionPlugin(precision="16-true")
+    precision = FSDPPrecisionPlugin(precision="16-mixed")
     assert isinstance(precision.scaler, torch.cuda.amp.GradScaler)
     assert torch.get_default_dtype() == torch.float32
     with precision.forward_context():
-        # check with str due to a bug upstream: https://github.com/pytorch/pytorch/issues/65786
-        assert str(torch.get_autocast_gpu_dtype()) in ("torch.float16", "torch.half")
+        assert torch.get_autocast_gpu_dtype() == torch.float32
+
+    precision = FSDPPrecisionPlugin(precision="16-true")
+    assert precision.scaler is None
+    assert torch.get_default_dtype() == torch.float32
+    with precision.forward_context():
+        assert torch.get_autocast_gpu_dtype() == torch.float16
+
+    precision = FSDPPrecisionPlugin(precision="bf16-mixed")
+    assert precision.scaler is None
+    with precision.forward_context():
+        assert torch.get_autocast_gpu_dtype() == torch.bfloat16
 
     precision = FSDPPrecisionPlugin(precision="bf16-true")
     assert precision.scaler is None
     with precision.forward_context():
-        # check with str due to a bug upstream: https://github.com/pytorch/pytorch/issues/65786
-        assert str(torch.get_autocast_gpu_dtype()) == str(torch.bfloat16)
+        assert torch.get_autocast_gpu_dtype() == torch.bfloat16
 
     context_manager = precision._autocast_context_manager()
     assert isinstance(context_manager, torch.autocast)
-    # check with str due to a bug upstream: https://github.com/pytorch/pytorch/issues/65786
-    assert str(context_manager.fast_dtype) == str(torch.bfloat16)
+    assert context_manager.fast_dtype == torch.bfloat16
 
 
 @RunIf(min_torch="1.12")

--- a/tests/tests_pytorch/plugins/precision/test_fsdp.py
+++ b/tests/tests_pytorch/plugins/precision/test_fsdp.py
@@ -92,22 +92,21 @@ def test_fsdp_precision_forward_context():
     precision = FSDPPrecisionPlugin(precision="16-true")
     assert precision.scaler is None
     assert torch.get_default_dtype() == torch.float32
-    with precision.forward_context():
-        assert torch.get_autocast_gpu_dtype() == torch.float16
+    with precision.forward_context():  # forward context is not using autocast ctx manager
+        assert torch.get_default_dtype() == torch.float16
 
     precision = FSDPPrecisionPlugin(precision="bf16-mixed")
     assert precision.scaler is None
     with precision.forward_context():
         assert torch.get_autocast_gpu_dtype() == torch.float32
-
-    precision = FSDPPrecisionPlugin(precision="bf16-true")
-    assert precision.scaler is None
-    with precision.forward_context():
-        assert torch.get_autocast_gpu_dtype() == torch.bfloat16
-
     context_manager = precision._autocast_context_manager()
     assert isinstance(context_manager, torch.autocast)
     assert context_manager.fast_dtype == torch.bfloat16
+
+    precision = FSDPPrecisionPlugin(precision="bf16-true")
+    assert precision.scaler is None
+    with precision.forward_context():  # forward context is not using autocast ctx manager
+        assert torch.get_default_dtype() == torch.bfloat16
 
 
 @RunIf(min_torch="1.12")

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -62,16 +62,23 @@ class TestFSDPModel(BoringModel):
         # There is some issue with SGD optimizer state in FSDP
         return torch.optim.AdamW(self.layer.parameters(), lr=0.1)
 
-    def on_train_batch_end(self, *_) -> None:
+    def on_train_batch_start(self, batch, batch_idx):
+        assert batch.dtype == torch.float32
+
+    def on_train_batch_end(self, _, batch, batch_idx):
+        assert batch.dtype == torch.float32
         self._assert_layer_fsdp_instance()
 
-    def on_test_batch_end(self, *_) -> None:
+    def on_test_batch_end(self, _, batch, batch_idx):
+        assert batch.dtype == torch.float32
         self._assert_layer_fsdp_instance()
 
-    def on_validation_batch_end(self, *_) -> None:
+    def on_validation_batch_end(self, _, batch, batch_idx):
+        assert batch.dtype == torch.float32
         self._assert_layer_fsdp_instance()
 
-    def on_predict_batch_end(self, *_) -> None:
+    def on_predict_batch_end(self, _, batch, batch_idx):
+        assert batch.dtype == torch.float32
         self._assert_layer_fsdp_instance()
 
     def _assert_layer_fsdp_instance(self) -> None:
@@ -118,16 +125,23 @@ class TestBoringModel(BoringModel):
 
 
 class TestFSDPModelAutoWrapped(TestBoringModel):
-    def on_train_batch_end(self, *_) -> None:
+    def on_train_batch_start(self, batch, batch_idx):
+        assert batch.dtype == torch.float32
+
+    def on_train_batch_end(self, _, batch, batch_idx):
+        assert batch.dtype == torch.float32
         self._assert_layer_fsdp_instance()
 
-    def on_test_batch_end(self, *_) -> None:
+    def on_test_batch_end(self, _, batch, batch_idx):
+        assert batch.dtype == torch.float32
         self._assert_layer_fsdp_instance()
 
-    def on_validation_batch_end(self, *_) -> None:
+    def on_validation_batch_end(self, _, batch, batch_idx):
+        assert batch.dtype == torch.float32
         self._assert_layer_fsdp_instance()
 
-    def on_predict_batch_end(self, *_) -> None:
+    def on_predict_batch_end(self, _, batch, batch_idx):
+        assert batch.dtype == torch.float32
         self._assert_layer_fsdp_instance()
 
     def _assert_layer_fsdp_instance(self) -> None:


### PR DESCRIPTION
## What does this PR do?

Fixes #18612
This is the 2nd option from https://github.com/Lightning-AI/lightning/issues/18612#issuecomment-1731658655

FSDP converts inputs in its forward to the the param_type.

<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18630.org.readthedocs.build/en/18630/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca @justusschock @awaelchli