### PR TITLE
ci: restrict build docs on PR

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -14,7 +14,12 @@ on:
       - "docs/**"
       - "_notebooks"
       - "requirements/**"
-      - "src/**"
+      - "src/lightning/app/**"
+      - "src/lightning_app/*"
+      - "src/lightning/fabric/**"
+      - "src/lightning_fabric/*"
+      - "src/lightning/pytorch/**"
+      - "src/pytorch_lightning/*"
       - "setup.py"
       - "pyproject.toml" # includes metadata used in the package creation
       - "!*.md"

--- a/docs/source-app/conf.py
+++ b/docs/source-app/conf.py
@@ -444,5 +444,8 @@ coverage_skip_undoc_in_source = True
 # skip false positive linkcheck errors from anchors
 linkcheck_anchors = False
 
+# A timeout value, in seconds, for the linkcheck builder.
+linkcheck_timeout = 10
+
 # ignore all links in any CHANGELOG file
 linkcheck_exclude_documents = [r"^(.*\/)*CHANGELOG.*$"]

--- a/docs/source-fabric/conf.py
+++ b/docs/source-fabric/conf.py
@@ -408,5 +408,8 @@ coverage_skip_undoc_in_source = True
 # skip false positive linkcheck errors from anchors
 linkcheck_anchors = False
 
+# A timeout value, in seconds, for the linkcheck builder.
+linkcheck_timeout = 10
+
 # ignore all links in any CHANGELOG file
 linkcheck_exclude_documents = [r"^(.*\/)*CHANGELOG.*$"]

--- a/docs/source-pytorch/conf.py
+++ b/docs/source-pytorch/conf.py
@@ -600,6 +600,9 @@ coverage_skip_undoc_in_source = True
 # skip false positive linkcheck errors from anchors
 linkcheck_anchors = False
 
+# A timeout value, in seconds, for the linkcheck builder.
+linkcheck_timeout = 10
+
 # ignore all links in any CHANGELOG file
 linkcheck_exclude_documents = [r"^(.*\/)*CHANGELOG.*$"]
 


### PR DESCRIPTION
## What does this PR do?

no need to run docs build with sub-packages without their docs

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18923.org.readthedocs.build/en/18923/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca