### PR TITLE
Fix display of navigation tiles in Fabric docs

### DIFF
--- a/docs/source-fabric/examples/index.rst
+++ b/docs/source-fabric/examples/index.rst
@@ -53,6 +53,7 @@ Examples
     :button_link: https://github.com/Lightning-AI/lightning/blob/master/examples/fabric/reinforcement_learning
     :col_css: col-md-4
     :height: 150
+    :tag: intermediate
 
 .. displayitem::
     :header: K-Fold Cross Validation
@@ -60,12 +61,14 @@ Examples
     :button_link: https://github.com/Lightning-AI/lightning/tree/master/examples/fabric/kfold_cv
     :col_css: col-md-4
     :height: 150
+    :tag: intermediate
 
 .. displayitem::
     :header: Active Learning
     :description: Coming soon
     :col_css: col-md-4
     :height: 150
+    :tag: intermediate
 
 
 .. raw:: html

--- a/docs/source-fabric/index.rst
+++ b/docs/source-fabric/index.rst
@@ -110,7 +110,7 @@ Get Started
 
 .. raw:: html
 
-    <div class="tutorials-callout-container">
+    <div class="display-card-container">
         <div class="row">
 
 .. Add callout items below this line
@@ -170,6 +170,8 @@ Get Started
 
 .. End of callout item section
 
+|
+|
 
 .. raw:: html
 


### PR DESCRIPTION
## What does this PR do?

Fixes a display issue in the tiles on the main page:

Before:
<img width="1458" alt="image" src="https://github.com/Lightning-AI/lightning/assets/5495193/e8a4ec48-95e9-4efb-b257-64810e66fcd3">

After:
<img width="1458" alt="image" src="https://github.com/Lightning-AI/lightning/assets/5495193/1bb42308-87a4-461e-9b60-90d959c6af6a">




cc @borda