### PR TITLE
Add batches argument to throughput

### DIFF
--- a/src/lightning/fabric/utilities/throughput.py
+++ b/src/lightning/fabric/utilities/throughput.py
@@ -132,6 +132,8 @@ class Throughput:
 
         """
         self._time.append(time)
+        if samples < batches:
+            raise ValueError(f"Expected samples ({samples}) to be greater or equal than batches ({batches})")
         self._batches.append(batches)
         self._samples.append(samples)
         if lengths is not None:

--- a/src/lightning/fabric/utilities/throughput.py
+++ b/src/lightning/fabric/utilities/throughput.py
@@ -125,7 +125,7 @@ class Throughput:
                 call.
             batches: Total batches seen per device. It should monotonically increase with each call.
             samples: Total samples seen per device. It should monotonically increase by the batch size with each call.
-            lengths: Total length of the samples seen. It should monotonically increase by the length of a batch with
+            lengths: Total length of the samples seen. It should monotonically increase by the lengths of a batch with
                 each call.
             flops_per_batch: Flops per batch per device. You can easily compute this by using :func:`measure_flops`.
                 The value might be different in each device if the batch size is not the same.
@@ -135,6 +135,8 @@ class Throughput:
         self._batches.append(batches)
         self._samples.append(samples)
         if lengths is not None:
+            if lengths < samples:
+                raise ValueError(f"Expected lengths ({lengths}) to be greater or equal than samples ({samples})")
             self._lengths.append(lengths)
             if len(self._samples) != len(self._lengths):
                 raise RuntimeError(

--- a/src/lightning/pytorch/callbacks/throughput_monitor.py
+++ b/src/lightning/pytorch/callbacks/throughput_monitor.py
@@ -145,10 +145,11 @@ class ThroughputMonitor(Callback):
         batch_size = self.batch_size_fn(batch)
         throughput.update(
             time=elapsed,
+            batches=iter_num,
             # this assumes that all iterations used the same batch size
             samples=iter_num * batch_size,
-            flops_per_batch=flops_per_batch,
             lengths=None if self.length_fn is None else self._lengths[stage],
+            flops_per_batch=flops_per_batch,
         )
 
     def _compute(self, trainer: "Trainer", iter_num: Optional[int] = None) -> None:

--- a/tests/tests_fabric/utilities/test_throughput.py
+++ b/tests/tests_fabric/utilities/test_throughput.py
@@ -129,7 +129,7 @@ def mock_train_loop(monitor):
     for iter_num in range(1, 6):
         # forward + backward + step + zero_grad ...
         t1 = iter_num + 0.5
-        total_lengths += 2
+        total_lengths += 3 * 2
         monitor.update(
             time=t1 - total_t0,
             batches=iter_num,
@@ -147,18 +147,18 @@ def test_throughput_monitor():
         monitor = ThroughputMonitor(fabric, window_size=4, separator="|")
     mock_train_loop(monitor)
     assert logger_mock.log_metrics.mock_calls == [
-        call(metrics={"time": 1.5, "batches": 1, "samples": 3, "lengths": 2}, step=0),
-        call(metrics={"time": 2.5, "batches": 2, "samples": 6, "lengths": 4}, step=1),
-        call(metrics={"time": 3.5, "batches": 3, "samples": 9, "lengths": 6}, step=2),
+        call(metrics={"time": 1.5, "batches": 1, "samples": 3, "lengths": 6}, step=0),
+        call(metrics={"time": 2.5, "batches": 2, "samples": 6, "lengths": 12}, step=1),
+        call(metrics={"time": 3.5, "batches": 3, "samples": 9, "lengths": 18}, step=2),
         call(
             metrics={
                 "time": 4.5,
                 "batches": 4,
                 "samples": 12,
-                "lengths": 8,
+                "lengths": 24,
                 "device|batches_per_sec": 1.0,
                 "device|samples_per_sec": 3.0,
-                "device|items_per_sec": 6.0,
+                "device|items_per_sec": 18.0,
                 "device|flops_per_sec": 10.0,
                 "device|mfu": 0.1,
             },
@@ -169,10 +169,10 @@ def test_throughput_monitor():
                 "time": 5.5,
                 "batches": 5,
                 "samples": 15,
-                "lengths": 10,
+                "lengths": 30,
                 "device|batches_per_sec": 1.0,
                 "device|samples_per_sec": 3.0,
-                "device|items_per_sec": 6.0,
+                "device|items_per_sec": 18.0,
                 "device|flops_per_sec": 10.0,
                 "device|mfu": 0.1,
             },
@@ -214,21 +214,21 @@ def test_throughput_monitor_world_size():
         monitor.world_size = 2
     mock_train_loop(monitor)
     assert logger_mock.log_metrics.mock_calls == [
-        call(metrics={"time": 1.5, "batches": 1, "samples": 3, "lengths": 2}, step=0),
-        call(metrics={"time": 2.5, "batches": 2, "samples": 6, "lengths": 4}, step=1),
-        call(metrics={"time": 3.5, "batches": 3, "samples": 9, "lengths": 6}, step=2),
+        call(metrics={"time": 1.5, "batches": 1, "samples": 3, "lengths": 6}, step=0),
+        call(metrics={"time": 2.5, "batches": 2, "samples": 6, "lengths": 12}, step=1),
+        call(metrics={"time": 3.5, "batches": 3, "samples": 9, "lengths": 18}, step=2),
         call(
             metrics={
                 "time": 4.5,
                 "batches": 4,
                 "samples": 12,
-                "lengths": 8,
+                "lengths": 24,
                 "device/batches_per_sec": 1.0,
                 "device/samples_per_sec": 3.0,
                 "batches_per_sec": 2.0,
                 "samples_per_sec": 6.0,
-                "items_per_sec": 4.0,
-                "device/items_per_sec": 6.0,
+                "items_per_sec": 12.0,
+                "device/items_per_sec": 18.0,
                 "flops_per_sec": 20.0,
                 "device/flops_per_sec": 10.0,
                 "device/mfu": 0.1,
@@ -240,13 +240,13 @@ def test_throughput_monitor_world_size():
                 "time": 5.5,
                 "batches": 5,
                 "samples": 15,
-                "lengths": 10,
+                "lengths": 30,
                 "device/batches_per_sec": 1.0,
                 "device/samples_per_sec": 3.0,
                 "batches_per_sec": 2.0,
                 "samples_per_sec": 6.0,
-                "items_per_sec": 4.0,
-                "device/items_per_sec": 6.0,
+                "items_per_sec": 12.0,
+                "device/items_per_sec": 18.0,
                 "flops_per_sec": 20.0,
                 "device/flops_per_sec": 10.0,
                 "device/mfu": 0.1,

--- a/tests/tests_fabric/utilities/test_throughput.py
+++ b/tests/tests_fabric/utilities/test_throughput.py
@@ -120,6 +120,13 @@ def test_throughput():
         "device/samples_per_sec": 2.0,
     }
 
+    throughput = Throughput(window_size=2)
+    with pytest.raises(ValueError, match=r"samples.*to be greater or equal than batches"):
+        throughput.update(time=0, batches=2, samples=1)
+    throughput = Throughput(window_size=2)
+    with pytest.raises(ValueError, match=r"lengths.*to be greater or equal than samples"):
+        throughput.update(time=0, batches=2, samples=2, lengths=1)
+
 
 def mock_train_loop(monitor):
     # simulate lit-gpt style loop

--- a/tests/tests_pytorch/callbacks/test_throughput_monitor.py
+++ b/tests/tests_pytorch/callbacks/test_throughput_monitor.py
@@ -29,7 +29,7 @@ def test_measure_flops():
 def test_throughput_monitor_fit(tmp_path):
     logger_mock = Mock()
     logger_mock.save_dir = tmp_path
-    monitor = ThroughputMonitor(length_fn=lambda x: 2, batch_size_fn=lambda x: 3, window_size=4, separator="|")
+    monitor = ThroughputMonitor(length_fn=lambda x: 3 * 2, batch_size_fn=lambda x: 3, window_size=4, separator="|")
     model = BoringModel()
     model.flops_per_batch = 10
     trainer = Trainer(
@@ -57,26 +57,27 @@ def test_throughput_monitor_fit(tmp_path):
     expected = {
         "train|device|batches_per_sec": 1.0,
         "train|device|samples_per_sec": 3.0,
-        "train|device|items_per_sec": 6.0,
+        "train|device|items_per_sec": 18.0,
         "train|device|flops_per_sec": 10.0,
         "train|device|mfu": 0.1,
         "epoch": 0,
     }
     assert logger_mock.log_metrics.mock_calls == [
         call(
-            metrics={"train|time": 1.5, "train|batches": 1, "train|samples": 3, "train|lengths": 2, "epoch": 0}, step=0
+            metrics={"train|time": 1.5, "train|batches": 1, "train|samples": 3, "train|lengths": 6, "epoch": 0}, step=0
         ),
         call(
-            metrics={"train|time": 2.5, "train|batches": 2, "train|samples": 6, "train|lengths": 4, "epoch": 0}, step=1
+            metrics={"train|time": 2.5, "train|batches": 2, "train|samples": 6, "train|lengths": 12, "epoch": 0}, step=1
         ),
         call(
-            metrics={"train|time": 3.5, "train|batches": 3, "train|samples": 9, "train|lengths": 6, "epoch": 0}, step=2
+            metrics={"train|time": 3.5, "train|batches": 3, "train|samples": 9, "train|lengths": 18, "epoch": 0}, step=2
         ),
         call(
-            metrics={**expected, "train|time": 4.5, "train|batches": 4, "train|samples": 12, "train|lengths": 8}, step=3
+            metrics={**expected, "train|time": 4.5, "train|batches": 4, "train|samples": 12, "train|lengths": 24},
+            step=3,
         ),
         call(
-            metrics={**expected, "train|time": 5.5, "train|batches": 5, "train|samples": 15, "train|lengths": 10},
+            metrics={**expected, "train|time": 5.5, "train|batches": 5, "train|samples": 15, "train|lengths": 30},
             step=4,
         ),
     ]
@@ -162,7 +163,7 @@ def test_throughput_monitor_fit_no_length_fn(tmp_path):
 def test_throughput_monitor_fit_gradient_accumulation(tmp_path):
     logger_mock = Mock()
     logger_mock.save_dir = tmp_path
-    monitor = ThroughputMonitor(length_fn=lambda x: 2, batch_size_fn=lambda x: 3, window_size=4, separator="|")
+    monitor = ThroughputMonitor(length_fn=lambda x: 3 * 2, batch_size_fn=lambda x: 3, window_size=4, separator="|")
     model = BoringModel()
     model.flops_per_batch = 10
 
@@ -206,13 +207,13 @@ def test_throughput_monitor_fit_gradient_accumulation(tmp_path):
     expected = {
         "train|device|batches_per_sec": 1.0,
         "train|device|samples_per_sec": 3.0,
-        "train|device|items_per_sec": 6.0,
+        "train|device|items_per_sec": 18.0,
         "train|device|flops_per_sec": 10.0,
         "train|device|mfu": 0.1,
     }
     assert logger_mock.log_metrics.mock_calls == [
         call(
-            metrics={"train|time": 2.5, "train|batches": 2, "train|samples": 6, "train|lengths": 4, "epoch": 0}, step=0
+            metrics={"train|time": 2.5, "train|batches": 2, "train|samples": 6, "train|lengths": 12, "epoch": 0}, step=0
         ),
         call(
             metrics={
@@ -220,7 +221,7 @@ def test_throughput_monitor_fit_gradient_accumulation(tmp_path):
                 "train|time": 4.5,
                 "train|batches": 4,
                 "train|samples": 12,
-                "train|lengths": 8,
+                "train|lengths": 24,
                 "epoch": 0,
             },
             step=1,
@@ -231,7 +232,7 @@ def test_throughput_monitor_fit_gradient_accumulation(tmp_path):
                 "train|time": 5.5,
                 "train|batches": 5,
                 "train|samples": 15,
-                "train|lengths": 10,
+                "train|lengths": 30,
                 "epoch": 0,
             },
             step=2,
@@ -242,7 +243,7 @@ def test_throughput_monitor_fit_gradient_accumulation(tmp_path):
                 "train|time": 7.5,
                 "train|batches": 7,
                 "train|samples": 21,
-                "train|lengths": 14,
+                "train|lengths": 42,
                 "epoch": 1,
             },
             step=3,
@@ -253,7 +254,7 @@ def test_throughput_monitor_fit_gradient_accumulation(tmp_path):
                 "train|time": 9.5,
                 "train|batches": 9,
                 "train|samples": 27,
-                "train|lengths": 18,
+                "train|lengths": 54,
                 "epoch": 1,
             },
             step=4,
@@ -264,7 +265,7 @@ def test_throughput_monitor_fit_gradient_accumulation(tmp_path):
                 "train|time": 10.5,
                 "train|batches": 10,
                 "train|samples": 30,
-                "train|lengths": 20,
+                "train|lengths": 60,
                 "epoch": 1,
             },
             step=5,


### PR DESCRIPTION
## What does this PR do?

Adds a `batches=int` argument to `Throughput.update()`.

Before, it assumed that each `update()` call meant that 1 batch had happened (by using `len(self._samples)`).

However, users might want to not have to call `update()` every batch. For example, to avoid the synchronization required to properly measure the elapsed time. To support this, there needs to be an explicit argument to track number of batches.


<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18905.org.readthedocs.build/en/18905/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca @justusschock @awaelchli