### PR TITLE
Call `wandb.finish` in the `WandbLogger.finalize`

### DIFF
--- a/src/lightning/pytorch/loggers/wandb.py
+++ b/src/lightning/pytorch/loggers/wandb.py
@@ -570,13 +570,15 @@ class WandbLogger(Logger):
     @rank_zero_only
     def finalize(self, status: str) -> None:
         if status != "success":
-            self._experiment.finish()
+            if self._experiment:
+                self._experiment.finish()
             # Currently, checkpoints only get logged on success
             return
         # log checkpoints as artifacts
         if self._checkpoint_callback and self._experiment is not None:
             self._scan_and_log_checkpoints(self._checkpoint_callback)
-        self._experiment.finish()
+        if self._experiment:
+            self._experiment.finish()
 
     def _scan_and_log_checkpoints(self, checkpoint_callback: ModelCheckpoint) -> None:
         import wandb

--- a/src/lightning/pytorch/loggers/wandb.py
+++ b/src/lightning/pytorch/loggers/wandb.py
@@ -570,11 +570,13 @@ class WandbLogger(Logger):
     @rank_zero_only
     def finalize(self, status: str) -> None:
         if status != "success":
+            self._experiment.finish()
             # Currently, checkpoints only get logged on success
             return
         # log checkpoints as artifacts
         if self._checkpoint_callback and self._experiment is not None:
             self._scan_and_log_checkpoints(self._checkpoint_callback)
+        self._experiment.finish()
 
     def _scan_and_log_checkpoints(self, checkpoint_callback: ModelCheckpoint) -> None:
         import wandb


### PR DESCRIPTION
## What does this PR do?

This ensures the logger is ready to create a new run once finalize has been called

Fixes #\<issue_number>

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
  - No
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you verify new and **existing tests pass** locally with your changes?

No to all these
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18659.org.readthedocs.build/en/18659/

<!-- readthedocs-preview pytorch-lightning end -->