### PR TITLE
Re-enable dynamo tests that were fixed in PyTorch 2.1

### DIFF
--- a/tests/tests_fabric/test_fabric.py
+++ b/tests/tests_fabric/test_fabric.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import sys
 from re import escape
 from unittest import mock
 from unittest.mock import ANY, MagicMock, Mock, PropertyMock, call
@@ -1198,8 +1197,7 @@ def test_verify_launch_called():
     fabric._validate_launched()
 
 
-@pytest.mark.skipif(sys.platform == "darwin", reason="https://github.com/pytorch/pytorch/issues/95708")
-@RunIf(dynamo=True)
+@RunIf(dynamo=True, min_torch="2.1.0")
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -1224,7 +1222,7 @@ def test_fabric_with_torchdynamo_fullgraph(kwargs):
         a = x * 10
         return model(a)
 
-    fabric = Fabric(devices=1, **kwargs)
+    fabric = Fabric(devices=1, accelerator="cpu", **kwargs)
     model = MyModel()
     fmodel = fabric.setup(model)
     # we are compiling a function that calls model.forward() inside

--- a/tests/tests_fabric/test_fabric.py
+++ b/tests/tests_fabric/test_fabric.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import sys
 from re import escape
 from unittest import mock
 from unittest.mock import ANY, MagicMock, Mock, PropertyMock, call
@@ -34,6 +35,7 @@ from lightning.fabric.strategies import (
 )
 from lightning.fabric.strategies.strategy import _Sharded
 from lightning.fabric.utilities.exceptions import MisconfigurationException
+from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from lightning.fabric.utilities.seed import pl_worker_init_function, seed_everything
 from lightning.fabric.utilities.warnings import PossibleUserWarning
 from lightning.fabric.wrappers import _FabricDataLoader, _FabricModule, _FabricOptimizer
@@ -1197,7 +1199,8 @@ def test_verify_launch_called():
     fabric._validate_launched()
 
 
-@RunIf(dynamo=True, min_torch="2.1.0")
+@pytest.mark.skipif(sys.platform == "darwin" and not _TORCH_GREATER_EQUAL_2_1, reason="Fix for MacOS in PyTorch 2.1")
+@RunIf(dynamo=True)
 @pytest.mark.parametrize(
     "kwargs",
     [

--- a/tests/tests_pytorch/utilities/test_compile.py
+++ b/tests/tests_pytorch/utilities/test_compile.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import sys
 from unittest import mock
 
 import pytest
@@ -25,10 +24,9 @@ from tests_pytorch.conftest import mock_cuda_count
 from tests_pytorch.helpers.runif import RunIf
 
 
-@RunIf(dynamo=True)
-@pytest.mark.skipif(sys.platform == "darwin", reason="https://github.com/pytorch/pytorch/issues/95708")
+@RunIf(dynamo=True, min_torch="2.1.0")
 @mock.patch("lightning.pytorch.trainer.call._call_and_handle_interrupt")
-def test_trainer_compiled_model(_, tmp_path, monkeypatch):
+def test_trainer_compiled_model(_, tmp_path, monkeypatch, mps_count_0):
     trainer_kwargs = {
         "default_root_dir": tmp_path,
         "fast_dev_run": True,
@@ -111,8 +109,7 @@ def test_compile_uncompile():
     assert not has_dynamo(to_uncompiled_model.predict_step)
 
 
-@pytest.mark.skipif(sys.platform == "darwin", reason="https://github.com/pytorch/pytorch/issues/95708")
-@RunIf(dynamo=True)
+@RunIf(dynamo=True, min_torch="2.1.0")
 def test_trainer_compiled_model_that_logs(tmp_path):
     class MyModel(BoringModel):
         def training_step(self, batch, batch_idx):
@@ -129,14 +126,14 @@ def test_trainer_compiled_model_that_logs(tmp_path):
         enable_checkpointing=False,
         enable_model_summary=False,
         enable_progress_bar=False,
+        accelerator="cpu",
     )
     trainer.fit(compiled_model)
 
     assert set(trainer.callback_metrics) == {"loss"}
 
 
-@pytest.mark.skipif(sys.platform == "darwin", reason="https://github.com/pytorch/pytorch/issues/95708")
-@RunIf(dynamo=True)
+@RunIf(dynamo=True, min_torch="2.1.0")
 def test_trainer_compiled_model_test(tmp_path):
     model = BoringModel()
     compiled_model = torch.compile(model)
@@ -147,5 +144,6 @@ def test_trainer_compiled_model_test(tmp_path):
         enable_checkpointing=False,
         enable_model_summary=False,
         enable_progress_bar=False,
+        accelerator="cpu",
     )
     trainer.test(compiled_model)

--- a/tests/tests_pytorch/utilities/test_compile.py
+++ b/tests/tests_pytorch/utilities/test_compile.py
@@ -11,10 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import sys
 from unittest import mock
 
 import pytest
 import torch
+from lightning.fabric.utilities.imports import _TORCH_GREATER_EQUAL_2_1
 from lightning.pytorch import LightningModule, Trainer
 from lightning.pytorch.demos.boring_classes import BoringModel
 from lightning.pytorch.utilities.compile import from_compiled, to_uncompiled
@@ -24,7 +26,8 @@ from tests_pytorch.conftest import mock_cuda_count
 from tests_pytorch.helpers.runif import RunIf
 
 
-@RunIf(dynamo=True, min_torch="2.1.0")
+@pytest.mark.skipif(sys.platform == "darwin" and not _TORCH_GREATER_EQUAL_2_1, reason="Fix for MacOS in PyTorch 2.1")
+@RunIf(dynamo=True)
 @mock.patch("lightning.pytorch.trainer.call._call_and_handle_interrupt")
 def test_trainer_compiled_model(_, tmp_path, monkeypatch, mps_count_0):
     trainer_kwargs = {
@@ -109,7 +112,8 @@ def test_compile_uncompile():
     assert not has_dynamo(to_uncompiled_model.predict_step)
 
 
-@RunIf(dynamo=True, min_torch="2.1.0")
+@pytest.mark.skipif(sys.platform == "darwin" and not _TORCH_GREATER_EQUAL_2_1, reason="Fix for MacOS in PyTorch 2.1")
+@RunIf(dynamo=True)
 def test_trainer_compiled_model_that_logs(tmp_path):
     class MyModel(BoringModel):
         def training_step(self, batch, batch_idx):
@@ -133,7 +137,8 @@ def test_trainer_compiled_model_that_logs(tmp_path):
     assert set(trainer.callback_metrics) == {"loss"}
 
 
-@RunIf(dynamo=True, min_torch="2.1.0")
+@pytest.mark.skipif(sys.platform == "darwin" and not _TORCH_GREATER_EQUAL_2_1, reason="Fix for MacOS in PyTorch 2.1")
+@RunIf(dynamo=True)
 def test_trainer_compiled_model_test(tmp_path):
     model = BoringModel()
     compiled_model = torch.compile(model)


### PR DESCRIPTION
## What does this PR do?

The issue https://github.com/pytorch/pytorch/issues/95708 has been fixed (verified locally on my Mac) and the skipped tests can be re-enabled.


cc @borda @carmocca @justusschock @awaelchli