### PR TITLE
Remove redundant Trainer state assignment

### DIFF
--- a/src/lightning/pytorch/trainer/trainer.py
+++ b/src/lightning/pytorch/trainer/trainer.py
@@ -304,7 +304,6 @@ class Trainer:
         """
         super().__init__()
         log.debug(f"{self.__class__.__name__}: Initializing trainer with parameters: {locals()}")
-        self.state = TrainerState()
 
         if default_root_dir is not None:
             default_root_dir = os.fspath(default_root_dir)


### PR DESCRIPTION
## What does this PR do?

Removes redundant state assignment in Trainer. See L474 in trainer.py.


<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18929.org.readthedocs.build/en/18929/

<!-- readthedocs-preview pytorch-lightning end -->

cc @justusschock @awaelchli