### PR TITLE
Install both `lightning` and `pytorch-lightning` in docker image

### DIFF
--- a/dockers/release/Dockerfile
+++ b/dockers/release/Dockerfile
@@ -40,8 +40,8 @@ RUN \
     # otherwise there is collision with folder name and pkg name on Pypi
     cd lightning && \
     pip install setuptools==59.5.0 && \
-    PACKAGE_NAME=pytorch pip install '.[extra,loggers,strategies]' --no-cache-dir && \
     PACKAGE_NAME=lightning pip install '.[extra,loggers,strategies]' --no-cache-dir && \
+    PACKAGE_NAME=pytorch pip install '.[extra,loggers,strategies]' --no-cache-dir && \
     cd .. && \
     rm -rf lightning
 

--- a/dockers/release/Dockerfile
+++ b/dockers/release/Dockerfile
@@ -36,10 +36,8 @@ RUN \
         unzip ${LIGHTNING_VERSION}.zip ; \
         mv lightning-*/ lightning ; \
         rm *.zip ; \
-    fi
+    fi && \
     # otherwise there is collision with folder name and pkg name on Pypi
-
-RUN \
     cd lightning && \
     pip install setuptools==59.5.0 && \
     PACKAGE_NAME=pytorch pip install '.[extra,loggers,strategies]' --no-cache-dir && \

--- a/dockers/release/Dockerfile
+++ b/dockers/release/Dockerfile
@@ -24,8 +24,6 @@ ARG LIGHTNING_VERSION=""
 
 COPY ./ /home/lightning/
 
-ENV PACKAGE_NAME=pytorch
-
 # install dependencies
 RUN \
     cd /home && \
@@ -38,11 +36,14 @@ RUN \
         unzip ${LIGHTNING_VERSION}.zip ; \
         mv lightning-*/ lightning ; \
         rm *.zip ; \
-    fi && \
+    fi
     # otherwise there is collision with folder name and pkg name on Pypi
+
+RUN \
     cd lightning && \
     pip install setuptools==59.5.0 && \
-    pip install '.[extra,loggers,strategies]' --no-cache-dir && \
+    PACKAGE_NAME=pytorch pip install '.[extra,loggers,strategies]' --no-cache-dir && \
+    PACKAGE_NAME=lightning pip install '.[extra,loggers,strategies]' --no-cache-dir && \
     cd .. && \
     rm -rf lightning
 


### PR DESCRIPTION
## What does this PR do?

Fixes #18890

Makes both packages available in our released docker image.


<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18898.org.readthedocs.build/en/18898/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda