### PR TITLE
PyTest random order for Fabric tests

### DIFF
--- a/.github/workflows/ci-tests-fabric.yml
+++ b/.github/workflows/ci-tests-fabric.yml
@@ -165,7 +165,7 @@ jobs:
         # NOTE: do not include coverage report here, see: https://github.com/nedbat/coveragepy/issues/1003
         run: |
           python -m coverage run --source ${{ env.COVERAGE_SCOPE }} \
-            -m pytest -v --timeout=30 --durations=50 --random-order-seed=123
+            -m pytest -v --timeout=30 --durations=50 --random-order-seed=2
 
       - name: Statistics
         if: success()

--- a/.github/workflows/ci-tests-fabric.yml
+++ b/.github/workflows/ci-tests-fabric.yml
@@ -165,7 +165,7 @@ jobs:
         # NOTE: do not include coverage report here, see: https://github.com/nedbat/coveragepy/issues/1003
         run: |
           python -m coverage run --source ${{ env.COVERAGE_SCOPE }} \
-            -m pytest -v --timeout=30 --durations=50
+            -m pytest -v --timeout=30 --durations=50 --random-order-seed=123
 
       - name: Statistics
         if: success()

--- a/.github/workflows/ci-tests-fabric.yml
+++ b/.github/workflows/ci-tests-fabric.yml
@@ -165,7 +165,7 @@ jobs:
         # NOTE: do not include coverage report here, see: https://github.com/nedbat/coveragepy/issues/1003
         run: |
           python -m coverage run --source ${{ env.COVERAGE_SCOPE }} \
-            -m pytest -v --timeout=30 --durations=50 --random-order-seed=2
+            -m pytest -v --timeout=30 --durations=50 --random-order-seed=$GITHUB_RUN_ID
 
       - name: Statistics
         if: success()

--- a/tests/tests_fabric/utilities/test_rank_zero.py
+++ b/tests/tests_fabric/utilities/test_rank_zero.py
@@ -20,12 +20,12 @@ from lightning.fabric.utilities.rank_zero import _get_rank
         ({"JSM_NAMESPACE_RANK": "4"}, None),
     ],
 )
-def test_rank_zero_known_environment_variables(env_vars, expected):
+def test_rank_zero_known_environment_variables(env_vars, expected, monkeypatch):
     """Test that rank environment variables are properly checked for rank_zero_only."""
     with mock.patch.dict(os.environ, env_vars):
         # force module reload to re-trigger the rank_zero_only.rank global computation
-        sys.modules.pop("lightning_utilities.core.rank_zero", None)
-        sys.modules.pop("lightning.fabric.utilities.rank_zero", None)
+        monkeypatch.delitem(sys.modules, "lightning_utilities.core.rank_zero", raising=False)
+        monkeypatch.delitem(sys.modules, "lightning.fabric.utilities.rank_zero", raising=False)
         from lightning.fabric.utilities.rank_zero import rank_zero_only
 
         @rank_zero_only


### PR DESCRIPTION
## What does this PR do?

Adds pytest random order for Fabric tests, just as we have it in the PyTorch Lightning tests.
TODO: Fix the issues revealed by the change in ordering.


<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--19040.org.readthedocs.build/en/19040/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda @carmocca @justusschock @awaelchli