### PR TITLE
docs: switch HTTPerror to custom runtime error

### DIFF
--- a/.actions/assistant.py
+++ b/.actions/assistant.py
@@ -453,7 +453,7 @@ class AssistantCLI:
             try:
                 urllib.request.urlretrieve(zip_url, zip_file)
             except urllib.error.HTTPError:
-                raise urllib.error.HTTPError(f"Requesting file '{zip_url}' does not exist or it is just unavailable.")
+                raise RuntimeError(f"Requesting file '{zip_url}' does not exist or it is just unavailable.")
 
             with zipfile.ZipFile(zip_file, "r") as zip_ref:
                 zip_ref.extractall(tmp)

--- a/docs/source-pytorch/conf.py
+++ b/docs/source-pytorch/conf.py
@@ -100,7 +100,7 @@ assist_local.AssistantCLI.pull_docs_files(
     target_dir="docs/source-pytorch/integrations/hpu",
     # todo: update after release
     # checkout="tags/1.0.0",
-    checkout="tags/1.1.0.dev",
+    checkout="tags/1.1.0",
 )
 
 if not _FAST_DOCS_DEV:


### PR DESCRIPTION
## What does this PR do?

the `HTTPerror` was not the best with the need to many params
see: https://github.com/Lightning-AI/lightning/actions/runs/6342374434/job/17227968190?pr=18655#step:9:93

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18666.org.readthedocs.build/en/18666/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca @tchaton