### PR TITLE
Add `@override` for remaining files in `src/lightning/pytorch`

### DIFF
--- a/src/lightning/pytorch/cli.py
+++ b/src/lightning/pytorch/cli.py
@@ -16,7 +16,7 @@ import sys
 from functools import partial, update_wrapper
 from types import MethodType
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Type, Union
-
+from typing_extensions import override
 import torch
 from lightning_utilities.core.imports import RequirementCache
 from lightning_utilities.core.rank_zero import _warn
@@ -235,7 +235,8 @@ class SaveConfigCallback(Callback):
                 "`save_to_log_dir=False` only makes sense when subclassing SaveConfigCallback to implement "
                 "`save_config` and it is desired to disable the standard behavior of saving to log_dir."
             )
-
+    
+    @override
     def setup(self, trainer: Trainer, pl_module: LightningModule, stage: str) -> None:
         if self.already_saved:
             return

--- a/src/lightning/pytorch/cli.py
+++ b/src/lightning/pytorch/cli.py
@@ -16,11 +16,12 @@ import sys
 from functools import partial, update_wrapper
 from types import MethodType
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Type, Union
-from typing_extensions import override
+
 import torch
 from lightning_utilities.core.imports import RequirementCache
 from lightning_utilities.core.rank_zero import _warn
 from torch.optim import Optimizer
+from typing_extensions import override
 
 import lightning.pytorch as pl
 from lightning.fabric.utilities.cloud_io import get_filesystem
@@ -235,7 +236,7 @@ class SaveConfigCallback(Callback):
                 "`save_to_log_dir=False` only makes sense when subclassing SaveConfigCallback to implement "
                 "`save_config` and it is desired to disable the standard behavior of saving to log_dir."
             )
-    
+
     @override
     def setup(self, trainer: Trainer, pl_module: LightningModule, stage: str) -> None:
         if self.already_saved:

--- a/src/lightning/pytorch/serve/servable_module_validator.py
+++ b/src/lightning/pytorch/serve/servable_module_validator.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Literal, Optional
 import requests
 import torch
 from lightning_utilities.core.imports import RequirementCache
-
+from typing_extensions import override
 import lightning.pytorch as pl
 from lightning.pytorch.callbacks import Callback
 from lightning.pytorch.serve.servable_module import ServableModule
@@ -71,6 +71,7 @@ class ServableModuleValidator(Callback):
         self.exit_on_failure = exit_on_failure
         self.resp: Optional[requests.Response] = None
 
+    @override
     @rank_zero_only
     def on_train_start(self, trainer: "pl.Trainer", servable_module: "pl.LightningModule") -> None:
         if isinstance(trainer.strategy, _NOT_SUPPORTED_STRATEGIES):
@@ -133,6 +134,7 @@ class ServableModuleValidator(Callback):
         """Returns whether the model was successfully served."""
         return self.resp.status_code == 200 if self.resp else None
 
+    @override
     def state_dict(self) -> Dict[str, Any]:
         return {"successful": self.successful, "optimization": self.optimization, "server": self.server}
 

--- a/src/lightning/pytorch/serve/servable_module_validator.py
+++ b/src/lightning/pytorch/serve/servable_module_validator.py
@@ -8,6 +8,7 @@ import requests
 import torch
 from lightning_utilities.core.imports import RequirementCache
 from typing_extensions import override
+
 import lightning.pytorch as pl
 from lightning.pytorch.callbacks import Callback
 from lightning.pytorch.serve.servable_module import ServableModule


### PR DESCRIPTION
It adds the `@override` decorator for all files in `src/lightning/pytorch` (https://github.com/Lightning-AI/lightning/issues/18695).

As per https://github.com/Lightning-AI/lightning/issues/18695#issuecomment-1750744922, this excludes files in `src/lightning/pytorch/utilities` and `src/lightning/pytorch/demos`.