### PR TITLE
Add recommendation for matmul precision in docs

### DIFF
--- a/docs/source-pytorch/advanced/speed.rst
+++ b/docs/source-pytorch/advanced/speed.rst
@@ -109,6 +109,25 @@ If you use a large number of ``num_workers`` in your dataloaders or your epochs 
 In this case, setting ``persistent_workers=True`` in your dataloader will significantly speed up the worker startup time across epochs.
 
 
+Low-precision Matrix Multiplication
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+GPUs of the generation Ampere or later (A100, H100, etc.) support `low-precision matrix multiplication <https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision>`_ to trade-off precision for performance:
+
+.. code-block:: python
+
+    # Default used by PyTorch
+    torch.set_float32_matmul_precision("highest")
+
+    # Faster, but less precise
+    torch.set_float32_matmul_precision("high")
+
+    # Fastest, but imprecise
+    torch.set_float32_matmul_precision("medium")
+
+It makes sense to lower the precision only in applications where the loss of precision has a negligible impact on your model's performance.
+
+
 TPU Training
 ============
 

--- a/docs/source-pytorch/advanced/speed.rst
+++ b/docs/source-pytorch/advanced/speed.rst
@@ -122,7 +122,7 @@ GPUs of the generation Ampere or later (A100, H100, etc.) support `low-precision
     # Faster, but less precise
     torch.set_float32_matmul_precision("high")
 
-    # Fastest, but imprecise
+    # Even faster, but also less precise
     torch.set_float32_matmul_precision("medium")
 
 It makes sense to lower the precision only in applications where the loss of precision has a negligible impact on your model's performance.

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -1251,7 +1251,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - When training with `precision=16` on IPU, the cast has been moved off the IPU onto the host, making the copies from host to IPU cheaper ([#13880](https://github.com/Lightning-AI/lightning/pull/13880))
 - Fixed error handling in learning rate finder when not enough data points are available to give a good suggestion ([#13845](https://github.com/Lightning-AI/lightning/pull/13845))
 - Fixed an issue that caused the learning rate finder to set the model's learning rate to None when no suggestion was possible ([#13845](https://github.com/Lightning-AI/lightning/pull/13845))
-- Fixed an issue causing deterministic algorighms and other globals to get reset in spawned processes ([#13921](https://github.com/Lightning-AI/lightning/pull/13921))
+- Fixed an issue causing deterministic algorithms and other globals to get reset in spawned processes ([#13921](https://github.com/Lightning-AI/lightning/pull/13921))
 - Fixed default `amp_level` for `DeepSpeedPrecisionPlugin` to `O2` ([#13897](https://github.com/Lightning-AI/lightning/pull/13897))
 - Fixed Python 3.10 compatibility for truncated back-propagation through time (TBPTT) ([#13973](https://github.com/Lightning-AI/lightning/pull/13973))
 - Fixed `TQDMProgressBar` reset and update to show correct time estimation (2/2) ([#13962](https://github.com/Lightning-AI/lightning/pull/13962))


### PR DESCRIPTION
## What does this PR do?

Fixes #18665

Note: We already have an info message for the Trainer and Fabric, so the user doesn't need to go to the docs to be informed about this necessarily. 


<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18689.org.readthedocs.build/en/18689/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda