### PR TITLE
Remove outdated workaround for PyTorch autocast bug

### DIFF
--- a/src/lightning/pytorch/plugins/precision/amp.py
+++ b/src/lightning/pytorch/plugins/precision/amp.py
@@ -108,9 +108,7 @@ class MixedPrecisionPlugin(PrecisionPlugin):
         super().clip_gradients(optimizer=optimizer, clip_val=clip_val, gradient_clip_algorithm=gradient_clip_algorithm)
 
     def autocast_context_manager(self) -> torch.autocast:
-        # the dtype could be automatically inferred but we need to manually set it due to a bug upstream
-        # https://github.com/pytorch/pytorch/issues/67233
-        return torch.autocast(self.device, dtype=torch.bfloat16 if self.precision == "bf16-mixed" else torch.half)
+        return torch.autocast(self.device, dtype=(torch.bfloat16 if self.precision == "bf16-mixed" else torch.half))
 
     @contextmanager
     def forward_context(self) -> Generator[None, None, None]:

--- a/tests/tests_fabric/plugins/precision/test_amp.py
+++ b/tests/tests_fabric/plugins/precision/test_amp.py
@@ -40,20 +40,17 @@ def test_amp_precision_forward_context():
     assert isinstance(precision.scaler, torch.cuda.amp.GradScaler)
     assert torch.get_default_dtype() == torch.float32
     with precision.forward_context():
-        # check with str due to a bug upstream: https://github.com/pytorch/pytorch/issues/65786
-        assert str(torch.get_autocast_gpu_dtype()) in ("torch.float16", "torch.half")
+        assert torch.get_autocast_gpu_dtype() == torch.float16
 
     precision = MixedPrecision(precision="bf16-mixed", device="cpu")
     assert precision.device == "cpu"
     assert precision.scaler is None
     with precision.forward_context():
-        # check with str due to a bug upstream: https://github.com/pytorch/pytorch/issues/65786
-        assert str(torch.get_autocast_cpu_dtype()) == str(torch.bfloat16)
+        assert torch.get_autocast_cpu_dtype() == torch.bfloat16
 
-    context_manager = precision._autocast_context_manager()
+    context_manager = precision.forward_context()
     assert isinstance(context_manager, torch.autocast)
-    # check with str due to a bug upstream: https://github.com/pytorch/pytorch/issues/65786
-    assert str(context_manager.fast_dtype) == str(torch.bfloat16)
+    assert context_manager.fast_dtype == torch.bfloat16
 
 
 def test_amp_precision_backward():

--- a/tests/tests_pytorch/plugins/test_amp_plugins.py
+++ b/tests/tests_pytorch/plugins/test_amp_plugins.py
@@ -192,8 +192,7 @@ def test_cpu_amp_precision_context_manager():
     assert plugin.scaler is None
     context_manager = plugin.autocast_context_manager()
     assert isinstance(context_manager, torch.autocast)
-    # check with str due to a bug upstream: https://github.com/pytorch/pytorch/issues/65786
-    assert str(context_manager.fast_dtype) == str(torch.bfloat16)
+    assert context_manager.fast_dtype == torch.bfloat16
 
 
 def test_amp_precision_plugin_parameter_validation():


### PR DESCRIPTION
## What does this PR do?

Removes code and comments about about an outdated workaround for using `torch.autocast()`
Found in #18630

