### PR TITLE
Fixes in evaluation_basic.rst

### DIFF
--- a/docs/source-pytorch/common/evaluation_basic.rst
+++ b/docs/source-pytorch/common/evaluation_basic.rst
@@ -124,7 +124,8 @@ To run the validation loop, pass in the validation set to **.fit**
 
    train_loader = DataLoader(train_set)
    valid_loader = DataLoader(valid_set)
+   model = LitAutoEncoder(...)
 
    # train with both splits
-   trainer = Trainer()
+   trainer = pl.Trainer()
    trainer.fit(model, train_loader, valid_loader)


### PR DESCRIPTION
## What does this PR do?

Adds documentation fixes. The same doc used `pl.LightningModule` but was missing the `pl.` for the `Trainer`.
