### PR TITLE
Fix `item_per_sec` metric in ThroughputMonitor

### DIFF
--- a/src/lightning/fabric/utilities/throughput.py
+++ b/src/lightning/fabric/utilities/throughput.py
@@ -183,12 +183,16 @@ class Throughput:
                     {"batches_per_sec": samples_per_sec, "samples_per_sec": dev_samples_per_sec * self.world_size}
                 )
 
-            if len(self._lengths) == self._lengths.maxlen:
-                elapsed_lengths = self._lengths[-1] - self._lengths[0]
-                avg_length = elapsed_lengths / elapsed_batches
-                if add_global_metrics:
-                    metrics["items_per_sec"] = samples_per_sec * avg_length
-                metrics[f"device{self.separator}items_per_sec"] = dev_samples_per_sec * avg_length
+        if len(self._lengths) == self._lengths.maxlen:
+            elapsed_time = self._time[-1] - self._time[0]
+            elapsed_lengths = self._lengths[-1] - self._lengths[0]
+            dev_items_per_sec = elapsed_lengths / elapsed_time
+            metrics[f"device{self.separator}items_per_sec"] = dev_items_per_sec
+            if add_global_metrics:
+                items_per_sec = dev_items_per_sec * self.world_size
+                metrics["items_per_sec"] = items_per_sec
+
+        print(metrics)
 
         if len(self._flops) == self._flops.maxlen:
             elapsed_flops = sum(self._flops) - self._flops[0]

--- a/src/lightning/fabric/utilities/throughput.py
+++ b/src/lightning/fabric/utilities/throughput.py
@@ -191,8 +191,6 @@ class Throughput:
                     items_per_sec = dev_items_per_sec * self.world_size
                     metrics["items_per_sec"] = items_per_sec
 
-            print(metrics)
-
         if len(self._flops) == self._flops.maxlen:
             elapsed_flops = sum(self._flops) - self._flops[0]
             elapsed_time = self._time[-1] - self._time[0]

--- a/src/lightning/fabric/utilities/throughput.py
+++ b/src/lightning/fabric/utilities/throughput.py
@@ -183,16 +183,15 @@ class Throughput:
                     {"batches_per_sec": samples_per_sec, "samples_per_sec": dev_samples_per_sec * self.world_size}
                 )
 
-        if len(self._lengths) == self._lengths.maxlen:
-            elapsed_time = self._time[-1] - self._time[0]
-            elapsed_lengths = self._lengths[-1] - self._lengths[0]
-            dev_items_per_sec = elapsed_lengths / elapsed_time
-            metrics[f"device{self.separator}items_per_sec"] = dev_items_per_sec
-            if add_global_metrics:
-                items_per_sec = dev_items_per_sec * self.world_size
-                metrics["items_per_sec"] = items_per_sec
+            if len(self._lengths) == self._lengths.maxlen:
+                elapsed_lengths = self._lengths[-1] - self._lengths[0]
+                dev_items_per_sec = elapsed_lengths / elapsed_time
+                metrics[f"device{self.separator}items_per_sec"] = dev_items_per_sec
+                if add_global_metrics:
+                    items_per_sec = dev_items_per_sec * self.world_size
+                    metrics["items_per_sec"] = items_per_sec
 
-        print(metrics)
+            print(metrics)
 
         if len(self._flops) == self._flops.maxlen:
             elapsed_flops = sum(self._flops) - self._flops[0]

--- a/tests/tests_fabric/utilities/test_throughput.py
+++ b/tests/tests_fabric/utilities/test_throughput.py
@@ -132,7 +132,7 @@ def test_throughput():
         "lengths": 8,
         "device/batches_per_sec": 2.0,
         "device/samples_per_sec": 4.0,
-        "device/items_per_sec": 16.0,
+        "device/items_per_sec": 8.0,
     }
 
     with pytest.raises(ValueError, match="Expected the value to increase"):
@@ -149,7 +149,7 @@ def test_throughput():
         "lengths": 20,
         "device/batches_per_sec": 1.0,
         "device/flops_per_sec": 10.0,
-        "device/items_per_sec": 20.0,
+        "device/items_per_sec": 10.0,
         "device/mfu": 0.2,
         "device/samples_per_sec": 2.0,
     }
@@ -166,7 +166,7 @@ def test_throughput():
         "lengths": 20,
         "device/batches_per_sec": 1.0,
         "device/flops_per_sec": 10.0,
-        "device/items_per_sec": 20.0,
+        "device/items_per_sec": 10.0,
         "device/samples_per_sec": 2.0,
     }
 
@@ -215,7 +215,7 @@ def test_throughput_monitor():
                 "lengths": 24,
                 "device|batches_per_sec": 1.0,
                 "device|samples_per_sec": 3.0,
-                "device|items_per_sec": 18.0,
+                "device|items_per_sec": 6.0,
                 "device|flops_per_sec": 10.0,
                 "device|mfu": 0.1,
             },
@@ -229,7 +229,7 @@ def test_throughput_monitor():
                 "lengths": 30,
                 "device|batches_per_sec": 1.0,
                 "device|samples_per_sec": 3.0,
-                "device|items_per_sec": 18.0,
+                "device|items_per_sec": 6.0,
                 "device|flops_per_sec": 10.0,
                 "device|mfu": 0.1,
             },
@@ -285,7 +285,7 @@ def test_throughput_monitor_world_size():
                 "batches_per_sec": 2.0,
                 "samples_per_sec": 6.0,
                 "items_per_sec": 12.0,
-                "device/items_per_sec": 18.0,
+                "device/items_per_sec": 6.0,
                 "flops_per_sec": 20.0,
                 "device/flops_per_sec": 10.0,
                 "device/mfu": 0.1,
@@ -303,7 +303,7 @@ def test_throughput_monitor_world_size():
                 "batches_per_sec": 2.0,
                 "samples_per_sec": 6.0,
                 "items_per_sec": 12.0,
-                "device/items_per_sec": 18.0,
+                "device/items_per_sec": 6.0,
                 "flops_per_sec": 20.0,
                 "device/flops_per_sec": 10.0,
                 "device/mfu": 0.1,

--- a/tests/tests_pytorch/callbacks/test_throughput_monitor.py
+++ b/tests/tests_pytorch/callbacks/test_throughput_monitor.py
@@ -57,7 +57,7 @@ def test_throughput_monitor_fit(tmp_path):
     expected = {
         "train|device|batches_per_sec": 1.0,
         "train|device|samples_per_sec": 3.0,
-        "train|device|items_per_sec": 18.0,
+        "train|device|items_per_sec": 6.0,
         "train|device|flops_per_sec": 10.0,
         "train|device|mfu": 0.1,
         "epoch": 0,
@@ -207,7 +207,7 @@ def test_throughput_monitor_fit_gradient_accumulation(tmp_path):
     expected = {
         "train|device|batches_per_sec": 1.0,
         "train|device|samples_per_sec": 3.0,
-        "train|device|items_per_sec": 18.0,
+        "train|device|items_per_sec": 6.0,
         "train|device|flops_per_sec": 10.0,
         "train|device|mfu": 0.1,
     }


### PR DESCRIPTION
## What does this PR do?

The `item_per_sec` didn't scale with the `device/item_per_sec`. Rewrote the logic to match how we compute it for the other metrics. 


<!-- readthedocs-preview pytorch-lightning start -->
----
:books: Documentation preview :books:: https://pytorch-lightning--19080.org.readthedocs.build/en/19080/

<!-- readthedocs-preview pytorch-lightning end -->

cc @carmocca @justusschock @awaelchli @borda