### PR TITLE
Fix ModelCheckpoint dirpath expanding home prefix

### DIFF
--- a/src/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/src/lightning/pytorch/callbacks/model_checkpoint.py
@@ -467,7 +467,7 @@ class ModelCheckpoint(Checkpoint):
         self._fs = get_filesystem(dirpath if dirpath else "")
 
         if dirpath and _is_local_file_protocol(dirpath if dirpath else ""):
-            dirpath = os.path.realpath(dirpath)
+            dirpath = os.path.realpath(os.path.expanduser(dirpath))
 
         self.dirpath = dirpath
         self.filename = filename

--- a/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
+++ b/tests/tests_pytorch/checkpointing/test_model_checkpoint.py
@@ -1536,3 +1536,17 @@ def test_find_last_checkpoints(name, extension, folder_contents, expected, tmp_p
     callback.FILE_EXTENSION = extension
     files = callback._find_last_checkpoints(trainer)
     assert files == {str(tmp_path / p) for p in expected}
+
+
+def test_expand_home():
+    """Test that the dirpath gets expanded if it contains `~`."""
+    home_root = Path.home()
+
+    checkpoint = ModelCheckpoint(dirpath="~/checkpoints")
+    assert checkpoint.dirpath == str(home_root / "checkpoints")
+    checkpoint = ModelCheckpoint(dirpath=Path("~/checkpoints"))
+    assert checkpoint.dirpath == str(home_root / "checkpoints")
+
+    # it is possible to have a folder with the name `~`
+    checkpoint = ModelCheckpoint(dirpath="./~/checkpoints")
+    assert checkpoint.dirpath == str(Path.cwd() / "~" / "checkpoints")


### PR DESCRIPTION
## What does this PR do?

If the user provides `ModelCheckpoint(dirpath="~/checkpoints")`, the path doesn't get expanded. Instead, it creates the folder with name `~` in the current working directory. 
