### PR TITLE
Update CLI tests to no longer require 3rd party logger dependencies

### DIFF
--- a/src/lightning/pytorch/trainer/trainer.py
+++ b/src/lightning/pytorch/trainer/trainer.py
@@ -300,7 +300,6 @@ class Trainer:
 
             MisconfigurationException:
                 If ``gradient_clip_algorithm`` is invalid.
-                If ``track_grad_norm`` is not a positive number or inf.
 
         """
         super().__init__()

--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -1471,8 +1471,11 @@ def test_neptune_logger_init_args():
 def test_tensorboard_logger_init_args():
     _test_logger_init_args(
         "TensorBoardLogger",
-        init={"save_dir": "tb"},  # Resolve from TensorBoardLogger.__init__
-        unresolved={"comment": "tb"},  # Resolve from FabricTensorBoardLogger.experiment SummaryWriter local import
+        init={
+            "save_dir": "tb",   # Resolve from TensorBoardLogger.__init
+            "comment": "tb"  # Resolve from FabricTensorBoardLogger.experiment SummaryWriter local import
+        },
+        unresolved={},
     )
 
 

--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -1471,7 +1471,7 @@ def test_tensorboard_logger_init_args():
     _test_logger_init_args(
         "TensorBoardLogger",
         init={
-            "save_dir": "tb",  # Resolve from TensorBoardLogger.__init
+            "save_dir": "tb",  # Resolve from TensorBoardLogger.__init__
             "comment": "tb",  # Resolve from FabricTensorBoardLogger.experiment SummaryWriter local import
         },
         unresolved={},

--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -1471,8 +1471,8 @@ def test_tensorboard_logger_init_args():
     _test_logger_init_args(
         "TensorBoardLogger",
         init={
-            "save_dir": "tb",   # Resolve from TensorBoardLogger.__init
-            "comment": "tb"  # Resolve from FabricTensorBoardLogger.experiment SummaryWriter local import
+            "save_dir": "tb",  # Resolve from TensorBoardLogger.__init
+            "comment": "tb",  # Resolve from FabricTensorBoardLogger.experiment SummaryWriter local import
         },
         unresolved={},
     )


### PR DESCRIPTION
## What does this PR do?

Fixes #18823


<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18899.org.readthedocs.build/en/18899/

<!-- readthedocs-preview pytorch-lightning end -->

cc @carmocca @mauvilsa @borda