### PR TITLE
Forbid non-FSDP precision plugins with FSDP

### DIFF
--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -226,9 +226,17 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
         plugin = self.precision
         if isinstance(plugin, FSDPPrecision):
             return plugin.mixed_precision_config
-        if isinstance(plugin, Precision):
-            raise TypeError(f"The FSDP strategy can only work with the `FSDPPrecision` plugin, found {plugin}")
         return None
+
+    @property
+    def precision(self) -> FSDPPrecision:
+        return self._precision if self._precision is not None else FSDPPrecision("32-true")
+
+    @precision.setter
+    def precision(self, precision: Optional[FSDPPrecision]) -> None:
+        if precision is not None and not isinstance(precision, FSDPPrecision):
+            raise TypeError(f"The FSDP strategy can only work with the `FSDPPrecision` plugin, found {precision}")
+        self._precision = precision
 
     def _configure_launcher(self) -> None:
         assert self.cluster_environment is not None

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -223,8 +223,11 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
     def mixed_precision_config(self) -> Optional["MixedPrecision"]:
         if self.mixed_precision:
             return self.mixed_precision
-        if isinstance(self.precision, FSDPPrecision):
-            return self.precision.mixed_precision_config
+        plugin = self.precision
+        if isinstance(plugin, FSDPPrecision):
+            return plugin.mixed_precision_config
+        if isinstance(plugin, Precision):
+            raise TypeError(f"The FSDP strategy can only work with the `FSDPPrecision` plugin, found {plugin}")
         return None
 
     def _configure_launcher(self) -> None:

--- a/src/lightning/fabric/strategies/fsdp.py
+++ b/src/lightning/fabric/strategies/fsdp.py
@@ -228,9 +228,13 @@ class FSDPStrategy(ParallelStrategy, _Sharded):
             return plugin.mixed_precision_config
         return None
 
-    @property
+    @property  # type: ignore[override]
     def precision(self) -> FSDPPrecision:
-        return self._precision if self._precision is not None else FSDPPrecision("32-true")
+        plugin = self._precision
+        if plugin is not None:
+            assert isinstance(plugin, FSDPPrecision)
+            return plugin
+        return FSDPPrecision("32-true")
 
     @precision.setter
     def precision(self, precision: Optional[FSDPPrecision]) -> None:

--- a/src/lightning/fabric/strategies/strategy.py
+++ b/src/lightning/fabric/strategies/strategy.py
@@ -50,8 +50,9 @@ class Strategy(ABC):
     ) -> None:
         self._accelerator: Optional[Accelerator] = accelerator
         self._checkpoint_io: Optional[CheckpointIO] = checkpoint_io
-        self._precision: Precision
-        self.precision = precision  # Call the precision setter for input validation
+        self._precision: Optional[Precision] = None
+        # Call the precision setter for input validation
+        self.precision = precision  # type: ignore[assignment]
         self._launcher: Optional[_Launcher] = None
         self._backward_sync_control: Optional[_BackwardSyncControl] = None
 

--- a/src/lightning/fabric/strategies/strategy.py
+++ b/src/lightning/fabric/strategies/strategy.py
@@ -50,7 +50,8 @@ class Strategy(ABC):
     ) -> None:
         self._accelerator: Optional[Accelerator] = accelerator
         self._checkpoint_io: Optional[CheckpointIO] = checkpoint_io
-        self._precision: Optional[Precision] = precision
+        self._precision: Precision
+        self.precision = precision  # Call the precision setter for input validation
         self._launcher: Optional[_Launcher] = None
         self._backward_sync_control: Optional[_BackwardSyncControl] = None
 

--- a/src/lightning/pytorch/plugins/precision/fsdp.py
+++ b/src/lightning/pytorch/plugins/precision/fsdp.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Callable, ContextManager, Dict, Literal, Optional
 
 import torch
@@ -116,7 +115,6 @@ class FSDPPrecisionPlugin(PrecisionPlugin):
             buffer_dtype=buffer_dtype,
         )
 
-    @contextmanager
     def init_context(self) -> ContextManager:
         return _DtypeContextManager(self.mixed_precision_config.param_dtype or torch.float32)
 

--- a/src/lightning/pytorch/plugins/precision/fsdp.py
+++ b/src/lightning/pytorch/plugins/precision/fsdp.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Callable, ContextManager, Dict, Generator, Literal, Optional
+from typing import TYPE_CHECKING, Any, Callable, ContextManager, Dict, Literal, Optional
 
 import torch
 from lightning_utilities import apply_to_collection
@@ -117,18 +117,8 @@ class FSDPPrecisionPlugin(PrecisionPlugin):
         )
 
     @contextmanager
-    def init_context(self) -> Generator[None, None, None]:
-        """A context manager to change the default tensor type when initializing module parameters or tensors.
-
-        See: :func:`torch.set_default_dtype`
-
-        """
-        default_dtype = torch.get_default_dtype()
-        torch.set_default_dtype(self.mixed_precision_config.param_dtype or torch.float32)
-        try:
-            yield
-        finally:
-            torch.set_default_dtype(default_dtype)
+    def init_context(self) -> ContextManager:
+        return _DtypeContextManager(self.mixed_precision_config.param_dtype or torch.float32)
 
     def forward_context(self) -> ContextManager:
         if "mixed" in self.precision:

--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -214,14 +214,16 @@ class FSDPStrategy(ParallelStrategy):
         return None
 
     @property
-    def precision(self) -> FSDPPrecisionPlugin:
-        return self._precision if self._precision is not None else FSDPPrecisionPlugin("32-true")
+    def precision_plugin(self) -> FSDPPrecisionPlugin:
+        return self._precision_plugin if self._precision_plugin is not None else FSDPPrecisionPlugin("32-true")
 
-    @precision.setter
-    def precision(self, precision: Optional[FSDPPrecisionPlugin]) -> None:
-        if precision is not None and not isinstance(precision, FSDPPrecisionPlugin):
-            raise TypeError(f"The FSDP strategy can only work with the `FSDPPrecisionPlugin` plugin, found {precision}")
-        self._precision = precision
+    @precision_plugin.setter
+    def precision_plugin(self, precision_plugin: Optional[FSDPPrecisionPlugin]) -> None:
+        if precision_plugin is not None and not isinstance(precision_plugin, FSDPPrecisionPlugin):
+            raise TypeError(
+                f"The FSDP strategy can only work with the `FSDPPrecisionPlugin` plugin, found {precision_plugin}"
+            )
+        self._precision_plugin = precision_plugin
 
     @property
     def distributed_sampler_kwargs(self) -> Dict:

--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -213,9 +213,13 @@ class FSDPStrategy(ParallelStrategy):
             return plugin.mixed_precision_config
         return None
 
-    @property
+    @property  # type: ignore[override]
     def precision_plugin(self) -> FSDPPrecisionPlugin:
-        return self._precision_plugin if self._precision_plugin is not None else FSDPPrecisionPlugin("32-true")
+        plugin = self._precision_plugin
+        if plugin is not None:
+            assert isinstance(plugin, FSDPPrecisionPlugin)
+            return plugin
+        return FSDPPrecisionPlugin("32-true")
 
     @precision_plugin.setter
     def precision_plugin(self, precision_plugin: Optional[FSDPPrecisionPlugin]) -> None:

--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -211,6 +211,8 @@ class FSDPStrategy(ParallelStrategy):
         plugin = self.precision_plugin
         if isinstance(plugin, FSDPPrecisionPlugin):
             return plugin.mixed_precision_config
+        if isinstance(plugin, PrecisionPlugin):
+            raise TypeError(f"The FSDP strategy can only work with the `FSDPPrecisionPlugin` plugin, found {plugin}")
         return None
 
     @property

--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -211,9 +211,17 @@ class FSDPStrategy(ParallelStrategy):
         plugin = self.precision_plugin
         if isinstance(plugin, FSDPPrecisionPlugin):
             return plugin.mixed_precision_config
-        if isinstance(plugin, PrecisionPlugin):
-            raise TypeError(f"The FSDP strategy can only work with the `FSDPPrecisionPlugin` plugin, found {plugin}")
         return None
+
+    @property
+    def precision(self) -> FSDPPrecisionPlugin:
+        return self._precision if self._precision is not None else FSDPPrecisionPlugin("32-true")
+
+    @precision.setter
+    def precision(self, precision: Optional[FSDPPrecisionPlugin]) -> None:
+        if precision is not None and not isinstance(precision, FSDPPrecisionPlugin):
+            raise TypeError(f"The FSDP strategy can only work with the `FSDPPrecisionPlugin` plugin, found {precision}")
+        self._precision = precision
 
     @property
     def distributed_sampler_kwargs(self) -> Dict:

--- a/src/lightning/pytorch/strategies/strategy.py
+++ b/src/lightning/pytorch/strategies/strategy.py
@@ -55,8 +55,9 @@ class Strategy(ABC):
     ) -> None:
         self._accelerator: Optional["pl.accelerators.Accelerator"] = accelerator
         self._checkpoint_io: Optional[CheckpointIO] = checkpoint_io
-        self._precision_plugin: PrecisionPlugin
-        self.precision_plugin = precision_plugin  # Call the precision setter for input validation
+        self._precision_plugin: Optional[PrecisionPlugin] = None
+        # Call the precision setter for input validation
+        self.precision_plugin = precision_plugin  # type: ignore[assignment]
         self._lightning_module: Optional[pl.LightningModule] = None
         self._model: Optional[Module] = None
         self._launcher: Optional[_Launcher] = None

--- a/src/lightning/pytorch/strategies/strategy.py
+++ b/src/lightning/pytorch/strategies/strategy.py
@@ -55,7 +55,8 @@ class Strategy(ABC):
     ) -> None:
         self._accelerator: Optional["pl.accelerators.Accelerator"] = accelerator
         self._checkpoint_io: Optional[CheckpointIO] = checkpoint_io
-        self._precision_plugin: Optional[PrecisionPlugin] = precision_plugin
+        self._precision_plugin: PrecisionPlugin
+        self.precision_plugin = precision_plugin  # Call the precision setter for input validation
         self._lightning_module: Optional[pl.LightningModule] = None
         self._model: Optional[Module] = None
         self._launcher: Optional[_Launcher] = None

--- a/tests/tests_fabric/strategies/test_fsdp.py
+++ b/tests/tests_fabric/strategies/test_fsdp.py
@@ -24,6 +24,7 @@ import pytest
 import torch
 import torch.nn as nn
 from lightning.fabric import Fabric
+from lightning.fabric.plugins import HalfPrecision
 from lightning.fabric.plugins.environments import LightningEnvironment
 from lightning.fabric.strategies import FSDPStrategy
 from lightning.fabric.strategies.fsdp import (
@@ -234,7 +235,7 @@ def test_fsdp_activation_checkpointing():
     apply_mock.assert_called_with(wrapped, checkpoint_wrapper_fn=ANY, **strategy._activation_checkpointing_kwargs)
 
 
-@RunIf(min_torch="1.13")
+@RunIf(min_torch="1.12")
 def test_fsdp_grad_clipping_value_error():
     strategy = FSDPStrategy()
     with pytest.raises(
@@ -245,6 +246,16 @@ def test_fsdp_grad_clipping_value_error():
         ),
     ):
         strategy.clip_gradients_value(Mock(), Mock(), Mock())
+
+
+@RunIf(min_torch="1.13")
+def test_fsdp_forbidden_precision_raises():
+    with pytest.raises(TypeError, match="can only work with the `FSDPPrecision"):
+        FSDPStrategy(precision=HalfPrecision())
+
+    strategy = FSDPStrategy()
+    with pytest.raises(TypeError, match="can only work with the `FSDPPrecision"):
+        strategy.precision = HalfPrecision()
 
 
 @RunIf(min_torch="1.13")

--- a/tests/tests_fabric/strategies/test_fsdp.py
+++ b/tests/tests_fabric/strategies/test_fsdp.py
@@ -235,7 +235,7 @@ def test_fsdp_activation_checkpointing():
     apply_mock.assert_called_with(wrapped, checkpoint_wrapper_fn=ANY, **strategy._activation_checkpointing_kwargs)
 
 
-@RunIf(min_torch="1.12")
+@RunIf(min_torch="1.13")
 def test_fsdp_grad_clipping_value_error():
     strategy = FSDPStrategy()
     with pytest.raises(

--- a/tests/tests_pytorch/strategies/test_fsdp.py
+++ b/tests/tests_pytorch/strategies/test_fsdp.py
@@ -21,6 +21,7 @@ from lightning.fabric.utilities.imports import (
 from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks import ModelCheckpoint
 from lightning.pytorch.demos.boring_classes import BoringModel
+from lightning.pytorch.plugins import HalfPrecisionPlugin
 from lightning.pytorch.plugins.precision.fsdp import FSDPPrecisionPlugin
 from lightning.pytorch.strategies import FSDPStrategy
 from lightning.pytorch.trainer.states import TrainerFn
@@ -401,6 +402,16 @@ def test_fsdp_activation_checkpointing_support():
     """Test that we error out if activation checkpointing requires a newer PyTorch version."""
     with pytest.raises(ValueError, match="activation_checkpointing` requires torch >= 1.13.0"):
         FSDPStrategy(activation_checkpointing=Mock())
+
+
+@RunIf(min_torch="1.12")
+def test_fsdp_forbidden_precision_raises():
+    with pytest.raises(TypeError, match="can only work with the `FSDPPrecision"):
+        FSDPStrategy(precision_plugin=HalfPrecisionPlugin())
+
+    strategy = FSDPStrategy()
+    with pytest.raises(TypeError, match="can only work with the `FSDPPrecision"):
+        strategy.precision_plugin = HalfPrecisionPlugin()
 
 
 @RunIf(min_torch="1.13")


### PR DESCRIPTION
## What does this PR do?

Avoid silent bugs where the user thinks a precision plugin is enabled with the FSDP strategy, when it's not (for example with #18655)



<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18664.org.readthedocs.build/en/18664/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca @justusschock @awaelchli