### PR TITLE
Fix BNB int8-training support

### DIFF
--- a/src/lightning/fabric/plugins/precision/bitsandbytes.py
+++ b/src/lightning/fabric/plugins/precision/bitsandbytes.py
@@ -191,10 +191,10 @@ def _import_bitsandbytes() -> ModuleType:
 
         def _quantize_weight(self, weight: torch.Tensor) -> None:
             # https://github.com/TimDettmers/bitsandbytes/blob/0.41.0/bitsandbytes/nn/modules.py#L291-L302
+            B = weight.contiguous().to(device="cuda", dtype=torch.float16)
             if self.state.has_fp16_weights:
-                self.weight.data = weight.cuda()
+                self.weight.data = B
             else:
-                B = weight.contiguous().half().cuda()
                 CB, CBt, SCB, SCBt, coo_tensorB = bnb.functional.double_quant(B)
                 del CBt
                 del SCBt

--- a/src/lightning/fabric/utilities/load.py
+++ b/src/lightning/fabric/utilities/load.py
@@ -154,8 +154,8 @@ class _NotYetLoadedTensor:
         }:
             return getattr(self.metatensor, name)
 
-        # needed for quantization (see lit-gpt)
-        if name in {"contiguous", "cuda"}:
+        # materializing these is needed for quantization (see lit-gpt)
+        if name in {"contiguous", "cuda", "half"}:
             return getattr(self._load_tensor(), name)
 
         raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")

--- a/src/lightning/fabric/utilities/load.py
+++ b/src/lightning/fabric/utilities/load.py
@@ -10,6 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 import pickle
 import warnings
 from functools import partial
@@ -153,8 +154,8 @@ class _NotYetLoadedTensor:
         }:
             return getattr(self.metatensor, name)
 
-        # Materialization with contiguous is needed for quantization (see lit-gpt)
-        if name in {"contiguous"}:
+        # needed for quantization (see lit-gpt)
+        if name in {"contiguous", "cuda"}:
             return getattr(self._load_tensor(), name)
 
         raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
@@ -193,6 +194,8 @@ class _LazyLoadingUnpickler(pickle.Unpickler):
 def _lazy_load(filename: _PATH) -> Any:
     if not _TORCH_GREATER_EQUAL_2_0:
         raise NotImplementedError("Lazy-loading is only supported with PyTorch >= 2.0.")
+    if not os.path.isfile(filename):
+        raise FileNotFoundError(f"Path {str(filename)!r} does not exist or is not a file.")
     file_reader = torch.PyTorchFileReader(str(filename))
     with BytesIO(file_reader.get_record("data.pkl")) as pkl:
         mup = _LazyLoadingUnpickler(pkl, file_reader)

--- a/tests/tests_fabric/utilities/test_load.py
+++ b/tests/tests_fabric/utilities/test_load.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pytest
 import torch
 import torch.nn as nn
 from lightning.fabric.utilities.load import _lazy_load, _materialize_tensors, _move_state_into, _NotYetLoadedTensor
@@ -74,6 +75,12 @@ def test_lazy_load_mixed_state(tmp_path):
     loaded_checkpoint = _lazy_load(tmp_path / "checkpoint.pt")
     model1.load_state_dict(loaded_checkpoint["model"])
     optim1.load_state_dict(loaded_checkpoint["optimizer"])
+
+
+@RunIf(min_torch="2.0.0")
+def test_lazy_load_raises():
+    with pytest.raises(FileNotFoundError, match="foo' does not exist"):
+        _lazy_load("foo")
 
 
 @RunIf(min_torch="2.0.0")


### PR DESCRIPTION
## What does this PR do?

Supports https://github.com/Lightning-AI/lit-gpt/pull/613 and https://github.com/Lightning-AI/lit-gpt/pull/596

<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18721.org.readthedocs.build/en/18721/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca @justusschock @awaelchli