### PR TITLE
Update minimum typing-extensions to 4.4

### DIFF
--- a/requirements/app/app.txt
+++ b/requirements/app/app.txt
@@ -1,6 +1,6 @@
 lightning-cloud ==0.5.46  # Must be pinned to ensure compatibility
 packaging
-typing-extensions >=4.0.0, <4.8.0
+typing-extensions >=4.4.0, <4.8.0
 deepdiff >=5.7.0, <6.6.0
 starsessions >=1.2.1, <2.0 # strict
 fsspec >=2022.5.0, <2023.10.0

--- a/requirements/app/app.txt
+++ b/requirements/app/app.txt
@@ -1,6 +1,6 @@
 lightning-cloud ==0.5.46  # Must be pinned to ensure compatibility
 packaging
-typing-extensions >=4.4.0, <4.8.0
+typing-extensions >=4.0.0, <4.8.0
 deepdiff >=5.7.0, <6.6.0
 starsessions >=1.2.1, <2.0 # strict
 fsspec >=2022.5.0, <2023.10.0

--- a/requirements/fabric/base.txt
+++ b/requirements/fabric/base.txt
@@ -5,5 +5,5 @@ numpy >=1.17.2, <1.27.0
 torch >=1.12.0, <2.2.0
 fsspec[http]>2021.06.0, <2023.10.0
 packaging >=20.0, <=23.1
-typing-extensions >=4.0.0, <4.8.0
+typing-extensions >=4.4.0, <4.8.0
 lightning-utilities >=0.8.0, <0.10.0

--- a/requirements/pytorch/base.txt
+++ b/requirements/pytorch/base.txt
@@ -8,5 +8,5 @@ PyYAML >=5.4, <6.1.0
 fsspec[http] >2021.06.0, <2023.10.0
 torchmetrics >=0.7.0, <1.3.0  # needed for using fixed compare_version
 packaging >=20.0, <=23.1
-typing-extensions >=4.0.0, <4.8.0
+typing-extensions >=4.4.0, <4.8.0
 lightning-utilities >=0.8.0, <0.10.0


### PR DESCRIPTION
## What does this PR do?

Tries to unblock https://github.com/Lightning-AI/lightning/pull/18911

4.4 was released in Oct 7, 2022 (https://pypi.org/project/typing-extensions/4.4.0/)


<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18916.org.readthedocs.build/en/18916/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca @justusschock @awaelchli