### PR TITLE
Update migration guide for 2.1

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -299,7 +299,7 @@ and the last true master commit is `ccc111` and your first commit is `mmm222`.
   # when all done, push back to the open PR
   git push -f
   ```
-- **Rebasing way**, see more about [rebase onto usage](https://womanonrails.com/git-rebase-onto)
+- **Rebasing way**, see more about [rebase onto usage](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase)
   ```bash
   git checkout my-branch
   # rebase your commits on the correct branch

--- a/docs/source-pytorch/upgrade/from_2_0.rst
+++ b/docs/source-pytorch/upgrade/from_2_0.rst
@@ -1,0 +1,16 @@
+:orphan:
+
+Regular User
+************
+
+.. include:: sections/2_0_regular.rst
+
+Advanced User
+*************
+
+.. include:: sections/2_0_advanced.rst
+
+Developer
+*********
+
+.. include:: sections/2_0_devel.rst

--- a/docs/source-pytorch/upgrade/migration_guide.rst
+++ b/docs/source-pytorch/upgrade/migration_guide.rst
@@ -1,11 +1,10 @@
-2.0 upgrade guide
+2.0 Upgrade Guide
 #################
 
-The following section will guide you through updating to the 2.0 release.
+The following section will guide you through updating your code to the 2.x series of releases.
 
 Particular versions
 *******************
-
 
 
 .. raw:: html
@@ -14,6 +13,13 @@ Particular versions
         <div class="row">
 
 .. Add callout items below this line
+
+.. displayitem::
+   :header: 2.0.x
+   :description: Upgrade from 2.0.x series to the 2.1.
+   :col_css: col-md-12
+   :button_link: from_2_0.html
+   :height: 100
 
 .. displayitem::
    :header: 1.9.x

--- a/docs/source-pytorch/upgrade/sections/2_0_advanced.rst
+++ b/docs/source-pytorch/upgrade/sections/2_0_advanced.rst
@@ -1,0 +1,35 @@
+.. list-table:: adv. user 2.0
+   :widths: 40 40 20
+   :header-rows: 1
+
+   * - If
+     - Then
+     - Ref
+
+   * - used the ``torchdistx`` package and integration in Trainer
+     - materialize the model weights manually, or follow our guide for initializing large models
+     - `PR17995`_
+
+   * - defined `def training_step(self, dataloader_iter, batch_idx)` in LightningModule
+     - remove `batch_idx` from the signature and expect `dataloader_iter` to return a triplet `(batch, batch_idx, dataloader_idx)`
+     - `PR18390`_
+
+   * - defined `def validation_step(self, dataloader_iter, batch_idx)` in LightningModule
+     - remove `batch_idx` from the signature and expect `dataloader_iter` to return a triplet `(batch, batch_idx, dataloader_idx)`
+     - `PR18390`_
+
+   * - defined `def test_step(self, dataloader_iter, batch_idx)` in LightningModule
+     - remove `batch_idx` from the signature and expect `dataloader_iter` to return a triplet `(batch, batch_idx, dataloader_idx)`
+     - `PR18390`_
+
+   * - defined `def predict_step(self, dataloader_iter, batch_idx)` in LightningModule
+     - remove `batch_idx` from the signature and expect `dataloader_iter` to return a triplet `(batch, batch_idx, dataloader_idx)`
+     - `PR18390`_
+
+   * - used `batch = next(dataloader_iter)` in LightningModule `*_step` hooks
+     - use `batch, batch_idx, dataloader_idx = next(dataloader_iter)`
+     - `PR18390`_
+
+
+.. _pr17995: https://github.com/Lightning-AI/lightning/pull/17995
+.. _pr18390: https://github.com/Lightning-AI/lightning/pull/18390

--- a/docs/source-pytorch/upgrade/sections/2_0_advanced.rst
+++ b/docs/source-pytorch/upgrade/sections/2_0_advanced.rst
@@ -10,24 +10,24 @@
      - materialize the model weights manually, or follow our guide for initializing large models
      - `PR17995`_
 
-   * - defined `def training_step(self, dataloader_iter, batch_idx)` in LightningModule
-     - remove `batch_idx` from the signature and expect `dataloader_iter` to return a triplet `(batch, batch_idx, dataloader_idx)`
+   * - defined ``def training_step(self, dataloader_iter, batch_idx)`` in LightningModule
+     - remove ``batch_idx`` from the signature and expect ``dataloader_iter`` to return a triplet ``(batch, batch_idx, dataloader_idx)``
      - `PR18390`_
 
-   * - defined `def validation_step(self, dataloader_iter, batch_idx)` in LightningModule
-     - remove `batch_idx` from the signature and expect `dataloader_iter` to return a triplet `(batch, batch_idx, dataloader_idx)`
+   * - defined ``def validation_step(self, dataloader_iter, batch_idx)`` in LightningModule
+     - remove ``batch_idx`` from the signature and expect ``dataloader_iter`` to return a triplet ``(batch, batch_idx, dataloader_idx)``
      - `PR18390`_
 
-   * - defined `def test_step(self, dataloader_iter, batch_idx)` in LightningModule
-     - remove `batch_idx` from the signature and expect `dataloader_iter` to return a triplet `(batch, batch_idx, dataloader_idx)`
+   * - defined ``def test_step(self, dataloader_iter, batch_idx)`` in LightningModule
+     - remove ``batch_idx`` from the signature and expect ``dataloader_iter`` to return a triplet ``(batch, batch_idx, dataloader_idx)``
      - `PR18390`_
 
-   * - defined `def predict_step(self, dataloader_iter, batch_idx)` in LightningModule
-     - remove `batch_idx` from the signature and expect `dataloader_iter` to return a triplet `(batch, batch_idx, dataloader_idx)`
+   * - defined ``def predict_step(self, dataloader_iter, batch_idx)`` in LightningModule
+     - remove ``batch_idx`` from the signature and expect ``dataloader_iter`` to return a triplet ``(batch, batch_idx, dataloader_idx)``
      - `PR18390`_
 
-   * - used `batch = next(dataloader_iter)` in LightningModule `*_step` hooks
-     - use `batch, batch_idx, dataloader_idx = next(dataloader_iter)`
+   * - used ``batch = next(dataloader_iter)`` in LightningModule ``*_step`` hooks
+     - use ``batch, batch_idx, dataloader_idx = next(dataloader_iter)``
      - `PR18390`_
 
 

--- a/docs/source-pytorch/upgrade/sections/2_0_advanced.rst
+++ b/docs/source-pytorch/upgrade/sections/2_0_advanced.rst
@@ -30,6 +30,11 @@
      - use ``batch, batch_idx, dataloader_idx = next(dataloader_iter)``
      - `PR18390`_
 
+   * - relied on automatic detection of Kubeflow environment
+     - use ``Trainer(plugins=KubeflowEnvironment())`` to explicitly set it on a Kubeflow cluster
+     - `PR18137`_
+
 
 .. _pr17995: https://github.com/Lightning-AI/lightning/pull/17995
 .. _pr18390: https://github.com/Lightning-AI/lightning/pull/18390
+.. _pr18137: https://github.com/Lightning-AI/lightning/pull/18390

--- a/docs/source-pytorch/upgrade/sections/2_0_advanced.rst
+++ b/docs/source-pytorch/upgrade/sections/2_0_advanced.rst
@@ -7,7 +7,7 @@
      - Ref
 
    * - used the ``torchdistx`` package and integration in Trainer
-     - materialize the model weights manually, or follow our guide for initializing large models
+     - materialize the model weights manually, or follow our :doc:`guide for initializing large models <../../advanced/model_init>`
      - `PR17995`_
 
    * - defined ``def training_step(self, dataloader_iter, batch_idx)`` in LightningModule

--- a/docs/source-pytorch/upgrade/sections/2_0_devel.rst
+++ b/docs/source-pytorch/upgrade/sections/2_0_devel.rst
@@ -6,11 +6,11 @@
      - Then
      - Ref
 
-   * - used the `XLAStrategy.is_distributed` property
+   * - used the ``XLAStrategy.is_distributed`` property
      - it was removed because it was always True
      - `PR17381`_
 
-   * - used the `SingleTPUStrategy.is_distributed` property
+   * - used the ``SingleTPUStrategy.is_distributed`` property
      - it was removed because it was always False
      - `PR17381`_
 

--- a/docs/source-pytorch/upgrade/sections/2_0_devel.rst
+++ b/docs/source-pytorch/upgrade/sections/2_0_devel.rst
@@ -1,0 +1,18 @@
+.. list-table:: devel 2.0
+   :widths: 40 40 20
+   :header-rows: 1
+
+   * - If
+     - Then
+     - Ref
+
+   * - used the `XLAStrategy.is_distributed` property
+     - it was removed because it was always True
+     - `PR17381`_
+
+   * - used the `SingleTPUStrategy.is_distributed` property
+     - it was removed because it was always False
+     - `PR17381`_
+
+
+.. _pr17381: https://github.com/Lightning-AI/lightning/pull/17381

--- a/docs/source-pytorch/upgrade/sections/2_0_regular.rst
+++ b/docs/source-pytorch/upgrade/sections/2_0_regular.rst
@@ -10,39 +10,40 @@
      - upgrade to PyTorch 2.1 or higher
      - `PR18691`_
 
-   * - called `self.trainer.model.parameters()` in `LightningModule.configure_optimizers()` when using FSDP
-     - On PyTorch 2.0+, call `self.parameters()` from now on
+   * - called ``self.trainer.model.parameters()`` in ``LightningModule.configure_optimizers()`` when using FSDP
+     - On PyTorch 2.0+, call ``self.parameters()`` from now on
      - `PR17309`_
 
-   * - used `Trainer(accelerator="tpu", devices=[i])"` to select the 1-based TPU core index
+   * - used ``Trainer(accelerator="tpu", devices=[i])"`` to select the 1-based TPU core index
      - the index is now 0-based
      - `PR17227`_
 
-   * - used `torch_xla < 1.13`
-     - upgrade to `torch_xla >= 1.13`
+   * - used ``torch_xla < 1.13``
+     - upgrade to ``torch_xla >= 1.13``
      - `PR17368`_
 
-   * - used `trainer.num_val_batches` to get the total size of all validation dataloaders
-     - use `sum(trainer.num_val_batches)`
+   * - used ``trainer.num_val_batches`` to get the total size of all validation dataloaders
+     - use ``sum(trainer.num_val_batches)``
      - `PR18441`_
 
-   * - used `trainer.num_test_batches` to get the total size of all test dataloaders
-     - use `sum(trainer.num_test_batches)`
+   * - used ``trainer.num_test_batches`` to get the total size of all test dataloaders
+     - use ``sum(trainer.num_test_batches)``
      - `PR18441`_
 
-   * - used `trainer.num_sanity_val_batches` to get the total size of all validation dataloaders for sanity checking
-     - use `sum(trainer.num_sanity_val_batches)`
+   * - used ``trainer.num_sanity_val_batches`` to get the total size of all validation dataloaders for sanity checking
+     - use ``sum(trainer.num_sanity_val_batches)``
      - `PR18441`_
 
-   * - used `Trainer(devices="auto")` to auto-select all available GPUs in a Jupyter notebook
-     - use `Trainer(devices=-1)`
+   * - used ``Trainer(devices="auto")`` to auto-select all available GPUs in a Jupyter notebook
+     - use ``Trainer(devices=-1)``
      - `PR18291`_
 
-   * - used `Trainer(devices="auto")` to auto-select all available GPUs in a Jupyter notebook
-     - use `Trainer(devices=-1)`
+   * - used ``Trainer(devices="auto")`` to auto-select all available GPUs in a Jupyter notebook
+     - use ``Trainer(devices=-1)``
      - `PR18291`_
 
 
+.. _pr18691: https://github.com/Lightning-AI/lightning/pull/18691
 .. _pr16579: https://github.com/Lightning-AI/lightning/pull/16579
 .. _pr17309: https://github.com/Lightning-AI/lightning/pull/17309
 .. _pr17227: https://github.com/Lightning-AI/lightning/pull/17227

--- a/docs/source-pytorch/upgrade/sections/2_0_regular.rst
+++ b/docs/source-pytorch/upgrade/sections/2_0_regular.rst
@@ -42,6 +42,10 @@
      - use ``Trainer(devices=-1)``
      - `PR18291`_
 
+   * - ``pip install lightning`` to install ``lightning.app`` dependencies
+     - use ``pip install lightning[app]`` if you need ``lightning.app``
+     - `PR18386`_
+
 
 .. _pr18691: https://github.com/Lightning-AI/lightning/pull/18691
 .. _pr16579: https://github.com/Lightning-AI/lightning/pull/16579
@@ -50,3 +54,4 @@
 .. _pr17368: https://github.com/Lightning-AI/lightning/pull/17368
 .. _pr18441: https://github.com/Lightning-AI/lightning/pull/18441
 .. _pr18291: https://github.com/Lightning-AI/lightning/pull/18291
+.. _pr18386: https://github.com/Lightning-AI/lightning/pull/18386

--- a/docs/source-pytorch/upgrade/sections/2_0_regular.rst
+++ b/docs/source-pytorch/upgrade/sections/2_0_regular.rst
@@ -26,11 +26,11 @@
      - use `sum(trainer.num_val_batches)`
      - `PR18441`_
 
-   * - used `trainer.num_test_batches` to get the total size of all validation dataloaders
+   * - used `trainer.num_test_batches` to get the total size of all test dataloaders
      - use `sum(trainer.num_test_batches)`
      - `PR18441`_
 
-   * - used `trainer.num_sanity_val_batches` to get the total size of all validation dataloaders
+   * - used `trainer.num_sanity_val_batches` to get the total size of all validation dataloaders for sanity checking
      - use `sum(trainer.num_sanity_val_batches)`
      - `PR18441`_
 

--- a/docs/source-pytorch/upgrade/sections/2_0_regular.rst
+++ b/docs/source-pytorch/upgrade/sections/2_0_regular.rst
@@ -1,0 +1,51 @@
+.. list-table:: reg. user 2.0
+   :widths: 40 40 20
+   :header-rows: 1
+
+   * - If
+     - Then
+     - Ref
+
+   * - used PyTorch 3.11
+     - upgrade to PyTorch 2.1 or higher
+     - `PR18691`_
+
+   * - called `self.trainer.model.parameters()` in `LightningModule.configure_optimizers()` when using FSDP
+     - On PyTorch 2.0+, call `self.parameters()` from now on
+     - `PR17309`_
+
+   * - used `Trainer(accelerator="tpu", devices=[i])"` to select the 1-based TPU core index
+     - the index is now 0-based
+     - `PR17227`_
+
+   * - used `torch_xla < 1.13`
+     - upgrade to `torch_xla >= 1.13`
+     - `PR17368`_
+
+   * - used `trainer.num_val_batches` to get the total size of all validation dataloaders
+     - use `sum(trainer.num_val_batches)`
+     - `PR18441`_
+
+   * - used `trainer.num_test_batches` to get the total size of all validation dataloaders
+     - use `sum(trainer.num_test_batches)`
+     - `PR18441`_
+
+   * - used `trainer.num_sanity_val_batches` to get the total size of all validation dataloaders
+     - use `sum(trainer.num_sanity_val_batches)`
+     - `PR18441`_
+
+   * - used `Trainer(devices="auto")` to auto-select all available GPUs in a Jupyter notebook
+     - use `Trainer(devices=-1)`
+     - `PR18291`_
+
+   * - used `Trainer(devices="auto")` to auto-select all available GPUs in a Jupyter notebook
+     - use `Trainer(devices=-1)`
+     - `PR18291`_
+
+
+.. _pr16579: https://github.com/Lightning-AI/lightning/pull/16579
+.. _pr17309: https://github.com/Lightning-AI/lightning/pull/17309
+.. _pr17227: https://github.com/Lightning-AI/lightning/pull/17227
+.. _pr17368: https://github.com/Lightning-AI/lightning/pull/17368
+.. _pr18441: https://github.com/Lightning-AI/lightning/pull/18441
+.. _pr18291: https://github.com/Lightning-AI/lightning/pull/18291


### PR DESCRIPTION
## What does this PR do?

Updates the migration guide for the few removals and changes in the 2.1 release.
API changes only occur for features dedicated to advanced uses (dataloader_iter) or ones that are marked experimental. 

<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18729.org.readthedocs.build/en/18729/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca