### PR TITLE
Skip hanging collective test

### DIFF
--- a/tests/tests_fabric/plugins/collectives/test_torch_collective.py
+++ b/tests/tests_fabric/plugins/collectives/test_torch_collective.py
@@ -230,8 +230,8 @@ def _test_distributed_collectives_fn(strategy, collective):
     torch.testing.assert_close(out, expected)
 
 
-@skip_distributed_unavailable
 @pytest.mark.skip(reason="test hangs too often")
+@skip_distributed_unavailable
 @pytest.mark.parametrize(
     "n", [1, pytest.param(2, marks=[RunIf(skip_windows=True), pytest.mark.xfail(raises=TimeoutError, strict=False)])]
 )

--- a/tests/tests_fabric/plugins/collectives/test_torch_collective.py
+++ b/tests/tests_fabric/plugins/collectives/test_torch_collective.py
@@ -231,7 +231,7 @@ def _test_distributed_collectives_fn(strategy, collective):
 
 
 @skip_distributed_unavailable
-@pytest.mark.flaky(reruns=5)
+@pytest.mark.skip(reason="test hangs too often")
 @pytest.mark.parametrize(
     "n", [1, pytest.param(2, marks=[RunIf(skip_windows=True), pytest.mark.xfail(raises=TimeoutError, strict=False)])]
 )


### PR DESCRIPTION
## What does this PR do?

The test(s) skipped in this PR hang too often and block merging other PRs. The test will be reactivated once the collective feature resumes development.

cc @borda @tchaton @carmocca @justusschock @awaelchli