### PR TITLE
Fix `ModelCheckpoint.CHECKPOINT_NAME_LAST` test interaction

### DIFF
--- a/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
+++ b/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
@@ -485,12 +485,12 @@ def test_model_checkpoint_file_extension(tmpdir):
     assert set(expected) == set(os.listdir(tmpdir))
 
 
-def test_model_checkpoint_save_last(tmpdir):
+def test_model_checkpoint_save_last(tmpdir, monkeypatch):
     """Tests that save_last produces only one last checkpoint."""
     seed_everything()
     model = LogInTwoMethods()
     epochs = 3
-    ModelCheckpoint.CHECKPOINT_NAME_LAST = "last-{epoch}"
+    monkeypatch.setattr(ModelCheckpoint, "CHECKPOINT_NAME_LAST", "last-{epoch}")
     model_checkpoint = ModelCheckpoint(monitor="early_stop_on", dirpath=tmpdir, save_top_k=-1, save_last=True)
     trainer = Trainer(
         default_root_dir=tmpdir,
@@ -511,7 +511,6 @@ def test_model_checkpoint_save_last(tmpdir):
     )
     assert os.path.islink(tmpdir / last_filename)
     assert os.path.realpath(tmpdir / last_filename) == model_checkpoint._last_checkpoint_saved
-    ModelCheckpoint.CHECKPOINT_NAME_LAST = "last"
 
 
 def test_model_checkpoint_link_checkpoint(tmp_path):


### PR DESCRIPTION
## What does this PR do?

[Fixes a test interaction seen in the master branch](https://github.com/Lightning-AI/lightning/actions/runs/6830026705/job/18577274245). The class attribute is set in one test, and then reset at the end of the test. In case this test fails for some reason, the patched attribute `ModelCheckpoint.CHECKPOINT_NAME_LAST` would carry over into other tests, causing them to fail since the checkpoint name assertion expects a different "last" name.




<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--18993.org.readthedocs.build/en/18993/

<!-- readthedocs-preview pytorch-lightning end -->

cc @carmocca @awaelchli @borda