### PR TITLE
Provide the default vocab size for the transformer demo model

### DIFF
--- a/src/lightning/pytorch/demos/transformer.py
+++ b/src/lightning/pytorch/demos/transformer.py
@@ -26,7 +26,13 @@ if hasattr(MultiheadAttention, "_reset_parameters") and not hasattr(MultiheadAtt
 
 class Transformer(nn.Module):
     def __init__(
-        self, vocab_size: int, ninp: int = 200, nhead: int = 2, nhid: int = 200, nlayers: int = 2, dropout: float = 0.2
+        self,
+        vocab_size: int = 33278,  # default for WikiText2
+        ninp: int = 200,
+        nhead: int = 2,
+        nhid: int = 200,
+        nlayers: int = 2,
+        dropout: float = 0.2,
     ) -> None:
         super().__init__()
         self.pos_encoder = PositionalEncoding(ninp, dropout)


### PR DESCRIPTION
## What does this PR do?


Similar to #18511

This sets the default for vocab size in our canonical transformer example that uses WikiText2. Setting the default makes it easier and shorter to construct demo examples, without having to worry about the dependency of downloading and instantiating the dataset in the right place before the model. 

cc @borda @lantiga 

<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18963.org.readthedocs.build/en/18963/

<!-- readthedocs-preview pytorch-lightning end -->