### PR TITLE
Change dangerous default random seed selection

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Calling a method other than `forward` that invokes submodules is now an error when the model is wrapped (e.g., with DDP) ([#18819](https://github.com/Lightning-AI/lightning/pull/18819))
 
 
+- `seed_everything()` without passing in a seed no longer randomly selects a seed, and now defaults to `0` ([#18846](https://github.com/Lightning-AI/lightning/pull/18846))
+
 
 ### Deprecated
 

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
--
+- `seed_everything()` without passing in a seed no longer randomly selects a seed, and now defaults to `0` ([#18846](https://github.com/Lightning-AI/lightning/pull/18846))
 
 
 ### Deprecated


### PR DESCRIPTION
## What does this PR do?

The `seed_everything` function can be called without arguments. In this case, it will take the seed value from the environment variable `PL_GLOBAL_SEED`. But if the environment variable is not set, it falls back to selecting the seed randomly. This isn't usually a problem if Lightning is in control of launching the processes, because child processes will inherit the seed value from the environment variable. However, in cases where processes are launched externally (e.g. SLURM, torchelastic etc.), this default behavior is dangerous because each process will independently choose a random seed. This can affect sampling, randomized validation splits, and other behaviors that rely on each process having the same seed. 

This PR removes this random behavior and makes it so that the `seed_everything` falls back to setting a fixed seed 0. This change only affects users who have intentionally called `seed_everything` with no arguments, and those who use `seed_everything=True` in LightningCLI. Those uses will now have to select the number randomly first, and then pass it in to `seed_everything`, unless they are happy with the new default of 0. 


Fixes #18638
(to be confirmed)


<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18846.org.readthedocs.build/en/18846/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca @justusschock @awaelchli