### PR TITLE
Call `find_free_network_port` only if necessary

### DIFF
--- a/src/lightning/fabric/plugins/environments/lightning.py
+++ b/src/lightning/fabric/plugins/environments/lightning.py
@@ -58,7 +58,7 @@ class LightningEnvironment(ClusterEnvironment):
     @property
     def main_port(self) -> int:
         if self._main_port == -1:
-            self._main_port = int(os.environ.get("MASTER_PORT", find_free_network_port()))
+            self._main_port = int(os.getenv("MASTER_PORT")) if "MASTER_PORT" in os.environ else find_free_network_port()
         return self._main_port
 
     @staticmethod

--- a/src/lightning/fabric/plugins/environments/lightning.py
+++ b/src/lightning/fabric/plugins/environments/lightning.py
@@ -58,7 +58,7 @@ class LightningEnvironment(ClusterEnvironment):
     @property
     def main_port(self) -> int:
         if self._main_port == -1:
-            self._main_port = int(os.getenv("MASTER_PORT")) if "MASTER_PORT" in os.environ else find_free_network_port()
+            self._main_port = int(os.environ["MASTER_PORT"]) if "MASTER_PORT" in os.environ else find_free_network_port()
         return self._main_port
 
     @staticmethod

--- a/src/lightning/fabric/plugins/environments/lightning.py
+++ b/src/lightning/fabric/plugins/environments/lightning.py
@@ -58,7 +58,9 @@ class LightningEnvironment(ClusterEnvironment):
     @property
     def main_port(self) -> int:
         if self._main_port == -1:
-            self._main_port = int(os.environ["MASTER_PORT"]) if "MASTER_PORT" in os.environ else find_free_network_port()
+            self._main_port = (
+                int(os.environ["MASTER_PORT"]) if "MASTER_PORT" in os.environ else find_free_network_port()
+            )
         return self._main_port
 
     @staticmethod


### PR DESCRIPTION
## What does this PR do?

A micro-optimization to avoid a call to `find_free_network_port` if not necessary.



<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--19037.org.readthedocs.build/en/19037/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @justusschock @awaelchli @carmocca