### PR TITLE
Rename Throughput flops argument

### DIFF
--- a/src/lightning/pytorch/callbacks/throughput_monitor.py
+++ b/src/lightning/pytorch/callbacks/throughput_monitor.py
@@ -149,7 +149,7 @@ class ThroughputMonitor(Callback):
             # this assumes that all iterations used the same batch size
             samples=iter_num * batch_size,
             lengths=None if self.length_fn is None else self._lengths[stage],
-            flops_per_batch=flops_per_batch,
+            flops=flops_per_batch,
         )
 
     def _compute(self, trainer: "Trainer", iter_num: Optional[int] = None) -> None:

--- a/tests/tests_fabric/utilities/test_throughput.py
+++ b/tests/tests_fabric/utilities/test_throughput.py
@@ -90,8 +90,8 @@ def test_throughput():
 
     # flops
     throughput = Throughput(available_flops=50, window_size=2)
-    throughput.update(time=1, batches=1, samples=2, flops_per_batch=10, lengths=10)
-    throughput.update(time=2, batches=2, samples=4, flops_per_batch=10, lengths=20)
+    throughput.update(time=1, batches=1, samples=2, flops=10, lengths=10)
+    throughput.update(time=2, batches=2, samples=4, flops=10, lengths=20)
     assert throughput.compute() == {
         "time": 2,
         "batches": 2,
@@ -107,8 +107,8 @@ def test_throughput():
     # flops without available
     throughput.available_flops = None
     throughput.reset()
-    throughput.update(time=1, batches=1, samples=2, flops_per_batch=10, lengths=10)
-    throughput.update(time=2, batches=2, samples=4, flops_per_batch=10, lengths=20)
+    throughput.update(time=1, batches=1, samples=2, flops=10, lengths=10)
+    throughput.update(time=2, batches=2, samples=4, flops=10, lengths=20)
     assert throughput.compute() == {
         "time": 2,
         "batches": 2,
@@ -142,7 +142,7 @@ def mock_train_loop(monitor):
             batches=iter_num,
             samples=iter_num * micro_batch_size,
             lengths=total_lengths,
-            flops_per_batch=10,
+            flops=10,
         )
         monitor.compute_and_log()
 


### PR DESCRIPTION
## What does this PR do?

Same motivation as https://github.com/Lightning-AI/lightning/pull/18905.

If `update` is not called every batch, then the flops need to be scaled by the update call interval. This would make the "flops_per_batch" name incorrect