### PR TITLE
Add `@override` for files in `src/lightning/fabric/accelerators`

### DIFF
--- a/src/lightning/fabric/accelerators/cpu.py
+++ b/src/lightning/fabric/accelerators/cpu.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import List, Union
-from typing_extensions import override
+
 import torch
+from typing_extensions import override
 
 from lightning.fabric.accelerators.accelerator import Accelerator
 from lightning.fabric.accelerators.registry import _AcceleratorRegistry
@@ -22,7 +23,7 @@ from lightning.fabric.accelerators.registry import _AcceleratorRegistry
 class CPUAccelerator(Accelerator):
     """Accelerator for CPU devices."""
 
-    @override    
+    @override
     def setup_device(self, device: torch.device) -> None:
         """
         Raises:

--- a/src/lightning/fabric/accelerators/cpu.py
+++ b/src/lightning/fabric/accelerators/cpu.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import List, Union
-
+from typing_extensions import override
 import torch
 
 from lightning.fabric.accelerators.accelerator import Accelerator
@@ -22,6 +22,7 @@ from lightning.fabric.accelerators.registry import _AcceleratorRegistry
 class CPUAccelerator(Accelerator):
     """Accelerator for CPU devices."""
 
+    @override    
     def setup_device(self, device: torch.device) -> None:
         """
         Raises:
@@ -31,31 +32,37 @@ class CPUAccelerator(Accelerator):
         if device.type != "cpu":
             raise ValueError(f"Device should be CPU, got {device} instead.")
 
+    @override
     def teardown(self) -> None:
         pass
 
     @staticmethod
+    @override
     def parse_devices(devices: Union[int, str, List[int]]) -> int:
         """Accelerator device parsing logic."""
         return _parse_cpu_cores(devices)
 
     @staticmethod
+    @override
     def get_parallel_devices(devices: Union[int, str, List[int]]) -> List[torch.device]:
         """Gets parallel devices for the Accelerator."""
         devices = _parse_cpu_cores(devices)
         return [torch.device("cpu")] * devices
 
     @staticmethod
+    @override
     def auto_device_count() -> int:
         """Get the devices when set to auto."""
         return 1
 
     @staticmethod
+    @override
     def is_available() -> bool:
         """CPU is always available for execution."""
         return True
 
     @classmethod
+    @override
     def register_accelerators(cls, accelerator_registry: _AcceleratorRegistry) -> None:
         accelerator_registry.register(
             "cpu",

--- a/src/lightning/fabric/accelerators/cuda.py
+++ b/src/lightning/fabric/accelerators/cuda.py
@@ -16,7 +16,7 @@ import warnings
 from contextlib import contextmanager
 from functools import lru_cache
 from typing import Generator, List, Optional, Union, cast
-
+from typing_extensions import override
 import torch
 
 from lightning.fabric.accelerators.accelerator import Accelerator
@@ -28,6 +28,7 @@ from lightning.fabric.utilities.rank_zero import rank_zero_info
 class CUDAAccelerator(Accelerator):
     """Accelerator for NVIDIA CUDA devices."""
 
+    @override    
     def setup_device(self, device: torch.device) -> None:
         """
         Raises:
@@ -39,10 +40,12 @@ class CUDAAccelerator(Accelerator):
         _check_cuda_matmul_precision(device)
         torch.cuda.set_device(device)
 
+    @override
     def teardown(self) -> None:
         _clear_cuda_memory()
 
     @staticmethod
+    @override
     def parse_devices(devices: Union[int, str, List[int]]) -> Optional[List[int]]:
         """Accelerator device parsing logic."""
         from lightning.fabric.utilities.device_parser import _parse_gpu_ids
@@ -50,20 +53,24 @@ class CUDAAccelerator(Accelerator):
         return _parse_gpu_ids(devices, include_cuda=True)
 
     @staticmethod
+    @override
     def get_parallel_devices(devices: List[int]) -> List[torch.device]:
         """Gets parallel devices for the Accelerator."""
         return [torch.device("cuda", i) for i in devices]
 
     @staticmethod
+    @override
     def auto_device_count() -> int:
         """Get the devices when set to auto."""
         return num_cuda_devices()
 
     @staticmethod
+    @override
     def is_available() -> bool:
         return num_cuda_devices() > 0
 
     @classmethod
+    @override
     def register_accelerators(cls, accelerator_registry: _AcceleratorRegistry) -> None:
         accelerator_registry.register(
             "cuda",

--- a/src/lightning/fabric/accelerators/cuda.py
+++ b/src/lightning/fabric/accelerators/cuda.py
@@ -16,8 +16,9 @@ import warnings
 from contextlib import contextmanager
 from functools import lru_cache
 from typing import Generator, List, Optional, Union, cast
-from typing_extensions import override
+
 import torch
+from typing_extensions import override
 
 from lightning.fabric.accelerators.accelerator import Accelerator
 from lightning.fabric.accelerators.registry import _AcceleratorRegistry
@@ -28,7 +29,7 @@ from lightning.fabric.utilities.rank_zero import rank_zero_info
 class CUDAAccelerator(Accelerator):
     """Accelerator for NVIDIA CUDA devices."""
 
-    @override    
+    @override
     def setup_device(self, device: torch.device) -> None:
         """
         Raises:

--- a/src/lightning/fabric/accelerators/mps.py
+++ b/src/lightning/fabric/accelerators/mps.py
@@ -14,8 +14,9 @@
 import platform
 from functools import lru_cache
 from typing import List, Optional, Union
-from typing_extensions import override
+
 import torch
+from typing_extensions import override
 
 from lightning.fabric.accelerators.accelerator import Accelerator
 from lightning.fabric.accelerators.registry import _AcceleratorRegistry

--- a/src/lightning/fabric/accelerators/mps.py
+++ b/src/lightning/fabric/accelerators/mps.py
@@ -14,7 +14,7 @@
 import platform
 from functools import lru_cache
 from typing import List, Optional, Union
-
+from typing_extensions import override
 import torch
 
 from lightning.fabric.accelerators.accelerator import Accelerator
@@ -28,6 +28,7 @@ class MPSAccelerator(Accelerator):
 
     """
 
+    @override
     def setup_device(self, device: torch.device) -> None:
         """
         Raises:
@@ -37,10 +38,12 @@ class MPSAccelerator(Accelerator):
         if device.type != "mps":
             raise ValueError(f"Device should be MPS, got {device} instead.")
 
+    @override
     def teardown(self) -> None:
         pass
 
     @staticmethod
+    @override
     def parse_devices(devices: Union[int, str, List[int]]) -> Optional[List[int]]:
         """Accelerator device parsing logic."""
         from lightning.fabric.utilities.device_parser import _parse_gpu_ids
@@ -48,6 +51,7 @@ class MPSAccelerator(Accelerator):
         return _parse_gpu_ids(devices, include_mps=True)
 
     @staticmethod
+    @override
     def get_parallel_devices(devices: Union[int, str, List[int]]) -> List[torch.device]:
         """Gets parallel devices for the Accelerator."""
         parsed_devices = MPSAccelerator.parse_devices(devices)
@@ -55,17 +59,20 @@ class MPSAccelerator(Accelerator):
         return [torch.device("mps", i) for i in range(len(parsed_devices))]
 
     @staticmethod
+    @override
     def auto_device_count() -> int:
         """Get the devices when set to auto."""
         return 1
 
     @staticmethod
+    @override
     @lru_cache(1)
     def is_available() -> bool:
         """MPS is only available on a machine with the ARM-based Apple Silicon processors."""
         return torch.backends.mps.is_available() and platform.processor() in ("arm", "arm64")
 
     @classmethod
+    @override
     def register_accelerators(cls, accelerator_registry: _AcceleratorRegistry) -> None:
         accelerator_registry.register(
             "mps",

--- a/src/lightning/fabric/accelerators/registry.py
+++ b/src/lightning/fabric/accelerators/registry.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Any, Callable, Dict, List, Optional
+from typing_extensions import override
 
 from lightning.fabric.utilities.exceptions import MisconfigurationException
 from lightning.fabric.utilities.registry import _register_classes
@@ -82,6 +83,7 @@ class _AcceleratorRegistry(dict):
 
         return do_register
 
+    @override
     def get(self, name: str, default: Optional[Any] = None) -> Any:
         """Calls the registered accelerator with the required parameters and returns the accelerator object.
 

--- a/src/lightning/fabric/accelerators/registry.py
+++ b/src/lightning/fabric/accelerators/registry.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Any, Callable, Dict, List, Optional
+
 from typing_extensions import override
 
 from lightning.fabric.utilities.exceptions import MisconfigurationException

--- a/src/lightning/fabric/accelerators/xla.py
+++ b/src/lightning/fabric/accelerators/xla.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import functools
 from typing import Any, List, Union
-
+from typing_extensions import override
 import torch
 from lightning_utilities.core.imports import RequirementCache
 
@@ -34,18 +34,22 @@ class XLAAccelerator(Accelerator):
             raise ModuleNotFoundError(str(_XLA_AVAILABLE))
         super().__init__(*args, **kwargs)
 
+    @override
     def setup_device(self, device: torch.device) -> None:
         pass
 
+    @override
     def teardown(self) -> None:
         pass
 
     @staticmethod
+    @override
     def parse_devices(devices: Union[int, str, List[int]]) -> Union[int, List[int]]:
         """Accelerator device parsing logic."""
         return _parse_tpu_devices(devices)
 
     @staticmethod
+    @override
     def get_parallel_devices(devices: Union[int, List[int]]) -> List[torch.device]:
         """Gets parallel devices for the Accelerator."""
         devices = _parse_tpu_devices(devices)
@@ -62,6 +66,7 @@ class XLAAccelerator(Accelerator):
         # it will be replaced with `xla_device` (also a torch.device`, but with extra logic) in the strategy
 
     @staticmethod
+    @override
     # XLA's multiprocessing will pop the TPU_NUM_DEVICES key, so we need to cache it
     # https://github.com/pytorch/xla/blob/v2.0.0/torch_xla/distributed/xla_multiprocessing.py#L280
     @functools.lru_cache(maxsize=1)
@@ -84,6 +89,7 @@ class XLAAccelerator(Accelerator):
         return getenv_as(xenv.TPU_NUM_DEVICES, int, 8)
 
     @staticmethod
+    @override
     @functools.lru_cache(maxsize=1)
     def is_available() -> bool:
         try:
@@ -94,6 +100,7 @@ class XLAAccelerator(Accelerator):
             return False
 
     @classmethod
+    @override
     def register_accelerators(cls, accelerator_registry: _AcceleratorRegistry) -> None:
         accelerator_registry.register("tpu", cls, description=cls.__name__)
 

--- a/src/lightning/fabric/accelerators/xla.py
+++ b/src/lightning/fabric/accelerators/xla.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 import functools
 from typing import Any, List, Union
-from typing_extensions import override
+
 import torch
 from lightning_utilities.core.imports import RequirementCache
+from typing_extensions import override
 
 from lightning.fabric.accelerators.accelerator import Accelerator
 from lightning.fabric.accelerators.registry import _AcceleratorRegistry


### PR DESCRIPTION
This PR adds the `@override` decorator for all files in `src/lightning/fabric/accelerators` (https://github.com/Lightning-AI/lightning/issues/18695).

<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--19068.org.readthedocs.build/en/19068/

<!-- readthedocs-preview pytorch-lightning end -->