### PR TITLE
Cast to >=float32 tensor when passing scalar to self.log

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -52,6 +52,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed an issue where Metric instances from `torchmetrics` wouldn't get moved to the device when using FSDP ([#18954](https://github.com/Lightning-AI/lightning/issues/18954))
 
 
+- Fixed the tensor conversion in `self.log` to respect the default dtype ([#19046](https://github.com/Lightning-AI/lightning/issues/19046))
+
+
 ## [2.1.0] - 2023-10-11
 
 ### Added

--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -627,7 +627,11 @@ class LightningModule(
         return dtype if dtype in (torch.float32, torch.float64) else torch.float32
 
     def __to_tensor_high_precision(self, value: Union[Tensor, numbers.Number], name: str) -> Tensor:
-        value = value.clone().detach() if isinstance(value, Tensor) else torch.tensor(value, device=self.device, dtype=_get_default_high_precision_dtype())
+        value = (
+            value.clone().detach()
+            if isinstance(value, Tensor)
+            else torch.tensor(value, device=self.device, dtype=_get_default_high_precision_dtype())
+        )
         if not torch.numel(value) == 1:
             raise ValueError(
                 f"`self.log({name}, {value})` was called, but the tensor must have a single element."

--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -451,7 +451,7 @@ class LightningModule(
                 " but it should not contain information about `dataloader_idx`"
             )
 
-        value = apply_to_collection(value, (Tensor, numbers.Number), self.__to_tensor, name)
+        value = apply_to_collection(value, (Tensor, numbers.Number), self.__to_tensor_high_precision, name)
 
         if trainer._logger_connector.should_reset_tensors(self._current_fx_name):
             # if we started a new epoch (running its first batch) the hook name has changed
@@ -620,6 +620,21 @@ class LightningModule(
     @staticmethod
     def __check_allowed(v: Any, name: str, value: Any) -> None:
         raise ValueError(f"`self.log({name}, {value})` was called, but `{type(v).__name__}` values cannot be logged")
+
+    def _get_default_high_precision_dtype() -> torch.dtype:
+        """The default dtype for new tensors, but no lower than float32."""
+        dtype = torch.get_default_dtype()
+        return dtype if dtype in (torch.float32, torch.float64) else torch.float32
+
+    def __to_tensor_high_precision(self, value: Union[Tensor, numbers.Number], name: str) -> Tensor:
+        value = value.clone().detach() if isinstance(value, Tensor) else torch.tensor(value, device=self.device, dtype=_get_default_high_precision_dtype())
+        if not torch.numel(value) == 1:
+            raise ValueError(
+                f"`self.log({name}, {value})` was called, but the tensor must have a single element."
+                f" You can try doing `self.log({name}, {value}.mean())`"
+            )
+        value = value.squeeze()
+        return value
 
     def __to_tensor(self, value: Union[Tensor, numbers.Number], name: str) -> Tensor:
         value = value.clone().detach() if isinstance(value, Tensor) else torch.tensor(value, device=self.device)

--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -61,6 +61,7 @@ from lightning.pytorch.core.saving import _load_from_checkpoint
 from lightning.pytorch.loggers import Logger
 from lightning.pytorch.trainer import call
 from lightning.pytorch.trainer.connectors.logger_connector.fx_validator import _FxValidator
+from lightning.pytorch.trainer.connectors.logger_connector.result import _get_default_dtype
 from lightning.pytorch.utilities import GradClipAlgorithmType
 from lightning.pytorch.utilities.exceptions import MisconfigurationException
 from lightning.pytorch.utilities.imports import _TORCHMETRICS_GREATER_EQUAL_0_9_1
@@ -621,17 +622,11 @@ class LightningModule(
     def __check_allowed(v: Any, name: str, value: Any) -> None:
         raise ValueError(f"`self.log({name}, {value})` was called, but `{type(v).__name__}` values cannot be logged")
 
-    @staticmethod
-    def __get_default_high_precision_dtype() -> torch.dtype:
-        """The default dtype for new tensors, but no lower than float32."""
-        dtype = torch.get_default_dtype()
-        return dtype if dtype in (torch.float32, torch.float64) else torch.float32
-
     def __to_tensor(self, value: Union[Tensor, numbers.Number], name: str) -> Tensor:
         value = (
             value.clone().detach()
             if isinstance(value, Tensor)
-            else torch.tensor(value, device=self.device, dtype=self.__get_default_high_precision_dtype())
+            else torch.tensor(value, device=self.device, dtype=_get_default_dtype())
         )
         if not torch.numel(value) == 1:
             raise ValueError(

--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -621,7 +621,8 @@ class LightningModule(
     def __check_allowed(v: Any, name: str, value: Any) -> None:
         raise ValueError(f"`self.log({name}, {value})` was called, but `{type(v).__name__}` values cannot be logged")
 
-    def _get_default_high_precision_dtype() -> torch.dtype:
+    @staticmethod
+    def __get_default_high_precision_dtype() -> torch.dtype:
         """The default dtype for new tensors, but no lower than float32."""
         dtype = torch.get_default_dtype()
         return dtype if dtype in (torch.float32, torch.float64) else torch.float32
@@ -630,7 +631,7 @@ class LightningModule(
         value = (
             value.clone().detach()
             if isinstance(value, Tensor)
-            else torch.tensor(value, device=self.device, dtype=self._get_default_high_precision_dtype())
+            else torch.tensor(value, device=self.device, dtype=self.__get_default_high_precision_dtype())
         )
         if not torch.numel(value) == 1:
             raise ValueError(

--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -630,7 +630,7 @@ class LightningModule(
         value = (
             value.clone().detach()
             if isinstance(value, Tensor)
-            else torch.tensor(value, device=self.device, dtype=_get_default_high_precision_dtype())
+            else torch.tensor(value, device=self.device, dtype=self._get_default_high_precision_dtype())
         )
         if not torch.numel(value) == 1:
             raise ValueError(


### PR DESCRIPTION
## What does this PR do?

Ensures that values get cast to float32+ tensors when passed to `self.log`.

Fixes #18984

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [X] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [X] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [X] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [X] Is this pull request ready for review? (if not, please submit in draft mode)
- [X] Check that all items from **Before submitting** are resolved
- [X] Make sure the title is self-explanatory and the description concisely explains the PR
- [X] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--19046.org.readthedocs.build/en/19046/

<!-- readthedocs-preview pytorch-lightning end -->