### PR TITLE
Move`ignore[override]` annotation to method signature

### DIFF
--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -213,9 +213,9 @@ class FSDPStrategy(ParallelStrategy):
             return plugin.mixed_precision_config
         return None
 
-    @property  # type: ignore[override]
+    @property
     @override
-    def precision_plugin(self) -> FSDPPrecision:
+    def precision_plugin(self) -> FSDPPrecision:  # type: ignore[override]
         plugin = self._precision_plugin
         if plugin is not None:
             assert isinstance(plugin, FSDPPrecision)

--- a/src/lightning/pytorch/strategies/single_xla.py
+++ b/src/lightning/pytorch/strategies/single_xla.py
@@ -54,9 +54,9 @@ class SingleDeviceXLAStrategy(SingleDeviceStrategy):
         )
         self.debug = debug
 
-    @property  # type: ignore[override]
+    @property
     @override
-    def checkpoint_io(self) -> Union[XLACheckpointIO, _WrappingCheckpointIO]:
+    def checkpoint_io(self) -> Union[XLACheckpointIO, _WrappingCheckpointIO]:  # type: ignore[override]
         plugin = self._checkpoint_io
         if plugin is not None:
             assert isinstance(plugin, (XLACheckpointIO, _WrappingCheckpointIO))
@@ -70,9 +70,9 @@ class SingleDeviceXLAStrategy(SingleDeviceStrategy):
             raise TypeError(f"The XLA strategy can only work with the `XLACheckpointIO` plugin, found {io}")
         self._checkpoint_io = io
 
-    @property  # type: ignore[override]
+    @property
     @override
-    def precision_plugin(self) -> XLAPrecision:
+    def precision_plugin(self) -> XLAPrecision:  # type: ignore[override]
         plugin = self._precision_plugin
         if plugin is not None:
             assert isinstance(plugin, XLAPrecision)

--- a/src/lightning/pytorch/strategies/xla.py
+++ b/src/lightning/pytorch/strategies/xla.py
@@ -70,9 +70,9 @@ class XLAStrategy(DDPStrategy):
         self._launched = False
         self._sync_module_states = sync_module_states
 
-    @property  # type: ignore[override]
+    @property
     @override
-    def checkpoint_io(self) -> Union[XLACheckpointIO, _WrappingCheckpointIO]:
+    def checkpoint_io(self) -> Union[XLACheckpointIO, _WrappingCheckpointIO]:  # type: ignore[override]
         plugin = self._checkpoint_io
         if plugin is not None:
             assert isinstance(plugin, (XLACheckpointIO, _WrappingCheckpointIO))
@@ -86,9 +86,9 @@ class XLAStrategy(DDPStrategy):
             raise TypeError(f"The XLA strategy can only work with the `XLACheckpointIO` plugin, found {io}")
         self._checkpoint_io = io
 
-    @property  # type: ignore[override]
+    @property
     @override
-    def precision_plugin(self) -> XLAPrecision:
+    def precision_plugin(self) -> XLAPrecision:  # type: ignore[override]
         plugin = self._precision_plugin
         if plugin is not None:
             assert isinstance(plugin, XLAPrecision)


### PR DESCRIPTION
Moves the `# type: ignore[override]` comment to the method signature in cases where it appeared on another line, in agreement with https://github.com/Lightning-AI/lightning/pull/19025#discussion_r1398252687.