### PR TITLE
Avoid importing from `lightning.app` in `lightning.data`

### DIFF
--- a/src/lightning/data/datasets/index.py
+++ b/src/lightning/data/datasets/index.py
@@ -2,7 +2,7 @@ import math
 import os
 from io import TextIOWrapper
 
-from lightning.app.utilities.network import LightningClient
+from lightning_cloud.rest_client import LightningClient
 
 
 def get_index(s3_connection_path: str, index_file_path: str) -> bool:


### PR DESCRIPTION
## What does this PR do?

To use lightning.data, you are meant to install the dependencies like so: `pip install lightning[data]`. But the source code tries to import from `lightning.app` too, so you'd also have to install the app dependencies.

This PR imports the LightningClient directly from the cloud package instead of through app.


<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18988.org.readthedocs.build/en/18988/

<!-- readthedocs-preview pytorch-lightning end -->