### PR TITLE
Remove outdated "optimized installation" section from docs

### DIFF
--- a/docs/source-pytorch/starter/installation.rst
+++ b/docs/source-pytorch/starter/installation.rst
@@ -61,16 +61,7 @@ Install future patch releases from the source. Note that the patch release conta
 
     pip install https://github.com/Lightning-AI/lightning/archive/refs/heads/release/stable.zip -U
 
-----
 
-*******************************
-Optimized for model development
-*******************************
-If you are deploying models built with Lightning in production and require few dependencies, try using the optimized `lightning[pytorch]` package:
-
-.. code-block:: bash
-
-    pip install lightning
 
 ^^^^^^^^^^^^^^^^^^^^^^
 Custom PyTorch Version


### PR DESCRIPTION
## What does this PR do?

The section I'm removing here is no longer relevant. In 2.1, we removed the dependencies that `pip install lightning` brought in the past. Now, `lightning` is as light as `lightning[pytorch]` /  `pytorch-lightning`. There is no longer a need for a special section.


<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--19057.org.readthedocs.build/en/19057/

<!-- readthedocs-preview pytorch-lightning end -->

cc @borda